### PR TITLE
fix: linter adding e on console.log for catch failure

### DIFF
--- a/tests/unit/state/stateAdminValidation.test.js
+++ b/tests/unit/state/stateAdminValidation.test.js
@@ -85,7 +85,9 @@ async function setupMockedState(config) {
         state, 
         restore: () => {
             stubs.forEach(s => s.restore());
-            try { fs.rmSync(dbPath, { recursive: true, force: true }); } catch (e) {}
+            try { fs.rmSync(dbPath, { recursive: true, force: true }); } catch (e) {
+                console.log(e);
+            }
         } 
     };
 }


### PR DESCRIPTION
This is just a linter fix.