### PR TITLE
Hotfix get unconfirmed balance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1081,7 +1081,7 @@ export class MainSettlementBus extends ReadyResource {
                     const address = splitted[1];
                     const confirmedFlag = splitted[2];
                     let unconfirmedBalance = confirmedFlag === 'false'
-                    let nodeEntry = unconfirmedBalance ? await this.#state.getUnsignedNodeEntry(address) : await this.#state.getNodeEntry(address)
+                    let nodeEntry = unconfirmedBalance ? await this.#state.getNodeEntryUnsigned(address) : await this.#state.getNodeEntry(address)
                     if (nodeEntry) {
                         console.log({
                             Address: address,

--- a/test/acceptance/v1/rpc.test.mjs
+++ b/test/acceptance/v1/rpc.test.mjs
@@ -98,6 +98,12 @@ describe("API acceptance tests", () => {
         expect(res.body).toEqual({ address: wallet.address, balance: "9670000000000000000" })
     })
 
+    it("GET /v1/balance unconfirmed", async () => {
+        const res = await request(server).get(`/v1/balance/${wallet.address}?confirmed=false`)
+        expect(res.statusCode).toBe(200)
+        expect(res.body).toEqual({ address: wallet.address, balance: "9670000000000000000" })
+    })
+
     it("POST /v1/broadcast-transaction", async () => {
         const txData = await tracCrypto.transaction.preBuild(
             wallet.address,


### PR DESCRIPTION
### Bug fix in `v1/balance` endpoint

The issue occurred when executing the following request:
```js
v1/balance/xxxxx?confirmed=false
```

An error was returned indicating that the function `getUnsignedNodeEntry` was **undefined**.  
The root cause was a typo, the correct function name is `getNodeEntryUnsigned`.

The typo has been fixed, and an **acceptance test** has been added to verify the endpoint’s correct behavior.
