### PR TITLE
feat: cli asks for transaction confirmation on transfer operation

### DIFF
--- a/cli/commandHandler.js
+++ b/cli/commandHandler.js
@@ -1,6 +1,7 @@
 import { randomBytes } from "hypercore-crypto";
 import { Handlers } from "./handlers.js";
 import { isHexString } from "../src/utils/helpers.js";
+import { bigIntToDecimalString } from "../src/utils/amountSerialization.js";
 
 export const COMMANDS = {
     HELP: "/help",
@@ -44,6 +45,7 @@ export class CommandHandler {
     #closeCli;
     #wallet;
     #handlers;
+    #pendingConfirmation = null;
 
     constructor({ config, msb, handleClose, wallet }) {
         this.#config = config;
@@ -54,6 +56,10 @@ export class CommandHandler {
     }
 
     async handle(input) {
+        if (this.#pendingConfirmation !== null) {
+            return this.#handlePendingConfirmation(input);
+        }
+
         const [command, ...parts] = input.split(" ");
         const context = { command, input, parts };
         const handlers = this.#getHandlers();
@@ -163,7 +169,7 @@ export class CommandHandler {
             },
             {
                 evaluate: ({ input }) => input.startsWith(COMMANDS.TRANSFER),
-                process: async ({ parts }) => this.#msb.handleTransferOperation(parts[0], parts[1])
+                process: async ({ parts }) => this.#queueTransferConfirmation(parts[0], parts[1])
             },
             {
                 evaluate: ({ input }) => input.startsWith(COMMANDS.GET_BALANCE),
@@ -213,5 +219,55 @@ export class CommandHandler {
                 process: async ({ parts }) => this.#handlers.handleExtendedTxDetails(parts[0], parts[1] === "true")
             }
         ];
+    }
+
+    async #handlePendingConfirmation(input) {
+        const normalizedInput = input.trim().toLowerCase();
+        const pendingConfirmation = this.#pendingConfirmation;
+
+        if (normalizedInput === "y" || normalizedInput === "yes") {
+            this.#pendingConfirmation = null;
+
+            try {
+                return await pendingConfirmation.onConfirm();
+            } catch (error) {
+                const errorMessage = error instanceof Error ? error.message : `${error}`;
+                console.error(`Command failed: ${errorMessage}`);
+                console.log("Try again or use /help.");
+            }
+
+            return;
+        }
+
+        if (normalizedInput === "n" || normalizedInput === "no") {
+            this.#pendingConfirmation = null;
+            return pendingConfirmation.onDecline();
+        }
+
+        console.log('Invalid input. Please answer "y" or "n".');
+        console.log(pendingConfirmation.prompt);
+    }
+
+    async #queueTransferConfirmation(recipientAddress, amount) {
+        const preparedTransfer = await this.#msb.prepareTransferOperation(recipientAddress, amount);
+
+        console.info("Transfer Details:");
+        console.info(`Transaction hash ${preparedTransfer.payload.tro.tx}`)
+        if (preparedTransfer.isSelfTransfer) {
+            console.info("Self transfer - only fee will be deducted");
+        }
+        console.info(`Amount: ${bigIntToDecimalString(preparedTransfer.amountBigInt)}`);
+        console.info(`Transaction cost: ${bigIntToDecimalString(preparedTransfer.totalDeductedAmount)}`);
+        console.info(`Estimated transaction fee: ${bigIntToDecimalString(preparedTransfer.feeBigInt)}`);
+        console.info(`Current balance: ${bigIntToDecimalString(preparedTransfer.senderBalance)}`);
+        console.info(`Balance after transaction: ${bigIntToDecimalString(preparedTransfer.expectedNewBalance)}`);
+
+        this.#pendingConfirmation = {
+            prompt: "Do you want to proceed? (y/n)",
+            onConfirm: async () => this.#msb.submitPreparedTransferOperation(preparedTransfer),
+            onDecline: async () => this.#msb.printHelp()
+        };
+
+        console.log(this.#pendingConfirmation.prompt);
     }
 }

--- a/cli/commandHandler.js
+++ b/cli/commandHandler.js
@@ -231,8 +231,10 @@ export class CommandHandler {
             try {
                 return await pendingConfirmation.onConfirm();
             } catch (error) {
-                const errorMessage = error instanceof Error ? error.message : `${error}`;
-                console.error(`Command failed: ${errorMessage}`);
+                const errorMessage = typeof error === "object" && error !== null && "message" in error
+                    ? error.message
+                    : `${error}`;
+                console.error(`Transaction submission failed: ${errorMessage}`);
                 console.log("Try again or use /help.");
             }
 
@@ -252,7 +254,6 @@ export class CommandHandler {
         const preparedTransfer = await this.#msb.prepareTransferOperation(recipientAddress, amount);
 
         console.info("Transfer Details:");
-        console.info(`Transaction hash ${preparedTransfer.payload.tro.tx}`)
         if (preparedTransfer.isSelfTransfer) {
             console.info("Self transfer - only fee will be deducted");
         }

--- a/cli/commandHandler.js
+++ b/cli/commandHandler.js
@@ -258,8 +258,8 @@ export class CommandHandler {
             console.info("Self transfer - only fee will be deducted");
         }
         console.info(`Amount: ${bigIntToDecimalString(preparedTransfer.amountBigInt)}`);
-        console.info(`Transaction cost: ${bigIntToDecimalString(preparedTransfer.totalDeductedAmount)}`);
         console.info(`Estimated transaction fee: ${bigIntToDecimalString(preparedTransfer.feeBigInt)}`);
+        console.info(`Total transaction cost: ${bigIntToDecimalString(preparedTransfer.totalDeductedAmount)}`);
         console.info(`Current balance: ${bigIntToDecimalString(preparedTransfer.senderBalance)}`);
         console.info(`Balance after transaction: ${bigIntToDecimalString(preparedTransfer.expectedNewBalance)}`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1601,7 +1600,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -1935,7 +1933,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2716,7 +2713,6 @@
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
       "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -2945,7 +2941,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6196,7 +6191,6 @@
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -969,24 +969,6 @@ export class MainSettlementBus extends ReadyResource {
         return preparedTransfer.payload.tro.tx;
     }
 
-    async handleTransferOperation(recipientAddress, amount) {
-        const preparedTransfer = await this.prepareTransferOperation(recipientAddress, amount);
-
-        console.info('Transfer Details:');
-        console.info(`Transaction hash ${preparedTransfer.payload.tro.tx}`)
-        if (preparedTransfer.isSelfTransfer) {
-            console.info('Self transfer - only fee will be deducted');
-            console.info(`Fee: ${bigIntToDecimalString(preparedTransfer.feeBigInt)}`);
-            console.info(`Total amount to send: ${bigIntToDecimalString(preparedTransfer.totalDeductedAmount)}`);
-        } else {
-            console.info(`Amount: ${bigIntToDecimalString(preparedTransfer.amountBigInt)}`);
-            console.info(`Fee: ${bigIntToDecimalString(preparedTransfer.feeBigInt)}`);
-            console.info(`Total: ${bigIntToDecimalString(preparedTransfer.totalDeductedAmount)}`);
-        }
-        console.log(`Expected Balance After Transfer: ${bigIntToDecimalString(preparedTransfer.expectedNewBalance)}`);
-        await this.submitPreparedTransferOperation(preparedTransfer);
-    }
-
     async balanceMigrationOperation() {
         const isInitDisabled = await this.#state.isInitalizationDisabled()
 

--- a/src/index.js
+++ b/src/index.js
@@ -891,7 +891,7 @@ export class MainSettlementBus extends ReadyResource {
 
     }
 
-    async handleTransferOperation(recipientAddress, amount) {
+    async prepareTransferOperation(recipientAddress, amount) {
         if (!this.#config.enableWallet) {
             throw new Error(
                 "Can not perform transfer - wallet is not enabled."
@@ -939,33 +939,52 @@ export class MainSettlementBus extends ReadyResource {
         const txValidity = await this.#state.getIndexerSequenceState();
         const payload = await applyStateMessageFactory(this.#wallet, this.#config)
             .buildPartialTransferOperationMessage(
-            this.#wallet.address,
-            recipientAddress,
-            amountBuffer,
-            txValidity,
-            "json"
-        )
+                this.#wallet.address,
+                recipientAddress,
+                amountBuffer,
+                txValidity,
+                "json"
+            );
 
         const expectedNewBalance = senderBalance - totalDeductedAmount;
-        console.info('Transfer Details:');
-        console.info(`Transaction hash ${payload.tro.tx}`)
-        if (isSelfTransfer) {
-            console.info('Self transfer - only fee will be deducted');
-            console.info(`Fee: ${bigIntToDecimalString(feeBigInt)}`);
-            console.info(`Total amount to send: ${bigIntToDecimalString(totalDeductedAmount)}`);
-        } else {
-            console.info(`Amount: ${bigIntToDecimalString(amountBigInt)}`);
-            console.info(`Fee: ${bigIntToDecimalString(feeBigInt)}`);
-            console.info(`Total: ${bigIntToDecimalString(totalDeductedAmount)}`);
-        }
-        console.log(`Expected Balance After Transfer: ${bigIntToDecimalString(expectedNewBalance)}`);
-        const success = await this.broadcastPartialTransaction(payload);
+        return {
+            payload,
+            amountBigInt,
+            feeBigInt,
+            senderBalance,
+            totalDeductedAmount,
+            expectedNewBalance,
+            isSelfTransfer
+        };
+    }
+
+    async submitPreparedTransferOperation(preparedTransfer) {
+        const success = await this.broadcastPartialTransaction(preparedTransfer.payload);
         if (!success) {
             throw new Error("Failed to broadcast transfer transaction after multiple attempts.");
         } else {
-            console.log(`Transfer transaction broadcasted successfully. Tx hash: ${payload.tro.tx}`);
+            console.log(`Transfer transaction broadcasted successfully. Tx hash: ${preparedTransfer.payload.tro.tx}`);
         }
 
+        return preparedTransfer.payload.tro.tx;
+    }
+
+    async handleTransferOperation(recipientAddress, amount) {
+        const preparedTransfer = await this.prepareTransferOperation(recipientAddress, amount);
+
+        console.info('Transfer Details:');
+        console.info(`Transaction hash ${preparedTransfer.payload.tro.tx}`)
+        if (preparedTransfer.isSelfTransfer) {
+            console.info('Self transfer - only fee will be deducted');
+            console.info(`Fee: ${bigIntToDecimalString(preparedTransfer.feeBigInt)}`);
+            console.info(`Total amount to send: ${bigIntToDecimalString(preparedTransfer.totalDeductedAmount)}`);
+        } else {
+            console.info(`Amount: ${bigIntToDecimalString(preparedTransfer.amountBigInt)}`);
+            console.info(`Fee: ${bigIntToDecimalString(preparedTransfer.feeBigInt)}`);
+            console.info(`Total: ${bigIntToDecimalString(preparedTransfer.totalDeductedAmount)}`);
+        }
+        console.log(`Expected Balance After Transfer: ${bigIntToDecimalString(preparedTransfer.expectedNewBalance)}`);
+        await this.submitPreparedTransferOperation(preparedTransfer);
     }
 
     async balanceMigrationOperation() {

--- a/tests/unit/cli/commandHandler.test.js
+++ b/tests/unit/cli/commandHandler.test.js
@@ -1,0 +1,119 @@
+import { test } from "brittle";
+import sinon from "sinon";
+
+import { CommandHandler } from "../../../cli/commandHandler.js";
+
+function createPreparedTransfer() {
+    return {
+        amountBigInt: 10n,
+        feeBigInt: 3n,
+        senderBalance: 50n,
+        totalDeductedAmount: 13n,
+        expectedNewBalance: 37n,
+        isSelfTransfer: false
+    };
+}
+
+function createSubject(overrides = {}) {
+    const preparedTransfer = overrides.preparedTransfer ?? createPreparedTransfer();
+    const msb = {
+        prepareTransferOperation: sinon.stub().resolves(preparedTransfer),
+        submitPreparedTransferOperation: sinon.stub().resolves("tx-hash"),
+        printHelp: sinon.stub(),
+        close: sinon.stub(),
+        ...overrides.msb
+    };
+
+    const handler = new CommandHandler({
+        config: {},
+        msb,
+        handleClose: async () => {},
+        wallet: undefined
+    });
+
+    return { handler, msb, preparedTransfer };
+}
+
+function stubConsole(t) {
+    sinon.stub(console, "info");
+    sinon.stub(console, "log");
+    sinon.stub(console, "error");
+    t.teardown(() => sinon.restore());
+}
+
+test("CommandHandler queues transfer preview without submitting immediately", async (t) => {
+    stubConsole(t);
+
+    const { handler, msb } = createSubject();
+
+    await handler.handle("/transfer trac1recipient 10");
+
+    t.ok(msb.prepareTransferOperation.calledOnceWithExactly("trac1recipient", "10"));
+    t.ok(msb.submitPreparedTransferOperation.notCalled);
+    t.ok(console.info.calledWith("Transfer Details:"));
+    t.ok(console.info.calledWithMatch(sinon.match(/Estimated transaction fee:/)));
+    t.ok(console.info.calledWithMatch(sinon.match(/Current balance:/)));
+    t.ok(console.info.calledWithMatch(sinon.match(/Balance after transaction:/)));
+    t.ok(console.log.calledWith("Do you want to proceed? (y/n)"));
+});
+
+test("CommandHandler submits prepared transfer when confirmation is affirmative", async (t) => {
+    stubConsole(t);
+
+    const { handler, msb, preparedTransfer } = createSubject();
+
+    await handler.handle("/transfer trac1recipient 10");
+    await handler.handle("YES");
+
+    t.ok(msb.submitPreparedTransferOperation.calledOnceWithExactly(preparedTransfer));
+    t.ok(msb.printHelp.notCalled);
+});
+
+test("CommandHandler declines prepared transfer and shows help", async (t) => {
+    stubConsole(t);
+
+    const { handler, msb } = createSubject();
+
+    await handler.handle("/transfer trac1recipient 10");
+    await handler.handle("n");
+
+    t.ok(msb.submitPreparedTransferOperation.notCalled);
+    t.ok(msb.printHelp.calledOnce);
+});
+
+test("CommandHandler re-prompts on invalid confirmation input and keeps pending transfer", async (t) => {
+    stubConsole(t);
+
+    const { handler, msb } = createSubject();
+
+    await handler.handle("/transfer trac1recipient 10");
+    await handler.handle("maybe");
+
+    t.ok(msb.submitPreparedTransferOperation.notCalled);
+    t.ok(console.log.calledWith('Invalid input. Please answer "y" or "n".'));
+    t.ok(console.log.calledWith("Do you want to proceed? (y/n)"));
+
+    await handler.handle("y");
+
+    t.ok(msb.submitPreparedTransferOperation.calledOnce);
+});
+
+test("CommandHandler clears pending confirmation after submission failure", async (t) => {
+    stubConsole(t);
+
+    const { handler, msb } = createSubject({
+        msb: {
+            submitPreparedTransferOperation: sinon.stub().rejects(new Error("boom"))
+        }
+    });
+
+    await handler.handle("/transfer trac1recipient 10");
+    await handler.handle("y");
+
+    t.ok(console.error.calledWith("Transaction submission failed: boom"));
+    t.ok(console.log.calledWith("Try again or use /help."));
+
+    await handler.handle("/transfer trac1recipient 11");
+
+    t.is(msb.prepareTransferOperation.callCount, 2);
+});

--- a/tests/unit/unit.test.js
+++ b/tests/unit/unit.test.js
@@ -5,6 +5,7 @@ import { default as test } from 'brittle';
 async function runTests() {
 	test.pause();
 	await import('./config/configModule.test.js');
+	await import('./cli/commandHandler.test.js');
 	await import('./utils/utils.test.js');
 	await import('./messages/messages.test.js');
 	await import('./network/networkModule.test.js')


### PR DESCRIPTION
## Changes
- split transfer handling into prepare and submit steps
- add pending `y/n` confirmation for `/transfer` op
- show transfer preview before submission:
  - if self-trasnfer, inform that only tx fee will be deduced
  - transfer amount
  - "estimated" fee (this is still a fixed amount, but I chose to make the message "future-proof")
  - transaction cost
  - current balance
  - balance after transaction
- submit only after confirmation (user should input `y`)
- add unit tests for the CLI transfer confirmation flow

Note: It would be good to create more unit tests for CLI in another task. That is mostly uncovered