### PR TITLE
feat(ci): run unit tests on self-hosted runner

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,6 +33,7 @@ jobs:
         run: npm i -g bare
       - name: Run all tests
         run: npm run test:unit:all
+        
 # For now acceptance tests should be disable due to instability of the running MSB instance in the github actions environment
 # Github machines are not powerful enough to run MSB, and we won't ever finish our tests.
 #      - name: Run rpc acceptance tests


### PR DESCRIPTION
This PR updates the `unit-tests.yml` workflow to run only on our self-hosted Linux runner.

What was changed:
- Removed the OS matrix (ubuntu-latest, macos-latest, windows-latest).
- Updated runs-on to target the self-hosted runner labels: self-hosted + self-hosted-linux-x64.