### PR TITLE
210 add   port to rpc

### DIFF
--- a/msb.mjs
+++ b/msb.mjs
@@ -24,8 +24,10 @@ msb.ready().then(async () => {
 
     if (runRpc) {
         console.log('Starting RPC server...');
+        const portIndex = args.indexOf('--port');
+        const port = (portIndex !== -1 && args[portIndex + 1]) ? parseInt(args[portIndex + 1], 10) : 5000;
         const {startRpcServer} = await import('./rpc/rpc_server.mjs');
-        startRpcServer(msb);
+        startRpcServer(msb, port);
     } else {
         console.log('RPC server will not be started.');
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "scripts": {
     "dev": "pear run -d .",
-    "dev-rpc": "pear run -d . ${npm_config_store} --rpc",
+    "dev-rpc": "pear run -d . ${npm_config_store} --rpc --port ${npm_config_port}",
     "protobuf": "node scripts/generate-protobufs.js",
     "test:node": "brittle-node -t 120000 test/all.test.js",
     "test:bare": "brittle-bare -t 120000 test/all.test.js",

--- a/rpc/rpc_server.mjs
+++ b/rpc/rpc_server.mjs
@@ -9,7 +9,7 @@ const sslOptions = {
 }
 
 // Called by msb.mjs file
-export function startRpcServer(msbInstance) {
+export function startRpcServer(msbInstance, port) {
     const server = https.createServer(sslOptions, async (req, res) => {
         if (req.url.startsWith('/balance/')) {
             try {
@@ -38,7 +38,6 @@ export function startRpcServer(msbInstance) {
         }
     })
 
-    const port = 3000
     server.listen(port, () => {
         console.log(`Running RPC with https at https://localhost:${port}`)
     })


### PR DESCRIPTION
This PR adds the **--port** argument to the RPC mode.

The full command command is:
`npm run dev-rpc --store=<store_name> --port=<port_number>`

PS: the **--store** is _required_ to run **dev-rpc**, but **--port** is _optional_. In case any port is passed, the 5000 will be used as default.

