### PR TITLE
fix: log new license assignment and handle license length decoding

### DIFF
--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -3468,12 +3468,13 @@ class State extends ReadyResource {
             licenseCount = lengthEntryUtils.decodeBE(licenseCount);
             newLicenseLength = lengthEntryUtils.incrementBE(licenseCount);
         }
-
+        const decodedNewLicenseLength = lengthEntryUtils.decodeBE(newLicenseLength);
         if (null === newLicenseLength) return;
         if (null === validatorAddressBuffer) return;
+        if (null === decodedNewLicenseLength) return;
 
         await batch.put(EntryType.LICENSE_COUNT, newLicenseLength)
-        await batch.put(EntryType.LICENSE_INDEX + licenseCount, validatorAddressBuffer)
+        await batch.put(EntryType.LICENSE_INDEX + decodedNewLicenseLength, validatorAddressBuffer)
 
         return newLicenseLength;
     }


### PR DESCRIPTION
# Problem 
The `/add_admin` command was assigning license number `1` to the admin.
However, the value under `EntryType.LICENSE_INDEX` was `0`.
- Running `/get_license_address` did not return any address under license number `1`.
- Instead, the admin’s address appeared under license number `0` where `0` is supposed to indicate that a user does not hold a license.
(See screenshot 1 & 2)
1.
<img width="1057" height="173" alt="Screenshot 2025-10-03 at 01 50 30" src="https://github.com/user-attachments/assets/b6038f93-168a-4891-8a1b-8674119c9865" />
2.
<img width="834" height="307" alt="Screenshot 2025-10-03 at 01 51 40" src="https://github.com/user-attachments/assets/9200097c-4488-401d-8c61-5256ca0e4c60" />

# Fix
The fix was straightforward: decode newLength and concatenate its value with EntryType.LICENSE_INDEX.

<img width="1031" height="627" alt="Screenshot 2025-10-03 at 01 58 30" src="https://github.com/user-attachments/assets/d95f55a1-0127-408a-bbea-2b07e9e6c3f0" />
