### PR TITLE
feat: Implement builder for internal consensus messages in the time consensus layer (#591)

### DIFF
--- a/proto/consensus/v1/enums/result_code.proto
+++ b/proto/consensus/v1/enums/result_code.proto
@@ -14,5 +14,4 @@ package consensus.v1;
 enum ResultCode {
   RESULT_CODE_UNSPECIFIED = 0;
   RESULT_CODE_OK = 1;
-
 }

--- a/proto/consensus/v1/messages/proof_proposal.proto
+++ b/proto/consensus/v1/messages/proof_proposal.proto
@@ -9,7 +9,7 @@ message ProofProposal {
   uint32 network_id = 2;
   uint64 epoch = 3; // current epoch number
   bytes previous_epoch_record_hash = 4; // this must be a blob of previous epoch operation - TODO we need agree for the spec of the serialization
-  bytes proposer = 5; // address of the proposer or address
+  bytes proposer = 5; // TRAC address of the proposer
   bytes vdf_parameters_hash = 6; // H(difficulty || iterations)
   bytes vdf_proof = 7; // bytes blob  that is actually y || pi
   bytes signature = 8; // SIG(challenge_data + vdf_proof)

--- a/proto/consensus/v1/messages/proof_proposal.proto
+++ b/proto/consensus/v1/messages/proof_proposal.proto
@@ -3,12 +3,13 @@ syntax = "proto3";
 package consensus.v1;
 
 // Challenge data are from 1 to 6.
+// Proof data are from 7 to 8.
 message ProofProposal {
   uint32 protocol_version = 1; // 0x01
   uint32 network_id = 2;
   uint64 epoch = 3; // current epoch number
   bytes previous_epoch_record_hash = 4; // this must be a blob of previous epoch operation - TODO we need agree for the spec of the serialization
-  bytes proposer = 5; // writingKey OR address of the proposer or address
+  bytes proposer = 5; // address of the proposer or address
   bytes vdf_parameters_hash = 6; // H(difficulty || iterations)
   bytes vdf_proof = 7; // bytes blob  that is actually y || pi
   bytes signature = 8; // SIG(challenge_data + vdf_proof)

--- a/proto/consensus/v1/messages/proof_proposal_approval.proto
+++ b/proto/consensus/v1/messages/proof_proposal_approval.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package consensus.v1;
 
-// approval sig =  SIG(proof_proposal)
+// approval sig =  SIG(approver + proof_proposal)
 message ProofProposalApproval {
-  bytes member_id = 1;
+  bytes approver = 1;
   bytes approval_sig = 2;
 }

--- a/src/codecs/consensus/v1/consensusV1.generated.cjs
+++ b/src/codecs/consensus/v1/consensusV1.generated.cjs
@@ -1151,7 +1151,7 @@ $root.consensus = (function() {
              * Properties of a ProofProposalApproval.
              * @memberof consensus.v1
              * @interface IProofProposalApproval
-             * @property {Uint8Array|null} [member_id] ProofProposalApproval member_id
+             * @property {Uint8Array|null} [approver] ProofProposalApproval approver
              * @property {Uint8Array|null} [approval_sig] ProofProposalApproval approval_sig
              */
 
@@ -1171,12 +1171,12 @@ $root.consensus = (function() {
             }
 
             /**
-             * ProofProposalApproval member_id.
-             * @member {Uint8Array} member_id
+             * ProofProposalApproval approver.
+             * @member {Uint8Array} approver
              * @memberof consensus.v1.ProofProposalApproval
              * @instance
              */
-            ProofProposalApproval.prototype.member_id = $util.newBuffer([]);
+            ProofProposalApproval.prototype.approver = $util.newBuffer([]);
 
             /**
              * ProofProposalApproval approval_sig.
@@ -1210,8 +1210,8 @@ $root.consensus = (function() {
             ProofProposalApproval.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.member_id != null && Object.hasOwnProperty.call(message, "member_id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.member_id);
+                if (message.approver != null && Object.hasOwnProperty.call(message, "approver"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.approver);
                 if (message.approval_sig != null && Object.hasOwnProperty.call(message, "approval_sig"))
                     writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.approval_sig);
                 return writer;
@@ -1251,7 +1251,7 @@ $root.consensus = (function() {
                         break;
                     switch (tag >>> 3) {
                     case 1: {
-                            message.member_id = reader.bytes();
+                            message.approver = reader.bytes();
                             break;
                         }
                     case 2: {
@@ -1293,9 +1293,9 @@ $root.consensus = (function() {
             ProofProposalApproval.verify = function verify(message) {
                 if (typeof message !== "object" || message === null)
                     return "object expected";
-                if (message.member_id != null && message.hasOwnProperty("member_id"))
-                    if (!(message.member_id && typeof message.member_id.length === "number" || $util.isString(message.member_id)))
-                        return "member_id: buffer expected";
+                if (message.approver != null && message.hasOwnProperty("approver"))
+                    if (!(message.approver && typeof message.approver.length === "number" || $util.isString(message.approver)))
+                        return "approver: buffer expected";
                 if (message.approval_sig != null && message.hasOwnProperty("approval_sig"))
                     if (!(message.approval_sig && typeof message.approval_sig.length === "number" || $util.isString(message.approval_sig)))
                         return "approval_sig: buffer expected";
@@ -1314,11 +1314,11 @@ $root.consensus = (function() {
                 if (object instanceof $root.consensus.v1.ProofProposalApproval)
                     return object;
                 var message = new $root.consensus.v1.ProofProposalApproval();
-                if (object.member_id != null)
-                    if (typeof object.member_id === "string")
-                        $util.base64.decode(object.member_id, message.member_id = $util.newBuffer($util.base64.length(object.member_id)), 0);
-                    else if (object.member_id.length >= 0)
-                        message.member_id = object.member_id;
+                if (object.approver != null)
+                    if (typeof object.approver === "string")
+                        $util.base64.decode(object.approver, message.approver = $util.newBuffer($util.base64.length(object.approver)), 0);
+                    else if (object.approver.length >= 0)
+                        message.approver = object.approver;
                 if (object.approval_sig != null)
                     if (typeof object.approval_sig === "string")
                         $util.base64.decode(object.approval_sig, message.approval_sig = $util.newBuffer($util.base64.length(object.approval_sig)), 0);
@@ -1342,11 +1342,11 @@ $root.consensus = (function() {
                 var object = {};
                 if (options.defaults) {
                     if (options.bytes === String)
-                        object.member_id = "";
+                        object.approver = "";
                     else {
-                        object.member_id = [];
+                        object.approver = [];
                         if (options.bytes !== Array)
-                            object.member_id = $util.newBuffer(object.member_id);
+                            object.approver = $util.newBuffer(object.approver);
                     }
                     if (options.bytes === String)
                         object.approval_sig = "";
@@ -1356,8 +1356,8 @@ $root.consensus = (function() {
                             object.approval_sig = $util.newBuffer(object.approval_sig);
                     }
                 }
-                if (message.member_id != null && message.hasOwnProperty("member_id"))
-                    object.member_id = options.bytes === String ? $util.base64.encode(message.member_id, 0, message.member_id.length) : options.bytes === Array ? Array.prototype.slice.call(message.member_id) : message.member_id;
+                if (message.approver != null && message.hasOwnProperty("approver"))
+                    object.approver = options.bytes === String ? $util.base64.encode(message.approver, 0, message.approver.length) : options.bytes === Array ? Array.prototype.slice.call(message.approver) : message.approver;
                 if (message.approval_sig != null && message.hasOwnProperty("approval_sig"))
                     object.approval_sig = options.bytes === String ? $util.base64.encode(message.approval_sig, 0, message.approval_sig.length) : options.bytes === Array ? Array.prototype.slice.call(message.approval_sig) : message.approval_sig;
                 return object;

--- a/src/core/consensus/v1/consensusSigningMessage.js
+++ b/src/core/consensus/v1/consensusSigningMessage.js
@@ -1,0 +1,97 @@
+import {assertBuffer, createMessage, uint32ToBuffer, uint64ToBuffer} from "../../../utils/buffer.js";
+
+export function createProofProposalSigningMessage(
+    protocolVersion,
+    networkId,
+    epoch,
+    previousEpochRecordHash,
+    proposer,
+    vdfParametersHash,
+    vdfProof
+) {
+    return createMessage(
+        uint32ToBuffer(protocolVersion, 'Protocol version'),
+        uint32ToBuffer(networkId, 'Network id'),
+        uint64ToBuffer(epoch, 'Epoch'),
+        assertBuffer(previousEpochRecordHash, 'Previous epoch record hash'),
+        assertBuffer(proposer, 'Proposer'),
+        assertBuffer(vdfParametersHash, 'VDF parameters hash'),
+        assertBuffer(vdfProof, 'VDF proof')
+    );
+}
+
+export function safeCreateProofProposalSigningMessage(
+    protocolVersion,
+    networkId,
+    epoch,
+    previousEpochRecordHash,
+    proposer,
+    vdfParametersHash,
+    vdfProof
+) {
+    try {
+        return createProofProposalSigningMessage(
+            protocolVersion,
+            networkId,
+            epoch,
+            previousEpochRecordHash,
+            proposer,
+            vdfParametersHash,
+            vdfProof
+        );
+    } catch {
+        return null;
+    }
+}
+
+export function createProofProposalApprovalSigningMessage(
+    protocolVersion,
+    networkId,
+    epoch,
+    previousEpochRecordHash,
+    proposer,
+    vdfParametersHash,
+    vdfProof,
+    approver,
+    requesterProofSignature
+) {
+    return createMessage(
+        uint32ToBuffer(protocolVersion, 'Protocol version'),
+        uint32ToBuffer(networkId, 'Network id'),
+        uint64ToBuffer(epoch, 'Epoch'),
+        assertBuffer(previousEpochRecordHash, 'Previous epoch record hash'),
+        assertBuffer(proposer, 'Proposer'),
+        assertBuffer(vdfParametersHash, 'VDF parameters hash'),
+        assertBuffer(vdfProof, 'VDF proof'),
+        assertBuffer(approver, 'Approver'),
+        assertBuffer(requesterProofSignature, 'Requester proof signature')
+    );
+}
+
+export function safeCreateProofProposalApprovalSigningMessage(
+    protocolVersion,
+    networkId,
+    epoch,
+    previousEpochRecordHash,
+    proposer,
+    vdfParametersHash,
+    vdfProof,
+    approver,
+    requesterProofSignature
+) {
+    try {
+        return createProofProposalApprovalSigningMessage(
+            protocolVersion,
+            networkId,
+            epoch,
+            previousEpochRecordHash,
+            proposer,
+            vdfParametersHash,
+            vdfProof,
+            approver,
+            requesterProofSignature
+        );
+    } catch {
+        return null;
+    }
+}

--- a/src/core/consensus/v1/handlers/ConsesusEpochProofProposalOperationHandler.js
+++ b/src/core/consensus/v1/handlers/ConsesusEpochProofProposalOperationHandler.js
@@ -60,7 +60,7 @@ class ConsensusEpochProofProposalOperationHandler {
     }
 
     // TODO: validates the response from line 61 to the end
-    // is valid signature and is a valid member id
+    // is valid signature and is a valid approver
     async handleResponse(message, connection) {
         try {
             this.applyRateLimit(connection);
@@ -86,7 +86,7 @@ class ConsensusEpochProofProposalOperationHandler {
         return {
             code: payload.epoch_proof_proposal_response.result,
             result: {
-                memberId: payload.epoch_proof_proposal_response.member_id,
+                approver: payload.epoch_proof_proposal_response.approver,
                 signature: payload.epoch_proof_proposal_response.signature
             }
         };

--- a/src/core/consensus/v1/validators/ConsensusValidationSchema.js
+++ b/src/core/consensus/v1/validators/ConsensusValidationSchema.js
@@ -135,7 +135,7 @@ class ConsensusValidationSchema {
                 strict: true,
                 type: 'object',
                 props: {
-                    member_id: {type: 'buffer', length: PUBLIC_KEY_LENGTH, required: true},
+                    approver: {type: 'buffer', length: PUBLIC_KEY_LENGTH, required: true},
                     signature: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true},
                     result: {type: 'enum', values: ALLOWED_RESULT_CODES, required: true},
                 }

--- a/src/core/consensus/v1/validators/V1EpochProofProposalResponse.js
+++ b/src/core/consensus/v1/validators/V1EpochProofProposalResponse.js
@@ -15,7 +15,7 @@ class V1EpochProofProposalResponse extends V1BaseOperation {
         this.validateResponseType(payload, pendingRequestServiceEntry);
         this.validatePeerCorrectness(connection.remotePublicKey, pendingRequestServiceEntry);
 
-        this.validateMemberId(payload, connection.remotePublicKey);
+        this.validateApprover(payload, connection.remotePublicKey);
         const resultCode = payload.broadcast_transaction_response.result;
         if (resultCode === ResultCode.OK) {
             this.validateProposalSignature(payload, pendingRequestServiceEntry.requestEpochProofProposalHash);
@@ -23,12 +23,12 @@ class V1EpochProofProposalResponse extends V1BaseOperation {
         return true;
     }
 
-    validateMemberId(payload, remotePublicKey) {
-        const memberId = payload.epoch_proof_proposal_response?.member_id;
-        if (!isBufferValid(memberId, WRITER_BYTE_LENGTH) || !b4a.equals(memberId, remotePublicKey)) {
+    validateApprover(payload, remotePublicKey) {
+        const approver = payload.epoch_proof_proposal_response?.approver;
+        if (!isBufferValid(approver, WRITER_BYTE_LENGTH) || !b4a.equals(approver, remotePublicKey)) {
             throw new V1ProtocolError(
                 ResultCode.INVALID_PAYLOAD,
-                'Epoch proposal response member_id does not match sender public key.'
+                'Epoch proposal response approver does not match sender public key.'
             );
         }
     }
@@ -40,7 +40,7 @@ class V1EpochProofProposalResponse extends V1BaseOperation {
             verified = tracCryptoApi.signature.verify(
                 response.signature,
                 proposalHash,
-                response.member_id
+                response.approver
             );
         } catch {
             verified = false;

--- a/src/messages/consensus/v1/ConsensusMessageBuilder.js
+++ b/src/messages/consensus/v1/ConsensusMessageBuilder.js
@@ -1,0 +1,278 @@
+import b4a from 'b4a';
+import tracCryptoApi from 'trac-crypto-api';
+import {encodeProofProposalApproval} from '../../../codecs/consensus/v1/consensusV1OperationCodec.js';
+import {addressToBuffer, isAddressValid} from "../../../core/state/utils/address.js";
+import {ConsensusOperationType, ConsensusResultCode} from '../../../utils/constants.js';
+import {createMessage, safeWriteUInt32BE} from "../../../utils/buffer.js";
+
+class ConsensusMessageBuilder {
+    #wallet;
+    #config;
+    #header;
+    #type;
+    #session_id;
+    #timestamp;
+    #protocol_version;
+    #network_id;
+    #epoch;
+    #previous_epoch_record_hash;
+    #proposer;
+    #vdf_parameters_hash;
+    #vdf_proof;
+    #resultCode;
+    #approver;
+    #body;
+    #payloadKey;
+    #requester_proof_signature;
+
+    constructor(wallet, config) {
+        this.#config = config;
+        if (!wallet || typeof wallet !== 'object') {
+            throw new Error('Wallet must be a valid wallet object');
+        }
+        if (!isAddressValid(wallet.address, this.#config.addressPrefix)) {
+            throw new Error('Wallet should have a valid TRAC address.');
+        }
+
+        this.#wallet = wallet;
+    }
+
+    #validateUint32(value, fieldName) {
+        if (!Number.isInteger(value) || value < 0 || value > 0xFFFFFFFF) {
+            throw new Error(`${fieldName} must be an unsigned 32-bit integer.`);
+        }
+
+        return value;
+    }
+
+    #validateSafeUint64(value, fieldName) {
+        if (!Number.isSafeInteger(value) || value < 0) {
+            throw new Error(`${fieldName} must be a non-negative safe integer.`);
+        }
+
+        return value;
+    }
+
+    #validateBuffer(value, fieldName) {
+        if (!b4a.isBuffer(value)) {
+            throw new Error(`${fieldName} must be a buffer.`);
+        }
+
+        return value;
+    }
+
+    #validateAddress(address, fieldName) {
+        if (typeof address !== 'string') {
+            throw new Error(`${fieldName} must be a valid TRAC address.`);
+        }
+
+        try {
+            const publicKey = tracCryptoApi.address.decode(address);
+            const canonicalAddress = tracCryptoApi.address.encode(this.#config.addressPrefix, publicKey);
+            if (canonicalAddress !== address) {
+                throw new Error('Address is not canonical for configured prefix.');
+            }
+
+            return addressToBuffer(address, this.#config.addressPrefix);
+        } catch {
+            throw new Error(`${fieldName} must be a valid TRAC address.`);
+        }
+    }
+
+    #setHeader() {
+        if (!this.#type) throw new Error('Header requires type to be set');
+        if (!this.#session_id) throw new Error('Header requires session to be set');
+        if (!this.#timestamp) throw new Error('Header requires a timestamp provider');
+        //if (!Array.isArray(this.#capabilities)) throw new Error('Header requires capabilities array');
+
+        this.#header = {
+            type: this.#type,
+            session_id: this.#session_id,
+            timestamp: this.#timestamp,
+            //capabilities: this.#capabilities,
+        };
+        return this;
+    }
+
+    setType(type) {
+        if (!Object.values(ConsensusOperationType).includes(type)) {
+            throw new Error(`Invalid consensus operation type: ${type}`);
+        }
+        this.#type = type;
+        return this;
+    }
+
+    setSessionId(sessionId) {
+        if (typeof sessionId !== 'string' || sessionId.length === 0) {
+            throw new Error('Session id must be a non-empty string.');
+        }
+
+        this.#session_id = sessionId;
+        return this;
+    }
+
+    setTimestamp(timestamp = Date.now()) {
+        const value = timestamp instanceof Date ? timestamp.getTime() : timestamp;
+        if (!Number.isSafeInteger(value) || value <= 0) {
+            throw new Error('Timestamp must be a positive safe integer or Date.');
+        }
+
+        this.#timestamp = this.#validateSafeUint64(value, 'Timestamp');
+        return this;
+    }
+
+    setProtocolVersion(protocolVersion) {
+        this.#protocol_version = this.#validateUint32(protocolVersion, 'Protocol version');
+        return this;
+    }
+
+    setNetworkId(networkId) {
+        this.#network_id = this.#validateUint32(networkId, 'Network id');
+        return  this;
+    }
+
+    setEpoch(epoch) {
+        this.#epoch = this.#validateSafeUint64(epoch, 'Epoch');
+        return this;
+    }
+
+    setPreviousEpochRecordHash(previousEpochRecordHash) {
+        this.#previous_epoch_record_hash = this.#validateBuffer(
+            previousEpochRecordHash,
+            'Previous epoch record hash'
+        );
+        return this;
+    }
+
+    setProposer(proposer) {
+        this.#proposer = this.#validateAddress(proposer, 'Proposer');
+        return this;
+    }
+
+    setVdfParametersHash(vdfParametersHash) {
+        this.#vdf_parameters_hash = this.#validateBuffer(vdfParametersHash, 'VDF parameters hash');
+        return this;
+    }
+
+    setVdfProof(vdfProof) {
+        this.#vdf_proof = this.#validateBuffer(vdfProof, 'VDF proof');
+        return this;
+    }
+
+
+    setResultCode(code) {
+        if (!Object.values(ConsensusResultCode).includes(code)) {
+            throw new Error(`Invalid consensus result code: ${code}`);
+        }
+
+        this.#resultCode = code;
+        return this;
+    }
+
+    setApprover(approver) {
+        this.#approver = this.#validateAddress(approver, 'Approver');
+        return this;
+    }
+
+    setRequesterProofSignature(proofSignature) {
+        this.#requester_proof_signature = this.#validateBuffer(proofSignature, 'Requester proof signature');
+        return this;
+    }
+
+    async #buildProofProposalPayload() {
+        const message = createMessage(
+            this.#protocol_version,
+            this.#network_id,
+            this.#epoch,
+            this.#previous_epoch_record_hash,
+            this.#proposer,
+            this.#vdf_parameters_hash,
+            this.#vdf_proof
+        );
+        const hash = await tracCryptoApi.hash.blake3(message);
+        const signature = this.#wallet.sign(hash);
+        this.#payloadKey = 'proof_proposal';
+        this.#body = {
+            protocol_version: this.#protocol_version,
+            network_id: this.#network_id,
+            epoch: this.#epoch,
+            previous_epoch_record_hash: this.#previous_epoch_record_hash,
+            proposer: this.#proposer,
+            vdf_parameters_hash: this.#vdf_parameters_hash,
+            vdf_proof: this.#vdf_proof,
+            signature: signature,
+        };
+    }
+
+    async #buildProofProposalResponsePayload() {
+        if (this.#resultCode === undefined) {
+            throw new Error('Result code must be set before build.');
+        }
+
+        const messageApproval = createMessage(
+            this.#protocol_version,
+            this.#network_id,
+            this.#epoch,
+            this.#previous_epoch_record_hash,
+            this.#proposer,
+            this.#vdf_parameters_hash,
+            this.#vdf_proof,
+            this.#approver,
+            this.#requester_proof_signature
+        );
+        const hashApproval = await tracCryptoApi.hash.blake3(messageApproval);
+        const signatureApproval = this.#wallet.sign(hashApproval);
+
+        const proofProposalApproval = {
+            approver: this.#approver,
+            approval_sig: signatureApproval,
+        };
+
+        const encodedApproval = encodeProofProposalApproval(proofProposalApproval);
+        const responseMessage = createMessage(
+            safeWriteUInt32BE(this.#resultCode, 0),
+            encodedApproval
+        );
+        const responseHash = await tracCryptoApi.hash.blake3(responseMessage);
+        const responseSig = this.#wallet.sign(responseHash);
+
+        this.#payloadKey = 'proof_proposal_response';
+        this.#body = {
+            result: this.#resultCode,
+            approval: proofProposalApproval,
+            response_sig: responseSig,
+        };
+    }
+
+    async buildPayload() {
+        this.#setHeader();
+
+        switch (this.#type) {
+            case ConsensusOperationType.PROOF_PROPOSAL: {
+                await this.#buildProofProposalPayload();
+                break;
+            }
+            case ConsensusOperationType.PROOF_PROPOSAL_RESPONSE: {
+                await this.#buildProofProposalResponsePayload();
+                break;
+            }
+            default:
+                throw new Error(`Unsupported consensus type ${this.#type}`);
+        }
+    }
+
+    getResult() {
+        if (!this.#header || !this.#payloadKey || !this.#body) {
+            throw new Error('Header or payload not set before getResult');
+        }
+
+        return {
+            ...this.#header,
+            [this.#payloadKey]: this.#body
+        };
+    }
+
+
+}
+
+export default ConsensusMessageBuilder;

--- a/src/messages/consensus/v1/ConsensusMessageBuilder.js
+++ b/src/messages/consensus/v1/ConsensusMessageBuilder.js
@@ -1,7 +1,7 @@
 import b4a from 'b4a';
 import tracCryptoApi from 'trac-crypto-api';
 import {encodeProofProposalApproval} from '../../../codecs/consensus/v1/consensusV1OperationCodec.js';
-import {addressToBuffer} from "../../../core/state/utils/address.js";
+import {addressToBuffer, isAddressValid} from "../../../core/state/utils/address.js";
 import {ConsensusOperationType, ConsensusResultCode} from '../../../utils/constants.js';
 import {createMessage, safeWriteUInt32BE, validateUint32} from "../../../utils/buffer.js";
 import {
@@ -51,7 +51,7 @@ class ConsensusMessageBuilder {
     }
 
     #validateAddress(address, fieldName) {
-        if (typeof address !== 'string') {
+        if (typeof address !== 'string' || !isAddressValid(address, this.#config.addressPrefix)) {
             throw new Error(`${fieldName} must be a valid TRAC address.`);
         }
 

--- a/src/messages/consensus/v1/ConsensusMessageBuilder.js
+++ b/src/messages/consensus/v1/ConsensusMessageBuilder.js
@@ -4,6 +4,10 @@ import {encodeProofProposalApproval} from '../../../codecs/consensus/v1/consensu
 import {addressToBuffer, isAddressValid} from "../../../core/state/utils/address.js";
 import {ConsensusOperationType, ConsensusResultCode} from '../../../utils/constants.js';
 import {createMessage, safeWriteUInt32BE} from "../../../utils/buffer.js";
+import {
+    createProofProposalApprovalSigningMessage,
+    createProofProposalSigningMessage
+} from "../../../core/consensus/v1/consensusSigningMessage.js";
 
 class ConsensusMessageBuilder {
     #wallet;
@@ -180,7 +184,7 @@ class ConsensusMessageBuilder {
     }
 
     async #buildProofProposalPayload() {
-        const message = createMessage(
+        const message = createProofProposalSigningMessage(
             this.#protocol_version,
             this.#network_id,
             this.#epoch,
@@ -209,7 +213,7 @@ class ConsensusMessageBuilder {
             throw new Error('Result code must be set before build.');
         }
 
-        const messageApproval = createMessage(
+        const messageApproval = createProofProposalApprovalSigningMessage(
             this.#protocol_version,
             this.#network_id,
             this.#epoch,

--- a/src/messages/consensus/v1/ConsensusMessageBuilder.js
+++ b/src/messages/consensus/v1/ConsensusMessageBuilder.js
@@ -2,7 +2,7 @@ import b4a from 'b4a';
 import tracCryptoApi from 'trac-crypto-api';
 import {encodeProofProposalApproval} from '../../../codecs/consensus/v1/consensusV1OperationCodec.js';
 import {addressToBuffer, isAddressValid} from "../../../core/state/utils/address.js";
-import {ConsensusOperationType, ConsensusResultCode} from '../../../utils/constants.js';
+import {ConsensusOperationType, ConsensusProtocolVersion, ConsensusResultCode} from '../../../utils/constants.js';
 import {createMessage, safeWriteUInt32BE, validateUint32} from "../../../utils/buffer.js";
 import {
     createProofProposalApprovalSigningMessage,
@@ -111,7 +111,12 @@ class ConsensusMessageBuilder {
     }
 
     setProtocolVersion(protocolVersion) {
-        this.#protocol_version = validateUint32(protocolVersion, 'Protocol version');
+        const value = validateUint32(protocolVersion, 'Protocol version');
+        if (!Object.values(ConsensusProtocolVersion).includes(value)) {
+            throw new Error(`Unsupported consensus protocol version: ${protocolVersion}`);
+        }
+
+        this.#protocol_version = value;
         return this;
     }
 

--- a/src/messages/consensus/v1/ConsensusMessageBuilder.js
+++ b/src/messages/consensus/v1/ConsensusMessageBuilder.js
@@ -3,7 +3,7 @@ import tracCryptoApi from 'trac-crypto-api';
 import {encodeProofProposalApproval} from '../../../codecs/consensus/v1/consensusV1OperationCodec.js';
 import {addressToBuffer} from "../../../core/state/utils/address.js";
 import {ConsensusOperationType, ConsensusResultCode} from '../../../utils/constants.js';
-import {createMessage, safeWriteUInt32BE} from "../../../utils/buffer.js";
+import {createMessage, safeWriteUInt32BE, validateUint32} from "../../../utils/buffer.js";
 import {
     createProofProposalApprovalSigningMessage,
     createProofProposalSigningMessage
@@ -32,14 +32,6 @@ class ConsensusMessageBuilder {
     constructor(wallet, config) {
         this.#config = config;
         this.#wallet = wallet;
-    }
-
-    #validateUint32(value, fieldName) {
-        if (!Number.isInteger(value) || value < 0 || value > 0xFFFFFFFF) {
-            throw new Error(`${fieldName} must be an unsigned 32-bit integer.`);
-        }
-
-        return value;
     }
 
     #validateSafeUint64(value, fieldName) {
@@ -119,12 +111,12 @@ class ConsensusMessageBuilder {
     }
 
     setProtocolVersion(protocolVersion) {
-        this.#protocol_version = this.#validateUint32(protocolVersion, 'Protocol version');
+        this.#protocol_version = validateUint32(protocolVersion, 'Protocol version');
         return this;
     }
 
     setNetworkId(networkId) {
-        this.#network_id = this.#validateUint32(networkId, 'Network id');
+        this.#network_id = validateUint32(networkId, 'Network id');
         return  this;
     }
 

--- a/src/messages/consensus/v1/ConsensusMessageBuilder.js
+++ b/src/messages/consensus/v1/ConsensusMessageBuilder.js
@@ -1,7 +1,7 @@
 import b4a from 'b4a';
 import tracCryptoApi from 'trac-crypto-api';
 import {encodeProofProposalApproval} from '../../../codecs/consensus/v1/consensusV1OperationCodec.js';
-import {addressToBuffer, isAddressValid} from "../../../core/state/utils/address.js";
+import {addressToBuffer} from "../../../core/state/utils/address.js";
 import {ConsensusOperationType, ConsensusResultCode} from '../../../utils/constants.js';
 import {createMessage, safeWriteUInt32BE} from "../../../utils/buffer.js";
 import {
@@ -31,13 +31,6 @@ class ConsensusMessageBuilder {
 
     constructor(wallet, config) {
         this.#config = config;
-        if (!wallet || typeof wallet !== 'object') {
-            throw new Error('Wallet must be a valid wallet object');
-        }
-        if (!isAddressValid(wallet.address, this.#config.addressPrefix)) {
-            throw new Error('Wallet should have a valid TRAC address.');
-        }
-
         this.#wallet = wallet;
     }
 

--- a/src/messages/consensus/v1/ConsensusMessageDirector.js
+++ b/src/messages/consensus/v1/ConsensusMessageDirector.js
@@ -1,0 +1,103 @@
+import {ConsensusOperationType} from '../../../utils/constants.js';
+
+/**
+ * Director for v1 consensus protocol messages.
+ */
+
+class ConsensusMessageDirector {
+    #builder;
+
+    /**
+     * @param {ConsensusMessageBuilder} builderInstance
+     */
+    constructor(builderInstance) {
+        this.#builder = builderInstance;
+    }
+
+    /**
+     * Build a proof proposal message.
+     * @param {string} sessionId
+     * @param {number} protocolVersion
+     * @param {number} networkId
+     * @param {number} epoch
+     * @param {Buffer} previousEpochRecordHash
+     * @param {string} proposer
+     * @param {Buffer} vdfParametersHash
+     * @param {Buffer} vdfProof
+     * @returns {Promise<object>}
+     */
+    async buildProofProposal(
+        sessionId,
+        protocolVersion,
+        networkId,
+        epoch,
+        previousEpochRecordHash,
+        proposer,
+        vdfParametersHash,
+        vdfProof
+    ) {
+        await this.#builder
+            .setType(ConsensusOperationType.PROOF_PROPOSAL)
+            .setSessionId(sessionId)
+            .setTimestamp()
+            .setProtocolVersion(protocolVersion)
+            .setNetworkId(networkId)
+            .setEpoch(epoch)
+            .setPreviousEpochRecordHash(previousEpochRecordHash)
+            .setProposer(proposer)
+            .setVdfParametersHash(vdfParametersHash)
+            .setVdfProof(vdfProof)
+            .buildPayload();
+
+        return this.#builder.getResult();
+    }
+
+    /**
+     * Build a proof proposal response message.
+     * @param {string} sessionId
+     * @param {number} protocolVersion
+     * @param {number} networkId
+     * @param {number} epoch
+     * @param {Buffer} previousEpochRecordHash
+     * @param {string} proposer
+     * @param {Buffer} vdfParametersHash
+     * @param {Buffer} vdfProof
+     * @param {Buffer} requesterProofSignature
+     * @param {number} resultCode
+     * @param {string} approver
+     * @returns {Promise<object>}
+     */
+    async buildProofProposalResponse(
+        sessionId,
+        protocolVersion,
+        networkId,
+        epoch,
+        previousEpochRecordHash,
+        proposer,
+        vdfParametersHash,
+        vdfProof,
+        requesterProofSignature,
+        resultCode,
+        approver
+    ) {
+        await this.#builder
+            .setType(ConsensusOperationType.PROOF_PROPOSAL_RESPONSE)
+            .setSessionId(sessionId)
+            .setTimestamp()
+            .setProtocolVersion(protocolVersion)
+            .setNetworkId(networkId)
+            .setEpoch(epoch)
+            .setPreviousEpochRecordHash(previousEpochRecordHash)
+            .setProposer(proposer)
+            .setVdfParametersHash(vdfParametersHash)
+            .setVdfProof(vdfProof)
+            .setRequesterProofSignature(requesterProofSignature)
+            .setResultCode(resultCode)
+            .setApprover(approver)
+            .buildPayload();
+
+        return this.#builder.getResult();
+    }
+}
+
+export default ConsensusMessageDirector;

--- a/src/messages/consensus/v1/ConsensusMessageDirector.js
+++ b/src/messages/consensus/v1/ConsensusMessageDirector.js
@@ -1,4 +1,4 @@
-import {ConsensusOperationType} from '../../../utils/constants.js';
+import {ConsensusOperationType, ConsensusProtocolVersion} from '../../../utils/constants.js';
 
 /**
  * Director for v1 consensus protocol messages.
@@ -17,7 +17,6 @@ class ConsensusMessageDirector {
     /**
      * Build a proof proposal message.
      * @param {string} sessionId
-     * @param {number} protocolVersion
      * @param {number} networkId
      * @param {number} epoch
      * @param {Buffer} previousEpochRecordHash
@@ -28,7 +27,6 @@ class ConsensusMessageDirector {
      */
     async buildProofProposal(
         sessionId,
-        protocolVersion,
         networkId,
         epoch,
         previousEpochRecordHash,
@@ -40,7 +38,7 @@ class ConsensusMessageDirector {
             .setType(ConsensusOperationType.PROOF_PROPOSAL)
             .setSessionId(sessionId)
             .setTimestamp()
-            .setProtocolVersion(protocolVersion)
+            .setProtocolVersion(ConsensusProtocolVersion.V1)
             .setNetworkId(networkId)
             .setEpoch(epoch)
             .setPreviousEpochRecordHash(previousEpochRecordHash)
@@ -55,7 +53,6 @@ class ConsensusMessageDirector {
     /**
      * Build a proof proposal response message.
      * @param {string} sessionId
-     * @param {number} protocolVersion
      * @param {number} networkId
      * @param {number} epoch
      * @param {Buffer} previousEpochRecordHash
@@ -69,7 +66,6 @@ class ConsensusMessageDirector {
      */
     async buildProofProposalResponse(
         sessionId,
-        protocolVersion,
         networkId,
         epoch,
         previousEpochRecordHash,
@@ -84,7 +80,7 @@ class ConsensusMessageDirector {
             .setType(ConsensusOperationType.PROOF_PROPOSAL_RESPONSE)
             .setSessionId(sessionId)
             .setTimestamp()
-            .setProtocolVersion(protocolVersion)
+            .setProtocolVersion(ConsensusProtocolVersion.V1)
             .setNetworkId(networkId)
             .setEpoch(epoch)
             .setPreviousEpochRecordHash(previousEpochRecordHash)

--- a/src/messages/consensus/v1/consensusMessageFactory.js
+++ b/src/messages/consensus/v1/consensusMessageFactory.js
@@ -7,6 +7,6 @@ import ConsensusMessageBuilder from "./ConsensusMessageBuilder.js";
  * @param {object} config
  * @returns {ConsensusMessageDirector}
  */
-export const networkMessageFactory = (wallet, config) => {
+export const consensusMessageFactory = (wallet, config) => {
     return new ConsensusMessageDirector(new ConsensusMessageBuilder(wallet, config))
 }

--- a/src/messages/consensus/v1/consensusMessageFactory.js
+++ b/src/messages/consensus/v1/consensusMessageFactory.js
@@ -1,0 +1,12 @@
+import ConsensusMessageDirector from "./ConsensusMessageDirector.js";
+import ConsensusMessageBuilder from "./ConsensusMessageBuilder.js";
+
+/**
+ * Factory helper to create a director with a fresh builder instance.
+ * @param {IWallet} wallet
+ * @param {object} config
+ * @returns {ConsensusMessageDirector}
+ */
+export const networkMessageFactory = (wallet, config) => {
+    return new ConsensusMessageDirector(new ConsensusMessageBuilder(wallet, config))
+}

--- a/src/utils/buffer.js
+++ b/src/utils/buffer.js
@@ -128,11 +128,3 @@ export function toHex(publicKey) {
     return b4a.isBuffer(publicKey) ? b4a.toString(publicKey, 'hex') : publicKey;
 }
 
-export function convertToArray(input, elementLength, converter) {
-    if (!b4a.isBuffer(input) || input.length % elementLength !== 0) {
-        return null
-    }
-
-    const elements = _.chunk(input, elementLength)
-    return elements.map(converter)
-}

--- a/src/utils/buffer.js
+++ b/src/utils/buffer.js
@@ -5,6 +5,7 @@ export const ZERO_WK = b4a.alloc(32, 0); // 32 bytes of zeroes, used as a placeh
 export const NULL_BUFFER = b4a.alloc(0) // null buffer (single byte of 0)
 
 const isUInt32 = (n) => { return Number.isInteger(n) && n >= 1 && n <= 0xFFFFFFFF; }
+const MAX_UINT64 = 0xFFFFFFFFFFFFFFFFn;
 
 export function isBufferValid(key, size) {
     return b4a.isBuffer(key) && key.length === size;
@@ -71,21 +72,29 @@ export function deepCopyBuffer(buffer) {
     return copy;
 }
 
+/**
+ * Use BigInt because uint64 values can be larger than Number.MAX_SAFE_INTEGER.
+ */
 export function uint64ToBuffer(value, fieldName) {
     if (typeof value === 'number') {
         if (!Number.isSafeInteger(value) || value < 0) {
             throw new Error(`${fieldName} must be a non-negative safe integer`);
         }
-        value = BigInt(value);
     } else if (typeof value !== 'bigint') {
         throw new Error(`${fieldName} must be a number or bigint`);
     }
-    if (value < 0n) {
+
+    const uint64Value = typeof value === 'bigint' ? value : BigInt(value);
+
+    if (uint64Value < 0n) {
         throw new Error(`${fieldName} must be a non-negative integer`);
+    }
+    if (uint64Value > MAX_UINT64) {
+        throw new Error(`${fieldName} must be an unsigned 64-bit integer`);
     }
 
     const buf = b4a.alloc(8);
-    buf.writeBigUInt64BE(value);
+    buf.writeBigUInt64BE(uint64Value);
     return buf;
 }
 

--- a/src/utils/buffer.js
+++ b/src/utils/buffer.js
@@ -1,6 +1,5 @@
 import b4a from 'b4a';
 import { bigIntTo16ByteBuffer } from './amountSerialization.js';
-import _ from 'lodash'
 
 export const ZERO_WK = b4a.alloc(32, 0); // 32 bytes of zeroes, used as a placeholder for writing keys
 export const NULL_BUFFER = b4a.alloc(0) // null buffer (single byte of 0)

--- a/src/utils/buffer.js
+++ b/src/utils/buffer.js
@@ -144,11 +144,17 @@ export function assertBuffer(value, fieldName) {
     return value;
 }
 
-// apply - unsafe version
-export function uint32ToBuffer(value, fieldName) {
+export function validateUint32(value, fieldName) {
     if (!Number.isInteger(value) || value < 0 || value > 0xFFFFFFFF) {
         throw new Error(`${fieldName} must be an unsigned 32-bit integer.`);
     }
+
+    return value;
+}
+
+// unsafe version
+export function uint32ToBuffer(value, fieldName) {
+    validateUint32(value, fieldName);
 
     const buf = b4a.alloc(4);
     buf.writeUInt32BE(value, 0);

--- a/src/utils/buffer.js
+++ b/src/utils/buffer.js
@@ -71,7 +71,7 @@ export function deepCopyBuffer(buffer) {
     return copy;
 }
 
-function uint64ToBuffer(value, fieldName) {
+export function uint64ToBuffer(value, fieldName) {
     if (typeof value === 'number') {
         if (!Number.isSafeInteger(value) || value < 0) {
             throw new Error(`${fieldName} must be a non-negative safe integer`);
@@ -127,3 +127,21 @@ export function toHex(publicKey) {
     return b4a.isBuffer(publicKey) ? b4a.toString(publicKey, 'hex') : publicKey;
 }
 
+export function assertBuffer(value, fieldName) {
+    if (!b4a.isBuffer(value)) {
+        throw new Error(`${fieldName} must be a buffer.`);
+    }
+
+    return value;
+}
+
+// apply - unsafe version
+export function uint32ToBuffer(value, fieldName) {
+    if (!Number.isInteger(value) || value < 0 || value > 0xFFFFFFFF) {
+        throw new Error(`${fieldName} must be an unsigned 32-bit integer.`);
+    }
+
+    const buf = b4a.alloc(4);
+    buf.writeUInt32BE(value, 0);
+    return buf;
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,11 +1,12 @@
 import applyOperationsGenerated from '../codecs/apply/applyOperations.generated.cjs';
 import networkV1Generated from '../codecs/network/v1/networkV1.generated.cjs';
+import consensusV1Generated from '../codecs/consensus/v1/consensusV1.generated.cjs';
 import b4a from 'b4a'
 // TODO: We are going to have a lot of contstants. It would be good, to separate them into different files.
 
 const { OperationType: ApplyOperationType } = applyOperationsGenerated.apply.operations;
 const { MessageType: NetworkMessageType, ResultCode: NetworkResultCode } = networkV1Generated.network.v1;
-
+const { MessageType: ConsensusMessageType, ResultCode: ConsensusV1ResultCode } = consensusV1Generated.consensus.v1;
 //ATTENTION - THIS IS USED IN THE APPLY FUNCTION!
 export const EntryType = Object.freeze({
     ADMIN: 'admin',
@@ -44,6 +45,16 @@ export const NetworkOperationType = Object.freeze({
     BROADCAST_TRANSACTION_RESPONSE: NetworkMessageType.MESSAGE_TYPE_BROADCAST_TRANSACTION_RESPONSE,
     EPOCH_PROOF_PROPOSAL_REQUEST: NetworkMessageType.MESSAGE_TYPE_EPOCH_PROOF_PROPOSAL_REQUEST,
     EPOCH_PROOF_PROPOSAL_RESPONSE: NetworkMessageType.MESSAGE_TYPE_EPOCH_PROOF_PROPOSAL_RESPONSE,
+});
+
+export const ConsensusOperationType = Object.freeze({
+    PROOF_PROPOSAL: ConsensusMessageType.MESSAGE_TYPE_PROOF_PROPOSAL,
+    PROOF_PROPOSAL_RESPONSE: ConsensusMessageType.MESSAGE_TYPE_PROOF_PROPOSAL_RESPONSE,
+});
+
+export const ConsensusResultCode = Object.freeze({
+    UNSPECIFIED: ConsensusV1ResultCode.RESULT_CODE_UNSPECIFIED,
+    OK: ConsensusV1ResultCode.RESULT_CODE_OK,
 });
 
 export const ResultCode = Object.freeze({

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -52,6 +52,10 @@ export const ConsensusOperationType = Object.freeze({
     PROOF_PROPOSAL_RESPONSE: ConsensusMessageType.MESSAGE_TYPE_PROOF_PROPOSAL_RESPONSE,
 });
 
+export const ConsensusProtocolVersion = Object.freeze({
+    V1: 1,
+});
+
 export const ConsensusResultCode = Object.freeze({
     UNSPECIFIED: ConsensusV1ResultCode.RESULT_CODE_UNSPECIFIED,
     OK: ConsensusV1ResultCode.RESULT_CODE_OK,

--- a/tests/fixtures/consensusV1Operation.fixtures.js
+++ b/tests/fixtures/consensusV1Operation.fixtures.js
@@ -1,7 +1,10 @@
 import b4a from 'b4a';
 
+import { addressToBuffer } from '../../src/core/state/utils/address.js';
 import consensusV1Generated from '../../src/codecs/consensus/v1/consensusV1.generated.cjs';
 import { v7 as uuidv7 } from 'uuid';
+import { config } from '../helpers/config.js';
+import { asAddress } from '../helpers/address.js';
 
 const { MessageType, ResultCode } = consensusV1Generated.consensus.v1;
 
@@ -12,7 +15,10 @@ const proofProposal = Object.freeze({
     network_id: 67,
     epoch: 67,
     previous_epoch_record_hash: bytes(1, 32),
-    proposer: bytes(67, 32),
+    proposer: addressToBuffer(
+        asAddress('82f6c1f684f4e251dfe092155b8861a0625b596991810b2b80b9c65ccbec5ad3'),
+        config.addressPrefix
+    ),
     vdf_parameters_hash: bytes(3, 32),
     vdf_proof: bytes(67, 96),
     signature: bytes(67, 64)

--- a/tests/fixtures/consensusV1Operation.fixtures.js
+++ b/tests/fixtures/consensusV1Operation.fixtures.js
@@ -19,7 +19,7 @@ const proofProposal = Object.freeze({
 });
 
 const proofProposalApproval = Object.freeze({
-    member_id: bytes(67, 32),
+    approver: bytes(67, 32),
     approval_sig: bytes(67, 64)
 });
 

--- a/tests/unit/codecs/consensusV1OperationCodec.test.js
+++ b/tests/unit/codecs/consensusV1OperationCodec.test.js
@@ -48,13 +48,13 @@ test('Consensus codec safe ProofProposalApproval helpers handle invalid payloads
     t.teardown(() => consoleLog.restore());
 
     const invalidEncoded = safeEncodeProofProposalApproval({
-        member_id: 67,
+        approver: 67,
         approval_sig: fixtures.proofProposalApproval.approval_sig
     });
 
     t.ok(b4a.isBuffer(invalidEncoded));
     t.is(invalidEncoded.length, 0);
-    t.ok(consoleLog.calledOnceWithExactly('safeEncodeProofProposalApproval error:', 'member_id: buffer expected'));
+    t.ok(consoleLog.calledOnceWithExactly('safeEncodeProofProposalApproval error:', 'approver: buffer expected'));
     t.is(safeDecodeProofProposalApproval(null), null);
     t.is(safeDecodeProofProposalApproval({}), null);
     t.is(safeDecodeProofProposalApproval('not-a-buffer'), null);

--- a/tests/unit/messages/consensus/ConsensusMessageBuilder.test.js
+++ b/tests/unit/messages/consensus/ConsensusMessageBuilder.test.js
@@ -1,0 +1,257 @@
+import {test} from 'brittle';
+import b4a from 'b4a';
+import tracCryptoApi from 'trac-crypto-api';
+import {WalletProvider} from 'trac-wallet';
+import {v7 as uuidv7} from 'uuid';
+
+import ConsensusMessageBuilder from '../../../../src/messages/consensus/v1/ConsensusMessageBuilder.js';
+import {addressToBuffer} from '../../../../src/core/state/utils/address.js';
+import {
+    decodeConsensusMessage,
+    encodeConsensusMessage,
+    encodeProofProposalApproval
+} from '../../../../src/codecs/consensus/v1/consensusV1OperationCodec.js';
+import {createMessage, safeWriteUInt32BE} from '../../../../src/utils/buffer.js';
+import {ConsensusOperationType, ConsensusResultCode} from '../../../../src/utils/constants.js';
+import {errorMessageIncludes} from '../../../helpers/regexHelper.js';
+import {config} from '../../../helpers/config.js';
+import {testKeyPair1} from '../../../fixtures/apply.fixtures.js';
+
+async function createWallet() {
+    return await new WalletProvider(config).fromSecretKey(testKeyPair1.secretKey);
+}
+
+function uniqueResultCodes() {
+    return [...new Set(Object.values(ConsensusResultCode))].sort((a, b) => a - b);
+}
+
+function proofProposalFields(wallet) {
+    return {
+        sessionId: uuidv7(),
+        protocolVersion: 1,
+        networkId: 67,
+        epoch: 2,
+        previousEpochRecordHash: b4a.alloc(32, 1),
+        proposer: wallet.address,
+        proposerBuffer: addressToBuffer(wallet.address, config.addressPrefix),
+        vdfParametersHash: b4a.alloc(32, 2),
+        vdfProof: b4a.alloc(96, 3),
+        requesterProofSignature: b4a.alloc(64, 4),
+    };
+}
+
+function setProofProposalFields(builder, fields) {
+    return builder
+        .setSessionId(fields.sessionId)
+        .setTimestamp()
+        .setProtocolVersion(fields.protocolVersion)
+        .setNetworkId(fields.networkId)
+        .setEpoch(fields.epoch)
+        .setPreviousEpochRecordHash(fields.previousEpochRecordHash)
+        .setProposer(fields.proposer)
+        .setVdfParametersHash(fields.vdfParametersHash)
+        .setVdfProof(fields.vdfProof);
+}
+
+test('ConsensusMessageBuilder builds proof proposal and verifies signature', async t => {
+    const wallet = await createWallet();
+    const builder = new ConsensusMessageBuilder(wallet, config);
+    const fields = proofProposalFields(wallet);
+
+    await setProofProposalFields(
+        builder.setType(ConsensusOperationType.PROOF_PROPOSAL),
+        fields
+    ).buildPayload();
+
+    const payload = builder.getResult();
+    t.is(payload.type, ConsensusOperationType.PROOF_PROPOSAL);
+    t.is(payload.session_id, fields.sessionId);
+    t.ok(Number.isSafeInteger(payload.timestamp) && payload.timestamp > 0);
+
+    const proofProposal = payload.proof_proposal;
+    t.is(proofProposal.protocol_version, fields.protocolVersion);
+    t.is(proofProposal.network_id, fields.networkId);
+    t.is(proofProposal.epoch, fields.epoch);
+    t.alike(proofProposal.previous_epoch_record_hash, fields.previousEpochRecordHash);
+    t.alike(proofProposal.proposer, fields.proposerBuffer);
+    t.alike(proofProposal.vdf_parameters_hash, fields.vdfParametersHash);
+    t.alike(proofProposal.vdf_proof, fields.vdfProof);
+    t.ok(b4a.isBuffer(proofProposal.signature));
+
+    const message = createMessage(
+        proofProposal.protocol_version,
+        proofProposal.network_id,
+        proofProposal.epoch,
+        proofProposal.previous_epoch_record_hash,
+        proofProposal.proposer,
+        proofProposal.vdf_parameters_hash,
+        proofProposal.vdf_proof
+    );
+    const hash = await tracCryptoApi.hash.blake3(message);
+    t.ok(wallet.verify(proofProposal.signature, hash, wallet.publicKey));
+
+    const decoded = decodeConsensusMessage(encodeConsensusMessage(payload));
+    t.alike(decoded.proof_proposal, proofProposal);
+});
+
+test('ConsensusMessageBuilder iterates proof proposal response ResultCode values', async t => {
+    const wallet = await createWallet();
+    const fields = proofProposalFields(wallet);
+
+    for (const code of uniqueResultCodes()) {
+        const builder = new ConsensusMessageBuilder(wallet, config);
+        await setProofProposalFields(
+            builder.setType(ConsensusOperationType.PROOF_PROPOSAL_RESPONSE),
+            fields
+        )
+            .setRequesterProofSignature(fields.requesterProofSignature)
+            .setResultCode(code)
+            .setApprover(wallet.address)
+            .buildPayload();
+
+        const payload = builder.getResult();
+        t.is(payload.type, ConsensusOperationType.PROOF_PROPOSAL_RESPONSE);
+        t.is(payload.proof_proposal_response.result, code);
+        t.alike(payload.proof_proposal_response.approval.approver, fields.proposerBuffer);
+        t.ok(b4a.isBuffer(payload.proof_proposal_response.approval.approval_sig));
+        t.ok(b4a.isBuffer(payload.proof_proposal_response.response_sig));
+
+        const approvalMessage = createMessage(
+            fields.protocolVersion,
+            fields.networkId,
+            fields.epoch,
+            fields.previousEpochRecordHash,
+            fields.proposerBuffer,
+            fields.vdfParametersHash,
+            fields.vdfProof,
+            payload.proof_proposal_response.approval.approver,
+            fields.requesterProofSignature
+        );
+        const approvalHash = await tracCryptoApi.hash.blake3(approvalMessage);
+        t.ok(wallet.verify(
+            payload.proof_proposal_response.approval.approval_sig,
+            approvalHash,
+            wallet.publicKey
+        ));
+
+        const encodedApproval = encodeProofProposalApproval(payload.proof_proposal_response.approval);
+        const responseMessage = createMessage(
+            safeWriteUInt32BE(code, 0),
+            encodedApproval
+        );
+        const responseHash = await tracCryptoApi.hash.blake3(responseMessage);
+        t.ok(wallet.verify(payload.proof_proposal_response.response_sig, responseHash, wallet.publicKey));
+
+        const decoded = decodeConsensusMessage(encodeConsensusMessage(payload));
+        t.is(decoded.proof_proposal_response.result, code);
+        t.alike(decoded.proof_proposal_response.approval, payload.proof_proposal_response.approval);
+    }
+});
+
+test('ConsensusMessageBuilder validates required inputs', async t => {
+    const wallet = await createWallet();
+    const fields = proofProposalFields(wallet);
+
+    t.exception(
+        () => new ConsensusMessageBuilder(null, config),
+        errorMessageIncludes('Wallet must be a valid wallet object')
+    );
+
+    t.exception(
+        () => new ConsensusMessageBuilder({address: 'invalid'}, config),
+        errorMessageIncludes('Wallet should have a valid TRAC address.')
+    );
+
+    const builder = new ConsensusMessageBuilder(wallet, config);
+
+    t.exception(
+        () => builder.setType(undefined),
+        errorMessageIncludes('Invalid consensus operation type')
+    );
+
+    t.exception(
+        () => builder.setSessionId(''),
+        errorMessageIncludes('Session id must be a non-empty string.')
+    );
+
+    t.exception(
+        () => builder.setTimestamp(0),
+        errorMessageIncludes('Timestamp must be a positive safe integer or Date.')
+    );
+
+    t.exception(
+        () => builder.setProtocolVersion(-1),
+        errorMessageIncludes('Protocol version must be an unsigned 32-bit integer.')
+    );
+
+    t.exception(
+        () => builder.setEpoch(-1),
+        errorMessageIncludes('Epoch must be a non-negative safe integer.')
+    );
+
+    t.exception(
+        () => builder.setPreviousEpochRecordHash('not-a-buffer'),
+        errorMessageIncludes('Previous epoch record hash must be a buffer.')
+    );
+
+    t.exception(
+        () => builder.setProposer('invalid'),
+        errorMessageIncludes('Proposer must be a valid TRAC address.')
+    );
+
+    t.exception(
+        () => builder.setProposer(b4a.alloc(0)),
+        errorMessageIncludes('Proposer must be a valid TRAC address.')
+    );
+
+    const foreignPrefixAddress = tracCryptoApi.address.encode(
+        'other',
+        b4a.from(testKeyPair1.publicKey, 'hex')
+    );
+    t.exception(
+        () => builder.setProposer(foreignPrefixAddress),
+        errorMessageIncludes('Proposer must be a valid TRAC address.')
+    );
+
+    t.exception(
+        () => builder.setVdfParametersHash('not-a-buffer'),
+        errorMessageIncludes('VDF parameters hash must be a buffer.')
+    );
+
+    t.exception(
+        () => builder.setVdfProof('not-a-buffer'),
+        errorMessageIncludes('VDF proof must be a buffer.')
+    );
+
+    t.exception(
+        () => builder.setResultCode(67),
+        errorMessageIncludes('Invalid consensus result code: 67')
+    );
+
+    t.exception(
+        () => builder.setApprover('invalid'),
+        errorMessageIncludes('Approver must be a valid TRAC address.')
+    );
+
+    t.exception(
+        () => builder.setRequesterProofSignature('not-a-buffer'),
+        errorMessageIncludes('Requester proof signature must be a buffer.')
+    );
+
+    t.exception(
+        () => builder.getResult(),
+        errorMessageIncludes('Header or payload not set before getResult')
+    );
+
+    const responseBuilder = new ConsensusMessageBuilder(wallet, config);
+    await t.exception(
+        () => setProofProposalFields(
+            responseBuilder.setType(ConsensusOperationType.PROOF_PROPOSAL_RESPONSE),
+            fields
+        )
+            .setRequesterProofSignature(fields.requesterProofSignature)
+            .setApprover(wallet.address)
+            .buildPayload(),
+        errorMessageIncludes('Result code must be set before build.')
+    );
+});

--- a/tests/unit/messages/consensus/ConsensusMessageBuilder.test.js
+++ b/tests/unit/messages/consensus/ConsensusMessageBuilder.test.js
@@ -158,16 +158,6 @@ test('ConsensusMessageBuilder validates required inputs', async t => {
     const wallet = await createWallet();
     const fields = proofProposalFields(wallet);
 
-    t.exception(
-        () => new ConsensusMessageBuilder(null, config),
-        errorMessageIncludes('Wallet must be a valid wallet object')
-    );
-
-    t.exception(
-        () => new ConsensusMessageBuilder({address: 'invalid'}, config),
-        errorMessageIncludes('Wallet should have a valid TRAC address.')
-    );
-
     const builder = new ConsensusMessageBuilder(wallet, config);
 
     t.exception(

--- a/tests/unit/messages/consensus/ConsensusMessageBuilder.test.js
+++ b/tests/unit/messages/consensus/ConsensusMessageBuilder.test.js
@@ -12,6 +12,12 @@ import {
     encodeProofProposalApproval
 } from '../../../../src/codecs/consensus/v1/consensusV1OperationCodec.js';
 import {createMessage, safeWriteUInt32BE} from '../../../../src/utils/buffer.js';
+import {
+    createProofProposalApprovalSigningMessage,
+    createProofProposalSigningMessage,
+    safeCreateProofProposalApprovalSigningMessage,
+    safeCreateProofProposalSigningMessage
+} from '../../../../src/core/consensus/v1/consensusSigningMessage.js';
 import {ConsensusOperationType, ConsensusResultCode} from '../../../../src/utils/constants.js';
 import {errorMessageIncludes} from '../../../helpers/regexHelper.js';
 import {config} from '../../../helpers/config.js';
@@ -78,7 +84,7 @@ test('ConsensusMessageBuilder builds proof proposal and verifies signature', asy
     t.alike(proofProposal.vdf_proof, fields.vdfProof);
     t.ok(b4a.isBuffer(proofProposal.signature));
 
-    const message = createMessage(
+    const message = createProofProposalSigningMessage(
         proofProposal.protocol_version,
         proofProposal.network_id,
         proofProposal.epoch,
@@ -116,7 +122,7 @@ test('ConsensusMessageBuilder iterates proof proposal response ResultCode values
         t.ok(b4a.isBuffer(payload.proof_proposal_response.approval.approval_sig));
         t.ok(b4a.isBuffer(payload.proof_proposal_response.response_sig));
 
-        const approvalMessage = createMessage(
+        const approvalMessage = createProofProposalApprovalSigningMessage(
             fields.protocolVersion,
             fields.networkId,
             fields.epoch,
@@ -254,4 +260,216 @@ test('ConsensusMessageBuilder validates required inputs', async t => {
             .buildPayload(),
         errorMessageIncludes('Result code must be set before build.')
     );
+});
+
+test('ConsensusMessageBuilder signs zero uint32 values and uint64 epochs without dropping fields', async t => {
+    const wallet = await createWallet();
+    const builder = new ConsensusMessageBuilder(wallet, config);
+    const fields = {
+        ...proofProposalFields(wallet),
+        protocolVersion: 0,
+        networkId: 0,
+        epoch: 0x100000000
+    };
+
+    await setProofProposalFields(
+        builder.setType(ConsensusOperationType.PROOF_PROPOSAL),
+        fields
+    ).buildPayload();
+
+    const proofProposal = builder.getResult().proof_proposal;
+    const signedMessage = createProofProposalSigningMessage(
+        proofProposal.protocol_version,
+        proofProposal.network_id,
+        proofProposal.epoch,
+        proofProposal.previous_epoch_record_hash,
+        proofProposal.proposer,
+        proofProposal.vdf_parameters_hash,
+        proofProposal.vdf_proof
+    );
+    const signedHash = await tracCryptoApi.hash.blake3(signedMessage);
+
+    t.ok(wallet.verify(proofProposal.signature, signedHash, wallet.publicKey));
+
+    const legacyMessage = createMessage(
+        proofProposal.protocol_version,
+        proofProposal.network_id,
+        proofProposal.epoch,
+        proofProposal.previous_epoch_record_hash,
+        proofProposal.proposer,
+        proofProposal.vdf_parameters_hash,
+        proofProposal.vdf_proof
+    );
+    const legacyHash = await tracCryptoApi.hash.blake3(legacyMessage);
+    t.not(wallet.verify(proofProposal.signature, legacyHash, wallet.publicKey));
+});
+
+test('consensus signing message helpers expose unsafe and safe variants', t => {
+    const fields = proofProposalFields({
+        address: tracCryptoApi.address.encode(config.addressPrefix, b4a.from(testKeyPair1.publicKey, 'hex'))
+    });
+    const signingFields = {
+        ...fields,
+        proposer: fields.proposerBuffer
+    };
+
+    const valid = createProofProposalSigningMessage(
+        signingFields.protocolVersion,
+        signingFields.networkId,
+        signingFields.epoch,
+        signingFields.previousEpochRecordHash,
+        signingFields.proposer,
+        signingFields.vdfParametersHash,
+        signingFields.vdfProof
+    );
+    t.ok(b4a.isBuffer(valid));
+
+    t.exception(() => createProofProposalSigningMessage(
+        signingFields.protocolVersion,
+        signingFields.networkId,
+        Number.MAX_SAFE_INTEGER + 1,
+        signingFields.previousEpochRecordHash,
+        signingFields.proposer,
+        signingFields.vdfParametersHash,
+        signingFields.vdfProof
+    ));
+    t.is(safeCreateProofProposalSigningMessage(
+        signingFields.protocolVersion,
+        signingFields.networkId,
+        Number.MAX_SAFE_INTEGER + 1,
+        signingFields.previousEpochRecordHash,
+        signingFields.proposer,
+        signingFields.vdfParametersHash,
+        signingFields.vdfProof
+    ), null);
+});
+
+test('createProofProposalSigningMessage encodes fields in deterministic order', t => {
+    const protocolVersion = 0;
+    const networkId = 0xFFFFFFFF;
+    const epoch = 0x100000000;
+    const previousEpochRecordHash = b4a.alloc(32, 1);
+    const proposer = b4a.alloc(32, 2);
+    const vdfParametersHash = b4a.alloc(32, 3);
+    const vdfProof = b4a.alloc(96, 4);
+
+    const message = createProofProposalSigningMessage(
+        protocolVersion,
+        networkId,
+        epoch,
+        previousEpochRecordHash,
+        proposer,
+        vdfParametersHash,
+        vdfProof
+    );
+
+    const prefix = b4a.alloc(16);
+    prefix.writeUInt32BE(protocolVersion, 0);
+    prefix.writeUInt32BE(networkId, 4);
+    prefix.writeBigUInt64BE(BigInt(epoch), 8);
+    const expected = b4a.concat([
+        prefix,
+        previousEpochRecordHash,
+        proposer,
+        vdfParametersHash,
+        vdfProof
+    ]);
+
+    t.is(message.length, expected.length);
+    t.ok(b4a.equals(message, expected));
+});
+
+test('createProofProposalApprovalSigningMessage appends approver and requester signature bytes', t => {
+    const protocolVersion = 1;
+    const networkId = 2;
+    const epoch = 3;
+    const previousEpochRecordHash = b4a.alloc(32, 1);
+    const proposer = b4a.alloc(32, 2);
+    const vdfParametersHash = b4a.alloc(32, 3);
+    const vdfProof = b4a.alloc(96, 4);
+    const approver = b4a.alloc(32, 5);
+    const requesterProofSignature = b4a.alloc(64, 6);
+
+    const message = createProofProposalApprovalSigningMessage(
+        protocolVersion,
+        networkId,
+        epoch,
+        previousEpochRecordHash,
+        proposer,
+        vdfParametersHash,
+        vdfProof,
+        approver,
+        requesterProofSignature
+    );
+
+    const prefix = b4a.alloc(16);
+    prefix.writeUInt32BE(protocolVersion, 0);
+    prefix.writeUInt32BE(networkId, 4);
+    prefix.writeBigUInt64BE(BigInt(epoch), 8);
+    const expected = b4a.concat([
+        prefix,
+        previousEpochRecordHash,
+        proposer,
+        vdfParametersHash,
+        vdfProof,
+        approver,
+        requesterProofSignature
+    ]);
+    const approverOffset = expected.length - approver.length - requesterProofSignature.length;
+    const requesterProofSignatureOffset = expected.length - requesterProofSignature.length;
+
+    t.is(message.length, expected.length);
+    t.ok(b4a.equals(message, expected));
+    t.ok(b4a.equals(message.subarray(approverOffset, requesterProofSignatureOffset), approver));
+    t.ok(b4a.equals(message.subarray(requesterProofSignatureOffset), requesterProofSignature));
+});
+
+test('safe consensus signing helpers return null for invalid uint32 and buffer fields', t => {
+    const fields = proofProposalFields({
+        address: tracCryptoApi.address.encode(config.addressPrefix, b4a.from(testKeyPair1.publicKey, 'hex'))
+    });
+    const proposer = fields.proposerBuffer;
+    const approver = b4a.alloc(32, 7);
+
+    t.exception(() => createProofProposalSigningMessage(
+        fields.protocolVersion,
+        0x100000000,
+        fields.epoch,
+        fields.previousEpochRecordHash,
+        proposer,
+        fields.vdfParametersHash,
+        fields.vdfProof
+    ), errorMessageIncludes('Network id'));
+    t.is(safeCreateProofProposalSigningMessage(
+        fields.protocolVersion,
+        0x100000000,
+        fields.epoch,
+        fields.previousEpochRecordHash,
+        proposer,
+        fields.vdfParametersHash,
+        fields.vdfProof
+    ), null);
+
+    t.exception(() => createProofProposalApprovalSigningMessage(
+        fields.protocolVersion,
+        fields.networkId,
+        fields.epoch,
+        fields.previousEpochRecordHash,
+        proposer,
+        fields.vdfParametersHash,
+        fields.vdfProof,
+        'not-a-buffer',
+        fields.requesterProofSignature
+    ), errorMessageIncludes('Approver'));
+    t.is(safeCreateProofProposalApprovalSigningMessage(
+        fields.protocolVersion,
+        fields.networkId,
+        fields.epoch,
+        fields.previousEpochRecordHash,
+        proposer,
+        fields.vdfParametersHash,
+        fields.vdfProof,
+        approver,
+        'not-a-buffer'
+    ), null);
 });

--- a/tests/unit/messages/consensus/ConsensusMessageBuilder.test.js
+++ b/tests/unit/messages/consensus/ConsensusMessageBuilder.test.js
@@ -18,7 +18,11 @@ import {
     safeCreateProofProposalApprovalSigningMessage,
     safeCreateProofProposalSigningMessage
 } from '../../../../src/core/consensus/v1/consensusSigningMessage.js';
-import {ConsensusOperationType, ConsensusResultCode} from '../../../../src/utils/constants.js';
+import {
+    ConsensusOperationType,
+    ConsensusProtocolVersion,
+    ConsensusResultCode
+} from '../../../../src/utils/constants.js';
 import {errorMessageIncludes} from '../../../helpers/regexHelper.js';
 import {config} from '../../../helpers/config.js';
 import {testKeyPair1} from '../../../fixtures/apply.fixtures.js';
@@ -34,7 +38,7 @@ function uniqueResultCodes() {
 function proofProposalFields(wallet) {
     return {
         sessionId: uuidv7(),
-        protocolVersion: 1,
+        protocolVersion: ConsensusProtocolVersion.V1,
         networkId: 67,
         epoch: 2,
         previousEpochRecordHash: b4a.alloc(32, 1),
@@ -181,6 +185,11 @@ test('ConsensusMessageBuilder validates required inputs', async t => {
     );
 
     t.exception(
+        () => builder.setProtocolVersion(0),
+        errorMessageIncludes('Unsupported consensus protocol version: 0')
+    );
+
+    t.exception(
         () => builder.setEpoch(-1),
         errorMessageIncludes('Epoch must be a non-negative safe integer.')
     );
@@ -252,12 +261,12 @@ test('ConsensusMessageBuilder validates required inputs', async t => {
     );
 });
 
-test('ConsensusMessageBuilder signs zero uint32 values and uint64 epochs without dropping fields', async t => {
+test('ConsensusMessageBuilder signs zero network id and uint64 epochs without dropping fields', async t => {
     const wallet = await createWallet();
     const builder = new ConsensusMessageBuilder(wallet, config);
     const fields = {
         ...proofProposalFields(wallet),
-        protocolVersion: 0,
+        protocolVersion: ConsensusProtocolVersion.V1,
         networkId: 0,
         epoch: 0x100000000
     };
@@ -335,7 +344,7 @@ test('consensus signing message helpers expose unsafe and safe variants', t => {
 });
 
 test('createProofProposalSigningMessage encodes fields in deterministic order', t => {
-    const protocolVersion = 0;
+    const protocolVersion = ConsensusProtocolVersion.V1;
     const networkId = 0xFFFFFFFF;
     const epoch = 0x100000000;
     const previousEpochRecordHash = b4a.alloc(32, 1);

--- a/tests/unit/messages/consensus/ConsensusMessageDirector.test.js
+++ b/tests/unit/messages/consensus/ConsensusMessageDirector.test.js
@@ -8,6 +8,10 @@ import ConsensusMessageBuilder from '../../../../src/messages/consensus/v1/Conse
 import ConsensusMessageDirector from '../../../../src/messages/consensus/v1/ConsensusMessageDirector.js';
 import {addressToBuffer} from '../../../../src/core/state/utils/address.js';
 import {createMessage, safeWriteUInt32BE} from '../../../../src/utils/buffer.js';
+import {
+    createProofProposalApprovalSigningMessage,
+    createProofProposalSigningMessage
+} from '../../../../src/core/consensus/v1/consensusSigningMessage.js';
 import {ConsensusOperationType, ConsensusResultCode} from '../../../../src/utils/constants.js';
 import {
     decodeConsensusMessage,
@@ -58,7 +62,7 @@ test('ConsensusMessageDirector builds proof proposal and verifies signature', as
     t.alike(proofProposal.vdf_proof, vdfProof);
     t.ok(b4a.isBuffer(proofProposal.signature));
 
-    const message = createMessage(
+    const message = createProofProposalSigningMessage(
         proofProposal.protocol_version,
         proofProposal.network_id,
         proofProposal.epoch,
@@ -108,7 +112,7 @@ test('ConsensusMessageDirector builds proof proposal response and verifies signa
     t.ok(b4a.isBuffer(proofProposalResponse.approval.approval_sig));
     t.ok(b4a.isBuffer(proofProposalResponse.response_sig));
 
-    const approvalMessage = createMessage(
+    const approvalMessage = createProofProposalApprovalSigningMessage(
         protocolVersion,
         networkId,
         epoch,

--- a/tests/unit/messages/consensus/ConsensusMessageDirector.test.js
+++ b/tests/unit/messages/consensus/ConsensusMessageDirector.test.js
@@ -12,7 +12,11 @@ import {
     createProofProposalApprovalSigningMessage,
     createProofProposalSigningMessage
 } from '../../../../src/core/consensus/v1/consensusSigningMessage.js';
-import {ConsensusOperationType, ConsensusResultCode} from '../../../../src/utils/constants.js';
+import {
+    ConsensusOperationType,
+    ConsensusProtocolVersion,
+    ConsensusResultCode
+} from '../../../../src/utils/constants.js';
 import {
     decodeConsensusMessage,
     encodeConsensusMessage,
@@ -30,7 +34,6 @@ test('ConsensusMessageDirector builds proof proposal and verifies signature', as
     const director = new ConsensusMessageDirector(new ConsensusMessageBuilder(wallet, config));
 
     const sessionId = uuidv7();
-    const protocolVersion = 1;
     const networkId = 67;
     const epoch = 2;
     const previousEpochRecordHash = b4a.alloc(32, 1);
@@ -39,7 +42,6 @@ test('ConsensusMessageDirector builds proof proposal and verifies signature', as
 
     const payload = await director.buildProofProposal(
         sessionId,
-        protocolVersion,
         networkId,
         epoch,
         previousEpochRecordHash,
@@ -53,7 +55,7 @@ test('ConsensusMessageDirector builds proof proposal and verifies signature', as
     t.ok(Number.isSafeInteger(payload.timestamp) && payload.timestamp > 0);
 
     const proofProposal = payload.proof_proposal;
-    t.is(proofProposal.protocol_version, protocolVersion);
+    t.is(proofProposal.protocol_version, ConsensusProtocolVersion.V1);
     t.is(proofProposal.network_id, networkId);
     t.is(proofProposal.epoch, epoch);
     t.alike(proofProposal.previous_epoch_record_hash, previousEpochRecordHash);
@@ -80,7 +82,6 @@ test('ConsensusMessageDirector builds proof proposal response and verifies signa
     const director = new ConsensusMessageDirector(new ConsensusMessageBuilder(wallet, config));
 
     const sessionId = uuidv7();
-    const protocolVersion = 1;
     const networkId = 67;
     const epoch = 2;
     const previousEpochRecordHash = b4a.alloc(32, 1);
@@ -90,7 +91,6 @@ test('ConsensusMessageDirector builds proof proposal response and verifies signa
 
     const payload = await director.buildProofProposalResponse(
         sessionId,
-        protocolVersion,
         networkId,
         epoch,
         previousEpochRecordHash,
@@ -113,7 +113,7 @@ test('ConsensusMessageDirector builds proof proposal response and verifies signa
     t.ok(b4a.isBuffer(proofProposalResponse.response_sig));
 
     const approvalMessage = createProofProposalApprovalSigningMessage(
-        protocolVersion,
+        ConsensusProtocolVersion.V1,
         networkId,
         epoch,
         previousEpochRecordHash,

--- a/tests/unit/messages/consensus/ConsensusMessageDirector.test.js
+++ b/tests/unit/messages/consensus/ConsensusMessageDirector.test.js
@@ -1,0 +1,136 @@
+import {test} from 'brittle';
+import b4a from 'b4a';
+import tracCryptoApi from 'trac-crypto-api';
+import {WalletProvider} from 'trac-wallet';
+import {v7 as uuidv7} from 'uuid';
+
+import ConsensusMessageBuilder from '../../../../src/messages/consensus/v1/ConsensusMessageBuilder.js';
+import ConsensusMessageDirector from '../../../../src/messages/consensus/v1/ConsensusMessageDirector.js';
+import {addressToBuffer} from '../../../../src/core/state/utils/address.js';
+import {createMessage, safeWriteUInt32BE} from '../../../../src/utils/buffer.js';
+import {ConsensusOperationType, ConsensusResultCode} from '../../../../src/utils/constants.js';
+import {
+    decodeConsensusMessage,
+    encodeConsensusMessage,
+    encodeProofProposalApproval
+} from '../../../../src/codecs/consensus/v1/consensusV1OperationCodec.js';
+import {config} from '../../../helpers/config.js';
+import {testKeyPair1} from '../../../fixtures/apply.fixtures.js';
+
+async function createWallet() {
+    return await new WalletProvider(config).fromSecretKey(testKeyPair1.secretKey);
+}
+
+test('ConsensusMessageDirector builds proof proposal and verifies signature', async t => {
+    const wallet = await createWallet();
+    const director = new ConsensusMessageDirector(new ConsensusMessageBuilder(wallet, config));
+
+    const sessionId = uuidv7();
+    const protocolVersion = 1;
+    const networkId = 67;
+    const epoch = 2;
+    const previousEpochRecordHash = b4a.alloc(32, 1);
+    const vdfParametersHash = b4a.alloc(32, 2);
+    const vdfProof = b4a.alloc(96, 3);
+
+    const payload = await director.buildProofProposal(
+        sessionId,
+        protocolVersion,
+        networkId,
+        epoch,
+        previousEpochRecordHash,
+        wallet.address,
+        vdfParametersHash,
+        vdfProof
+    );
+
+    t.is(payload.type, ConsensusOperationType.PROOF_PROPOSAL);
+    t.is(payload.session_id, sessionId);
+    t.ok(Number.isSafeInteger(payload.timestamp) && payload.timestamp > 0);
+
+    const proofProposal = payload.proof_proposal;
+    t.is(proofProposal.protocol_version, protocolVersion);
+    t.is(proofProposal.network_id, networkId);
+    t.is(proofProposal.epoch, epoch);
+    t.alike(proofProposal.previous_epoch_record_hash, previousEpochRecordHash);
+    t.alike(proofProposal.proposer, addressToBuffer(wallet.address, config.addressPrefix));
+    t.alike(proofProposal.vdf_parameters_hash, vdfParametersHash);
+    t.alike(proofProposal.vdf_proof, vdfProof);
+    t.ok(b4a.isBuffer(proofProposal.signature));
+
+    const message = createMessage(
+        proofProposal.protocol_version,
+        proofProposal.network_id,
+        proofProposal.epoch,
+        proofProposal.previous_epoch_record_hash,
+        proofProposal.proposer,
+        proofProposal.vdf_parameters_hash,
+        proofProposal.vdf_proof
+    );
+    const hash = await tracCryptoApi.hash.blake3(message);
+    t.ok(wallet.verify(proofProposal.signature, hash, wallet.publicKey));
+});
+
+test('ConsensusMessageDirector builds proof proposal response and verifies signatures', async t => {
+    const wallet = await createWallet();
+    const director = new ConsensusMessageDirector(new ConsensusMessageBuilder(wallet, config));
+
+    const sessionId = uuidv7();
+    const protocolVersion = 1;
+    const networkId = 67;
+    const epoch = 2;
+    const previousEpochRecordHash = b4a.alloc(32, 1);
+    const vdfParametersHash = b4a.alloc(32, 2);
+    const vdfProof = b4a.alloc(96, 3);
+    const requesterProofSignature = b4a.alloc(64, 4);
+
+    const payload = await director.buildProofProposalResponse(
+        sessionId,
+        protocolVersion,
+        networkId,
+        epoch,
+        previousEpochRecordHash,
+        wallet.address,
+        vdfParametersHash,
+        vdfProof,
+        requesterProofSignature,
+        ConsensusResultCode.OK,
+        wallet.address
+    );
+
+    t.is(payload.type, ConsensusOperationType.PROOF_PROPOSAL_RESPONSE);
+    t.is(payload.session_id, sessionId);
+    t.ok(Number.isSafeInteger(payload.timestamp) && payload.timestamp > 0);
+
+    const proofProposalResponse = payload.proof_proposal_response;
+    t.is(proofProposalResponse.result, ConsensusResultCode.OK);
+    t.alike(proofProposalResponse.approval.approver, addressToBuffer(wallet.address, config.addressPrefix));
+    t.ok(b4a.isBuffer(proofProposalResponse.approval.approval_sig));
+    t.ok(b4a.isBuffer(proofProposalResponse.response_sig));
+
+    const approvalMessage = createMessage(
+        protocolVersion,
+        networkId,
+        epoch,
+        previousEpochRecordHash,
+        addressToBuffer(wallet.address, config.addressPrefix),
+        vdfParametersHash,
+        vdfProof,
+        proofProposalResponse.approval.approver,
+        requesterProofSignature
+    );
+    const approvalHash = await tracCryptoApi.hash.blake3(approvalMessage);
+    t.ok(wallet.verify(proofProposalResponse.approval.approval_sig, approvalHash, wallet.publicKey));
+
+    const encodedApproval = encodeProofProposalApproval(proofProposalResponse.approval);
+    const responseMessage = createMessage(
+        safeWriteUInt32BE(ConsensusResultCode.OK, 0),
+        encodedApproval
+    );
+    const responseHash = await tracCryptoApi.hash.blake3(responseMessage);
+    t.ok(wallet.verify(proofProposalResponse.response_sig, responseHash, wallet.publicKey));
+
+    const decoded = decodeConsensusMessage(encodeConsensusMessage(payload));
+    t.is(decoded.proof_proposal_response.result, ConsensusResultCode.OK);
+    t.alike(decoded.proof_proposal_response.approval, proofProposalResponse.approval);
+});

--- a/tests/unit/messages/messages.test.js
+++ b/tests/unit/messages/messages.test.js
@@ -2,10 +2,12 @@ import { default as test } from 'brittle';
 
 async function runMsgUtilsTests() {
     test.pause();
-    await import('./network/NetworkMessageBuilder.test.js');
-    await import('./network/NetworkMessageDirector.test.js');
     await import('./state/applyStateMessageBuilder.complete.test.js');
     await import('./state/applyStateMessageBuilder.partial.test.js');
+    await import('./network/NetworkMessageBuilder.test.js');
+    await import('./network/NetworkMessageDirector.test.js');
+    await import('./consensus/ConsensusMessageBuilder.test.js');
+    await import('./consensus/ConsensusMessageDirector.test.js');
     test.resume();
 }
 

--- a/tests/unit/utils/buffer/buffer.test.js
+++ b/tests/unit/utils/buffer/buffer.test.js
@@ -1,6 +1,17 @@
 import test from 'brittle';
 import b4a from 'b4a';
-import { createMessage, isBufferValid, safeWriteUInt32BE, deepCopyBuffer, encodeCapabilities, timestampToBuffer, idToBuffer } from '../../../../src/utils/buffer.js';
+import {
+    assertBuffer,
+    createMessage,
+    isBufferValid,
+    safeWriteUInt32BE,
+    uint32ToBuffer,
+    uint64ToBuffer,
+    deepCopyBuffer,
+    encodeCapabilities,
+    timestampToBuffer,
+    idToBuffer
+} from '../../../../src/utils/buffer.js';
 import { errorMessageIncludes } from "../../../helpers/regexHelper.js";
 
 const invalidDataTypes = [
@@ -248,4 +259,65 @@ test('timestampToBuffer and idToBuffer - reject invalid input', t => {
     t.exception(() => timestampToBuffer('1'), errorMessageIncludes('timestamp'));
     t.exception.all(() => idToBuffer(1));
     t.exception.all(() => idToBuffer(null));
+});
+
+test('uint32ToBuffer - encodes uint32 values and throws for invalid input', t => {
+    const zero = uint32ToBuffer(0, 'field');
+    t.ok(b4a.isBuffer(zero), 'returns a buffer for zero');
+    t.is(zero.readUInt32BE(0), 0, 'encodes zero');
+
+    const max = uint32ToBuffer(0xFFFFFFFF, 'field');
+    t.ok(b4a.isBuffer(max), 'returns buffer for max uint32');
+    t.is(max.readUInt32BE(0), 0xFFFFFFFF, 'encodes max uint32');
+
+    t.exception(() => uint32ToBuffer(-1, 'field'), errorMessageIncludes('field'));
+});
+
+test('uint64ToBuffer - encodes uint64 values and throws for invalid input', t => {
+    const zero = uint64ToBuffer(0, 'field');
+    t.ok(b4a.isBuffer(zero), 'returns a buffer for zero');
+    t.is(zero.readBigUInt64BE(0), 0n, 'encodes zero');
+
+    const large = uint64ToBuffer(0x100000000, 'field');
+    t.ok(b4a.isBuffer(large), 'returns buffer for values above uint32');
+    t.is(large.readBigUInt64BE(0), 0x100000000n, 'encodes uint64-range safe integer');
+
+    t.exception(() => uint64ToBuffer(-1, 'field'), errorMessageIncludes('field'));
+    t.exception(() => uint64ToBuffer(Number.MAX_SAFE_INTEGER + 1, 'field'), errorMessageIncludes('field'));
+});
+
+test('assertBuffer - returns buffers and throws for non-buffers', t => {
+    const buffer = b4a.alloc(1);
+    t.is(assertBuffer(buffer, 'field'), buffer, 'returns original buffer');
+    t.exception(() => assertBuffer('not-a-buffer', 'field'), errorMessageIncludes('field'));
+});
+
+test('uint32ToBuffer - rejects non-integer and out-of-range values with field name', t => {
+    const invalidValues = [
+        1.5,
+        NaN,
+        Infinity,
+        -1,
+        0x100000000,
+        '1',
+        1n
+    ];
+
+    for (const value of invalidValues) {
+        t.exception(() => uint32ToBuffer(value, 'counter'), errorMessageIncludes('counter'));
+    }
+});
+
+test('uint64ToBuffer - encodes bigint boundaries and rejects values outside uint64 range', t => {
+    const max = (2n ** 64n) - 1n;
+    const maxBuffer = uint64ToBuffer(max, 'field');
+
+    t.ok(b4a.isBuffer(maxBuffer), 'returns buffer for max uint64');
+    t.is(maxBuffer.readBigUInt64BE(0), max, 'encodes max uint64');
+    t.exception.all(() => uint64ToBuffer(2n ** 64n, 'field'));
+});
+
+test('assertBuffer - rejects missing and null values with field name', t => {
+    t.exception(() => assertBuffer(undefined, 'payload'), errorMessageIncludes('payload'));
+    t.exception(() => assertBuffer(null, 'payload'), errorMessageIncludes('payload'));
 });


### PR DESCRIPTION
This pull request makes several significant changes to the consensus proof proposal approval flow, focusing on renaming fields for clarity, updating related logic, and introducing a new message builder utility. The main theme is to standardize the use of the term "approver" instead of "member_id" throughout the protocol, codebase, and validation logic.

### Field Renaming and Protocol Updates

* Renamed the `member_id` field to `approver` in the `ProofProposalApproval` protobuf message and all related generated codec code, updating all usages, encodings, and documentation accordingly. [[1]](diffhunk://#diff-11065f2f962e796aa43aea40b881c3bbbec89b2e2fd9c57e34dbc27640dcc487L5-R7) [[2]](diffhunk://#diff-d339c53d77de5cced502b8f0c6873561ab4a71d35420967012925b6baa0268f4L1154-R1154) [[3]](diffhunk://#diff-d339c53d77de5cced502b8f0c6873561ab4a71d35420967012925b6baa0268f4L1174-R1179) [[4]](diffhunk://#diff-d339c53d77de5cced502b8f0c6873561ab4a71d35420967012925b6baa0268f4L1213-R1214) [[5]](diffhunk://#diff-d339c53d77de5cced502b8f0c6873561ab4a71d35420967012925b6baa0268f4L1254-R1254) [[6]](diffhunk://#diff-d339c53d77de5cced502b8f0c6873561ab4a71d35420967012925b6baa0268f4L1296-R1298) [[7]](diffhunk://#diff-d339c53d77de5cced502b8f0c6873561ab4a71d35420967012925b6baa0268f4L1317-R1321) [[8]](diffhunk://#diff-d339c53d77de5cced502b8f0c6873561ab4a71d35420967012925b6baa0268f4L1345-R1349) [[9]](diffhunk://#diff-d339c53d77de5cced502b8f0c6873561ab4a71d35420967012925b6baa0268f4L1359-R1360)
* Updated the proof proposal protobuf comments and field descriptions for clarity, specifying that the `proposer` is a TRAC address and annotating proof data fields.

### Validation and Handler Logic

* Updated all validation and handler logic to use `approver` instead of `member_id`, including schema validation, response building, and signature verification, ensuring the approver matches the sender's public key. [[1]](diffhunk://#diff-75339d3504e4d0829d7b8603e0937edfc18368db2d78ba349e5e136ecf4ba588L63-R63) [[2]](diffhunk://#diff-75339d3504e4d0829d7b8603e0937edfc18368db2d78ba349e5e136ecf4ba588L89-R89) [[3]](diffhunk://#diff-4d108e490d068a93f0fabd3bf5f3e651380cbdcb742d5f46e9b8db49cbe20debL138-R138) [[4]](diffhunk://#diff-a29894dd7d1085419fef608b814b1af9c3c215e26ab3b69099c6e60c1432d0ffL18-R31) [[5]](diffhunk://#diff-a29894dd7d1085419fef608b814b1af9c3c215e26ab3b69099c6e60c1432d0ffL43-R43)

### New Utility

* Added a new `ConsensusMessageBuilder` class to encapsulate the creation and validation of consensus messages, including proof proposal and proof proposal response payloads, with comprehensive input validation and signature generation.

### Minor Cleanups

* Removed an unnecessary blank line from the `ResultCode` enum in the protobuf file.

These changes improve code clarity, enforce stricter validation, and make the consensus proof approval process more robust and maintainable.