### PR TITLE
fix state mutation issue

### DIFF
--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -1804,12 +1804,12 @@ class State extends ReadyResource {
 
     async #getEntryApply(key, batch) {
         const entry = await batch.get(key);
-        return entry !== null ? deepCopyBuffer(entry.value) : null
+        return deepCopyBuffer(entry?.value)
     }
     
     async #getDeploymentEntryApply(key, batch) {
         const entry = await batch.get(EntryType.DEPLOYMENT + key);
-        return entry !== null ? deepCopyBuffer(entry.value) : null
+        return deepCopyBuffer(entry?.value)
     }
 
     async #getIndexerSequenceStateApply(base) {
@@ -1836,7 +1836,7 @@ class State extends ReadyResource {
 
     async #getRegisteredWriterKeyApply(batch, writingKey) {
         const entry =  await batch.get(EntryType.WRITER_ADDRESS + writingKey);
-        return entry !== null ? deepCopyBuffer(entry.value) : null
+        return deepCopyBuffer(entry?.value)
     }
 
     async #isApplyInitalizationDisabled(batch) {

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -23,6 +23,7 @@ import { blake3Hash } from '../../utils/crypto.js';
 import { BALANCE_FEE, toBalance, PERCENT_75, PERCENT_50, PERCENT_25 } from './utils/balance.js';
 import { safeWriteUInt32BE } from '../../utils/buffer.js';
 import deploymentEntryUtils from './utils/deploymentEntry.js';
+import { deepCopyBuffer } from '../../utils/buffer.js';
 
 class State extends ReadyResource {
     //TODO: AFTER createMessage(..args) check if this function did not return NULL
@@ -1804,12 +1805,12 @@ class State extends ReadyResource {
 
     async #getEntryApply(key, batch) {
         const entry = await batch.get(key);
-        return entry !== null ? entry.value : null
+        return entry !== null ? deepCopyBuffer(entry.value) : null
     }
-
+    
     async #getDeploymentEntryApply(key, batch) {
         const entry = await batch.get(EntryType.DEPLOYMENT + key);
-        return entry !== null ? entry.value : null
+        return entry !== null ? deepCopyBuffer(entry.value) : null
     }
 
     async #getIndexerSequenceStateApply(base) {
@@ -1835,7 +1836,8 @@ class State extends ReadyResource {
     }
 
     async #getRegisteredWriterKeyApply(batch, writingKey) {
-        return await batch.get(EntryType.WRITER_ADDRESS + writingKey);
+        const entry =  await batch.get(EntryType.WRITER_ADDRESS + writingKey);
+        return entry !== null ? deepCopyBuffer(entry.value) : null
     }
 
     async #isApplyInitalizationDisabled(batch) {

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -1753,7 +1753,6 @@ class State extends ReadyResource {
         if (!isSelfTransfer) {
             const recipientEntryBuffer = await this.#getEntryApply(recipientAddressString, batch);
             if (recipientEntryBuffer === null) {
-                if (transferAmount.value === null) return null;
                 const newRecipientEntry = nodeEntryUtils.init(
                     ZERO_WK,
                     nodeRoleUtils.NodeRole.READER,

--- a/src/utils/buffer.js
+++ b/src/utils/buffer.js
@@ -6,7 +6,7 @@ export const NULL_BUFFER = b4a.alloc(0) // null buffer (single byte of 0)
 
 const isUInt32 = (n) => { return Number.isInteger(n) && n >= 1 && n <= 0xFFFFFFFF; }
 
-export const isNullBuffer = (buffer) => {b4a.equals(buffer, NULL_BUFFER)}
+export const isNullBuffer = (buffer) => { b4a.equals(buffer, NULL_BUFFER) }
 
 export function isBufferValid(key, size) {
     return b4a.isBuffer(key) && key.length === size;
@@ -42,16 +42,23 @@ export function normalizeBuffer(message) {
     if (b4a.isBuffer(message)) {
         return message;
     }
-    
+
     if (message.type === 'Buffer' && Array.isArray(message.data)) {
         return b4a.from(message.data);
     }
-    
+
     if (typeof message === 'object' && Object.keys(message).every(key => !isNaN(key))) {
         return b4a.from(Object.values(message));
     }
-    
+
     return null;
 }
 
 export const bigIntToBuffer = bigIntTo16ByteBuffer
+
+export function deepCopyBuffer(buffer) {
+    if (!buffer) return null;
+    const copy = b4a.alloc(buffer.length);
+    buffer.copy(copy);
+    return copy;
+}

--- a/src/utils/buffer.js
+++ b/src/utils/buffer.js
@@ -6,8 +6,6 @@ export const NULL_BUFFER = b4a.alloc(0) // null buffer (single byte of 0)
 
 const isUInt32 = (n) => { return Number.isInteger(n) && n >= 1 && n <= 0xFFFFFFFF; }
 
-export const isNullBuffer = (buffer) => { b4a.equals(buffer, NULL_BUFFER) }
-
 export function isBufferValid(key, size) {
     return b4a.isBuffer(key) && key.length === size;
 }

--- a/test/buffer/buffer.test.js
+++ b/test/buffer/buffer.test.js
@@ -1,6 +1,6 @@
 import test from 'brittle';
 import b4a from 'b4a';
-import {createMessage, isBufferValid, safeWriteUInt32BE} from '../../src/utils/buffer.js';
+import {createMessage, isBufferValid, safeWriteUInt32BE, deepCopyBuffer} from '../../src/utils/buffer.js';
 
 const invalidDataTypes = [
     null,
@@ -153,4 +153,38 @@ test('safeWriteUInt32BE - negative case', t => {
     t.ok(b4a.isBuffer(negOffset), 'returns buffer for negative offset');
     t.is(negOffset.length, 4, 'buffer is 4 bytes');
     t.is(negOffset.readUInt32BE(0), 0, 'buffer is zeroed for negative offset');
+});
+
+test('deepCopyBuffer - returns null for falsy inputs', t => {
+    t.is(deepCopyBuffer(null), null, 'null input returns null');
+    t.is(deepCopyBuffer(undefined), null, 'undefined input returns null');
+});
+
+test('deepCopyBuffer - copies non-empty buffer', t => {
+    const buf = b4a.from([1, 2, 3, 4]);
+    const copy = deepCopyBuffer(buf);
+
+    t.ok(b4a.isBuffer(copy), 'returns a buffer');
+    t.is(copy.length, buf.length, 'same length');
+    t.ok(b4a.equals(copy, buf), 'contents match');
+    t.not(copy, buf, 'is a different buffer object');
+});
+
+test('deepCopyBuffer - copies empty buffer', t => {
+    const buf = b4a.alloc(0);
+    const copy = deepCopyBuffer(buf);
+
+    t.ok(b4a.isBuffer(copy), 'returns a buffer');
+    t.is(copy.length, 0, 'length is zero');
+    t.not(copy, buf, 'is a different buffer object');
+});
+
+test('deepCopyBuffer - modifying copy does not affect original (is not a reference)', t => {
+    const buf = b4a.from([9, 9, 9]);
+    const copy = deepCopyBuffer(buf);
+
+    copy[0] = 1;
+
+    t.is(buf[0], 9, 'original unchanged');
+    t.is(copy[0], 1, 'copy modified independently');
 });


### PR DESCRIPTION
## Status
Critical 

## Problem
Unexpected state mutations caused by shared buffer references returned from `batch.get()`

## Solution
- Added deep buffer copying in `#getEntryApply`,  `#getDeploymentEntryApply` and `#getRegisteredWriterKeyApply` methods

## Technical Details
State now changes only through explicit `batch.put()` operations, preventing accidental mutations of shared buffer references.
The issue was that multiple parts of the code were modifying the same buffer instances in memory. By implementing deep copying at the data retrieval level, each operation now works with isolated copies, maintaining data integrity.


