### PR TITLE
docs: update supported versions in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,10 @@ The following table shows which versions of this project are currently receiving
 
 | Version | Supported          |
 | -------- | ------------------ |
-| 0.2.x    | :white_check_mark: |
-| < 0.2    | :x:                |
+| 0.2.18   | :white_check_mark: |
+| 0.2.17   | :white_check_mark: |
+| main     | :warning: unstable |
+| < 0.2.17 | :x:                |
 
 Older versions (< 0.2.x) are no longer supported.  
 Please upgrade to the latest release to ensure you receive security fixes.


### PR DESCRIPTION
This pull request updates the supported versions table in `SECURITY.md` to reflect the current support status more accurately.

Documentation update:

* Updated the supported versions table to list `0.2.18` and `0.2.17` as supported, mark `main` as unstable, and clarify that versions `< 0.2.17` are not supported.