### PR TITLE
chore: bump trac-wallet to version 0.0.43-msb-r2.9 and update trac-crypto-api to version 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "protomux-wakeup": "2.4.0",
         "readline": "npm:bare-node-readline",
         "ready-resource": "1.1.2",
-        "trac-wallet": "0.0.43-msb-r2.8",
+        "trac-wallet": "0.0.43-msb-r2.9",
         "tty": "npm:bare-node-tty"
       },
       "devDependencies": {
@@ -6652,13 +6652,13 @@
       }
     },
     "node_modules/trac-crypto-api": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/trac-crypto-api/-/trac-crypto-api-0.1.2.tgz",
-      "integrity": "sha512-hzgEuEzTbJfzYHbiJhqBpAQtNlLghnl5c1mQqzzxz48jAQzqyYqi79RoFC5mhDyV1VCQe5FQjtIxu6lf4UkfYA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/trac-crypto-api/-/trac-crypto-api-0.1.3.tgz",
+      "integrity": "sha512-wiPW8IhQjahGwNG/rr+ynZo8E7ugKUq2xILicJ3LH86spax9fA6PFaupIaqafnKILPATd/f4Xwtl2llbBEJOsg==",
       "license": "ISC",
       "dependencies": {
         "@metamask/key-tree": "10.1.1",
-        "@tracsystems/blake3": "0.0.13",
+        "@tracsystems/blake3": "0.0.15",
         "b4a": "1.6.7",
         "bare-fs": "4.5.0",
         "bech32": "2.0.0",
@@ -6667,10 +6667,15 @@
         "sodium-universal": "5.0.1"
       }
     },
+    "node_modules/trac-crypto-api/node_modules/@tracsystems/blake3": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@tracsystems/blake3/-/blake3-0.0.15.tgz",
+      "integrity": "sha512-Qaw9WKoz1ZB7zeuhShCt9qohCoaHlQEd6Zvz9qC1ysrN65eCLfG/ODZE3T8x2Z0FRfqW69UfosCl0GFUGU83Qg=="
+    },
     "node_modules/trac-wallet": {
-      "version": "0.0.43-msb-r2.8",
-      "resolved": "https://registry.npmjs.org/trac-wallet/-/trac-wallet-0.0.43-msb-r2.8.tgz",
-      "integrity": "sha512-f/8owYK3GzH7ee2ifNN2PLJiuKfls5wJvrG2vuOuia3nw7no0+383aRyZLB/vIVtyR3S8+wspVextKqXxeSdkg==",
+      "version": "0.0.43-msb-r2.9",
+      "resolved": "https://registry.npmjs.org/trac-wallet/-/trac-wallet-0.0.43-msb-r2.9.tgz",
+      "integrity": "sha512-t73B/GcXxn0orEUyaG7Jx6Zz2MiPlhiTVIPgGnULhlHqtN+3VegoDBeF7/E+QR4/o0AZNFBRWZY/nQcn99qnew==",
       "license": "ISC",
       "dependencies": {
         "b4a": "1.6.7",
@@ -6681,7 +6686,7 @@
         "fs": "npm:bare-node-fs",
         "path": "npm:bare-node-path",
         "readline": "npm:bare-node-readline",
-        "trac-crypto-api": "0.1.2",
+        "trac-crypto-api": "0.1.3",
         "tty": "npm:bare-node-tty"
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "protomux-wakeup": "2.4.0",
     "readline": "npm:bare-node-readline",
     "ready-resource": "1.1.2",
-    "trac-wallet": "0.0.43-msb-r2.8",
+    "trac-wallet": "0.0.43-msb-r2.9",
     "tty": "npm:bare-node-tty"
   },
   "devDependencies": {


### PR DESCRIPTION
- bump trac-wallet version to 2.9 (this version contain memory fix of the blake3 package)