### PR TITLE
feat: extend apply schema validation for SET_EPOCH

### DIFF
--- a/src/core/consensus/v1/validators/ConsensusValidationSchema.js
+++ b/src/core/consensus/v1/validators/ConsensusValidationSchema.js
@@ -80,39 +80,6 @@ class ConsensusValidationSchema {
                     `
             };
         });
-        this.#validator.add("uint64", function ({messages}, _path, _context) {
-            return {
-                source:
-                    `
-                        if (typeof value === 'number') {
-                            if (!Number.isSafeInteger(value) || value < 0) {
-                                ${this.makeError({type: "uint64", actual: "value", messages})}
-                            }
-                            return value;
-                        }
-                        if (typeof value === 'bigint') {
-                            if (value < 0n || value > 0xFFFFFFFFFFFFFFFFn) {
-                                ${this.makeError({type: "uint64", actual: "value", messages})}
-                            }
-                            return value;
-                        }
-                        if (typeof value === 'string') {
-                            if (!/^(0|[1-9]\\d*)$/.test(value)) {
-                                ${this.makeError({type: "uint64", actual: "value", messages})}
-                                return value;
-                            }
-                            const uint64Value = BigInt(value);
-                            if (uint64Value > 0xFFFFFFFFFFFFFFFFn) {
-                                ${this.makeError({type: "uint64", actual: "value", messages})}
-                            }
-                            return value;
-                        }
-                        ${this.makeError({type: "uint64", actual: "value", messages})}
-                        return value;
-                    `
-            };
-        });
-
         this.#validateConsensusV1ProofProposalSchema = this.#compileV1EpochProofProposalRequestSchema();
         this.#validateConsensusV1ProposalApproval = this.#compileConsensusV1ProposalApprovalSchema();
     }

--- a/src/core/consensus/v1/validators/ConsensusValidationSchema.js
+++ b/src/core/consensus/v1/validators/ConsensusValidationSchema.js
@@ -35,7 +35,6 @@ class ConsensusValidationSchema {
         });
         const isBuffer = b4a.isBuffer;
         this.#validator.add("buffer", function ({schema, messages}, _path, _context) {
-            const allowZero = schema.allowZero === true;
             const allowEmpty = schema.allowEmpty === true;
             const exactLength = Number.isInteger(schema.length) ? schema.length : null;
             const minLength = Number.isInteger(schema.min) ? schema.min : null;
@@ -64,17 +63,15 @@ class ConsensusValidationSchema {
                             ${this.makeError({type: "emptyBuffer", actual: "len", messages})}
                             return value;
                         }
-                        if (!${allowZero}) {
-                            let isZeroFilled = true;
-                            for (let i = 0; i < len; i++) {
-                                if (value[i] !== 0) {
-                                    isZeroFilled = false;
-                                    break;
-                                }
+                        let isZeroFilled = true;
+                        for (let i = 0; i < len; i++) {
+                            if (value[i] !== 0) {
+                                isZeroFilled = false;
+                                break;
                             }
-                            if (isZeroFilled) {
-                                ${this.makeError({type: "nonZeroBuffer", actual: "value", messages})}
-                            }
+                        }
+                        if (isZeroFilled) {
+                            ${this.makeError({type: "nonZeroBuffer", actual: "value", messages})}
                         }
                             return value;
                     `
@@ -100,8 +97,8 @@ class ConsensusValidationSchema {
                 type: 'object',
                 props: {
                     protocol_version: {type: 'buffer', length: PROTOCOL_VERSION_BYTE_LENGTH, required: true},
-                    network_id: {type: 'buffer', length: NETWORK_ID_BYTE_LENGTH, allowZero: true, required: true},
-                    epoch: {type: 'buffer', length: EPOCH_BYTE_LENGTH, allowZero: true, required: true},
+                    network_id: {type: 'buffer', length: NETWORK_ID_BYTE_LENGTH, required: true},
+                    epoch: {type: 'buffer', length: EPOCH_BYTE_LENGTH, required: true},
                     previous_epoch_record_hash: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true},
                     proposer: {type: 'buffer', length: this.#config.addressLength, required: true},
                     vdf_parameters_hash: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true},

--- a/src/messages/consensus/v1/ConsensusMessageBuilder.js
+++ b/src/messages/consensus/v1/ConsensusMessageBuilder.js
@@ -114,12 +114,23 @@ class ConsensusMessageBuilder {
     }
 
     setNetworkId(networkId) {
-        this.#network_id = uint16ToBuffer(networkId, 'Network id');
-        return  this;
+        const value = uint16ToBuffer(networkId, 'Network id');
+        if (networkId === 0) {
+            throw new Error('Network id must be greater than zero.');
+        }
+
+        this.#network_id = value;
+        return this;
     }
 
     setEpoch(epoch) {
-        this.#epoch = uint64ToBuffer(epoch, 'Epoch');
+        const value = uint64ToBuffer(epoch, 'Epoch');
+        const epochValue = typeof epoch === 'bigint' ? epoch : BigInt(epoch);
+        if (epochValue === 0n) {
+            throw new Error('Epoch must be greater than zero.');
+        }
+
+        this.#epoch = value;
         return this;
     }
 

--- a/src/utils/check.js
+++ b/src/utils/check.js
@@ -273,32 +273,50 @@ class Check {
 
     }
 
+    #getOperationTypeName(operationType) {
+        for (const [name, value] of Object.entries(OperationType)) {
+            if (value === operationType) return name;
+        }
+
+        return undefined;
+    }
+
+    #operationTypeDomain(...values) {
+        return {
+            type: 'number',
+            required: true,
+            custom: (value, errors) => {
+                if (!values.includes(value)) {
+                    const singleValue = values.length === 1;
+                    const expectedOperationType = values[0];
+                    const expected = singleValue ? expectedOperationType : values;
+                    const operationName = this.#getOperationTypeName(expectedOperationType);
+
+                    errors.push({
+                        type: 'valueNotAllowed',
+                        actual: value,
+                        expected,
+                        field: 'type',
+                        message: singleValue
+                            ? `Operation type must be ${expectedOperationType} (${operationName})`
+                            : `Operation type must be one of: ${values.join(', ')}`
+                    });
+                }
+
+                return value;
+            }
+        };
+    }
+
     // Complete by default - no writer needed
     #compileCoreAdminOperationSchema() {
         const addressLength = this.#config.addressLength
         const schema = {
             $$strict: true,
-            type: {
-                type: 'number',
-                required: true,
-                custom: (value, errors) => {
-                    const allowedTypes = [
-                        OperationType.ADD_ADMIN,
-                        OperationType.DISABLE_INITIALIZATION,
-                    ];
-
-                    if (!allowedTypes.includes(value)) {
-                        errors.push({
-                            type: 'valueNotAllowed',
-                            actual: value,
-                            expected: allowedTypes,
-                            field: 'type',
-                            message: `Operation type must be one of: ${allowedTypes.join(', ')}`
-                        });
-                    }
-                    return value;
-                }
-            },
+            type: this.#operationTypeDomain(
+                OperationType.ADD_ADMIN,
+                OperationType.DISABLE_INITIALIZATION
+            ),
             address: {type: 'buffer', length: addressLength, required: true}, // invoker adddress (admin)
             cao: {
                 strict: true,
@@ -322,22 +340,7 @@ class Check {
     #compileBalanceInitializationSchema() {
         const schema = {
             $$strict: true,
-            type: {
-                type: 'number',
-                required: true,
-                custom: (value, errors) => {
-                    if (value !== OperationType.BALANCE_INITIALIZATION) {
-                        errors.push({
-                            type: 'valueNotAllowed',
-                            actual: value,
-                            expected: OperationType.BALANCE_INITIALIZATION,
-                            field: 'type',
-                            message: `Operation type must be ${OperationType.BALANCE_INITIALIZATION} (BALANCE_INITIALIZATION)`
-                        });
-                    }
-                    return value;
-                }
-            },
+            type: this.#operationTypeDomain(OperationType.BALANCE_INITIALIZATION),
             address: {type: 'buffer', length: this.#config.addressLength, required: true},
             bio: {
                 strict: true,
@@ -363,29 +366,12 @@ class Check {
     #compileAdminControlOperationSchema() {
         const schema = {
             $$strict: true,
-            type: {
-                type: 'number',
-                required: true,
-                custom: (value, errors) => {
-                    const allowedTypes = [
-                        OperationType.APPEND_WHITELIST,
-                        OperationType.ADD_INDEXER,
-                        OperationType.REMOVE_INDEXER,
-                        OperationType.BAN_VALIDATOR
-                    ];
-
-                    if (!allowedTypes.includes(value)) {
-                        errors.push({
-                            type: 'valueNotAllowed',
-                            actual: value,
-                            expected: allowedTypes,
-                            field: 'type',
-                            message: `Operation type must be one of: ${allowedTypes.join(', ')}`
-                        });
-                    }
-                    return value;
-                }
-            },
+            type: this.#operationTypeDomain(
+                OperationType.APPEND_WHITELIST,
+                OperationType.ADD_INDEXER,
+                OperationType.REMOVE_INDEXER,
+                OperationType.BAN_VALIDATOR
+            ),
             address: {type: 'buffer', length: this.#config.addressLength, required: true}, // invoker adddress (admin)
             aco: {
                 strict: true,
@@ -409,28 +395,11 @@ class Check {
     #compileRoleAccessOperationSchema() {
         const schema = {
             $$strict: true,
-            type: {
-                type: 'number',
-                required: true,
-                custom: (value, errors) => {
-                    const allowedTypes = [
-                        OperationType.ADD_WRITER,
-                        OperationType.REMOVE_WRITER,
-                        OperationType.ADMIN_RECOVERY
-                    ];
-
-                    if (!allowedTypes.includes(value)) {
-                        errors.push({
-                            type: 'valueNotAllowed',
-                            actual: value,
-                            expected: allowedTypes,
-                            field: 'type',
-                            message: `Operation type must be one of: ${allowedTypes.join(', ')}`
-                        });
-                    }
-                    return value;
-                }
-            },
+            type: this.#operationTypeDomain(
+                OperationType.ADD_WRITER,
+                OperationType.REMOVE_WRITER,
+                OperationType.ADMIN_RECOVERY
+            ),
             address: {type: 'buffer', length: this.#config.addressLength, required: true},
             rao: {
                 strict: true,
@@ -484,22 +453,7 @@ class Check {
     #compileTransactionOperationSchema() {
         const schema = {
             $$strict: true,
-            type: {
-                type: 'number',
-                required: true,
-                custom: (value, errors) => { // more secure than enum
-                    if (value !== OperationType.TX) {
-                        errors.push({
-                            type: 'valueNotAllowed',
-                            actual: value,
-                            expected: OperationType.TX,
-                            field: 'type',
-                            message: `Operation type must be ${OperationType.TX} (TX)`
-                        });
-                    }
-                    return value;
-                }
-            },
+            type: this.#operationTypeDomain(OperationType.TX),
             address: {type: 'buffer', length: this.#config.addressLength, required: true}, // invoker address
             txo: {
                 strict: true,
@@ -555,22 +509,7 @@ class Check {
     #compileBootstrapDeploymentSchema() {
         const schema = {
             $$strict: true,
-            type: {
-                type: 'number',
-                required: true,
-                custom: (value, errors) => {
-                    if (value !== OperationType.BOOTSTRAP_DEPLOYMENT) {
-                        errors.push({
-                            type: 'valueNotAllowed',
-                            actual: value,
-                            expected: OperationType.BOOTSTRAP_DEPLOYMENT,
-                            field: 'type',
-                            message: `Operation type must be ${OperationType.BOOTSTRAP_DEPLOYMENT} (BOOTSTRAP_DEPLOYMENT)`
-                        });
-                    }
-                    return value;
-                }
-            },
+            type: this.#operationTypeDomain(OperationType.BOOTSTRAP_DEPLOYMENT),
             address: {type: 'buffer', length: this.#config.addressLength, required: true},
             bdo: {
 
@@ -625,22 +564,7 @@ class Check {
     #compileTransferOperationSchema() {
         const schema = {
             $$strict: true,
-            type: {
-                type: 'number',
-                required: true,
-                custom: (value, errors) => {
-                    if (value !== OperationType.TRANSFER) {
-                        errors.push({
-                            type: 'valueNotAllowed',
-                            actual: value,
-                            expected: OperationType.TRANSFER,
-                            field: 'type',
-                            message: `Operation type must be ${OperationType.TRANSFER} (TRANSFER)`
-                        });
-                    }
-                    return value;
-                }
-            },
+            type: this.#operationTypeDomain(OperationType.TRANSFER),
             address: {type: 'buffer', length: this.#config.addressLength, required: true},
             tro: {
                 strict: true,
@@ -695,22 +619,7 @@ class Check {
     #compileSetEpochOperationSchema() {
         const schema = {
             $$strict: true,
-            type: {
-                type: 'number',
-                required: true,
-                custom: (value, errors) => {
-                    if (value !== OperationType.SET_EPOCH) {
-                        errors.push({
-                            type: 'valueNotAllowed',
-                            actual: value,
-                            expected: OperationType.SET_EPOCH,
-                            field: 'type',
-                            message: `Operation type must be ${OperationType.SET_EPOCH} (SET_EPOCH)`
-                        });
-                    }
-                    return value;
-                }
-            },
+            type: this.#operationTypeDomain(OperationType.SET_EPOCH),
             address: {type: 'buffer', length: this.#config.addressLength, required: true},
             seo: {
                 strict: true,

--- a/src/utils/check.js
+++ b/src/utils/check.js
@@ -10,20 +10,30 @@ import {
     BOOTSTRAP_BYTE_LENGTH,
     CHANNEL_BYTE_LENGTH,
     AMOUNT_BYTE_LENGTH,
+    PROTOCOL_VERSION_BYTE_LENGTH,
+    NETWORK_ID_BYTE_LENGTH,
+    EPOCH_BYTE_LENGTH,
+    VDF_BLOB_PROOF_SIZE,
 } from './constants.js';
-//TODO: ATTENTION - CURRENT IMPLEMENTATION UTILIZES `custom` FOR MULTIPLE TIMES IN MANY SCHEMAS. IT SHOULD BE CLEANED UP
-// TO UTILIZE ONLY ONE FUNCTION COMMON FOR ALL THE SCHEMAS. CREATE A TICKED P2/P3.
+import {
+    decodeProofProposalApproval,
+    decodeProofProposal,
+    encodeProofProposalApproval,
+    encodeProofProposal
+} from '../codecs/consensus/v1/consensusV1OperationCodec.js';
 
 class Check {
     #validator;
-    #validateCoreAdminOperationSchema
-    #validateAdminControlOperationSchema
-    #validateRoleAccessOperationSchema
+    #validateCoreAdminOperationSchema;
+    #validateAdminControlOperationSchema;
+    #validateRoleAccessOperationSchema;
     #validateBootstrapDeploymentSchema;
-    #validateTransactionOperationSchema
-    #validateTransferOperationSchema
-    #validateBalanceInitializationSchema
-    #config
+    #validateTransactionOperationSchema;
+    #validateTransferOperationSchema;
+    #validateBalanceInitializationSchema;
+    #validateSetEpochOperationSchema;
+    #proofDataFields;
+    #config;
 
     /**
      * @param {Config} config
@@ -31,6 +41,16 @@ class Check {
     constructor(config) {
         this.#config = config
 
+        this.#proofDataFields = Object.freeze([
+            {name: 'protocol_version', length: PROTOCOL_VERSION_BYTE_LENGTH, allowZero: false},
+            {name: 'network_id', length: NETWORK_ID_BYTE_LENGTH, allowZero: true},
+            {name: 'epoch', length: EPOCH_BYTE_LENGTH, allowZero: true},
+            {name: 'previous_epoch_record_hash', length: HASH_BYTE_LENGTH, allowZero: false},
+            {name: 'proposer', length: this.#config.addressLength, allowZero: false},
+            {name: 'vdf_parameters_hash', length: HASH_BYTE_LENGTH, allowZero: false},
+            {name: 'vdf_proof', length: VDF_BLOB_PROOF_SIZE, allowZero: false},
+            {name: 'signature', length: SIGNATURE_BYTE_LENGTH, allowZero: false}
+        ]);
         this.#validator = new Validator({
             useNewCustomCheckerFunction: true,
             messages: {
@@ -38,23 +58,32 @@ class Check {
                 bufferLength: "The '{field}' field must be a Buffer with length {expected}! Actual: {actual}",
                 nonZeroBuffer: "The '{field}' field must not be an empty or zero-filled Buffer!",
                 emptyBuffer: "The '{field}' field must not be an empty Buffer!",
+                proofData: "The '{field}' field must be an encoded ProofProposal buffer.",
+                proofProposalApproval: "The '{field}' field must be an encoded ProofProposalApproval buffer.",
             },
         });
         const isBuffer = b4a.isBuffer;
-        this.#validator.add("buffer", function ({ schema, messages }, _path, _context) {
+        const equals = b4a.equals;
+        const decodeApproval = decodeProofProposalApproval;
+        const encodeApproval = encodeProofProposalApproval;
+        const decodeProofData = decodeProofProposal;
+        const encodeProofData = encodeProofProposal;
+        const proofDataFields = this.#proofDataFields;
+        const addressLength = this.#config.addressLength;
+        this.#validator.add("buffer", function ({schema, messages}, _path, _context) {
             return {
                 source:
                     `
                         if (!${isBuffer}(value)) {
-                            ${this.makeError({ type: "buffer", actual: "value", messages })}
+                            ${this.makeError({type: "buffer", actual: "value", messages})}
                         }
                         if (value.length !== ${schema.length}) {
                             ${this.makeError({
-        type: "bufferLength",
-        expected: schema.length,
-        actual: "value.length",
-        messages
-    })}
+                        type: "bufferLength",
+                        expected: schema.length,
+                        actual: "value.length",
+                        messages
+                    })}
                         }
                         let isEmpty = true;
                             for (let i = 0; i < value.length; i++) {
@@ -64,28 +93,169 @@ class Check {
                                 }
                             }
                             if (isEmpty) {
-                                ${this.makeError({ type: "emptyBuffer", actual: "value", messages })}
+                                ${this.makeError({type: "emptyBuffer", actual: "value", messages})}
                             }
                             return value;
                     `
             };
         });
 
-        this.#validator.add("buffer_amount", function ({ schema, messages }, _path, _context) {
+        this.#validator.add("buffer_amount", function ({schema, messages}, _path, _context) {
             return {
                 source:
                     `
                         if (!${isBuffer}(value)) {
-                            ${this.makeError({ type: "buffer", actual: "value", messages })}
+                            ${this.makeError({type: "buffer", actual: "value", messages})}
                         }
                         if (value.length !== ${schema.length}) {
                             ${this.makeError({
-        type: "bufferLength",
-        expected: schema.length,
-        actual: "value.length",
-        messages
-    })}
+                        type: "bufferLength",
+                        expected: schema.length,
+                        actual: "value.length",
+                        messages
+                    })}
                         }
+                        return value;
+                    `
+            };
+        });
+        this.#validator.add("proof_data", function ({schema, messages, index}, _path, _context) {
+            _context.customs[index] = {
+                schema,
+                decodeProofData,
+                encodeProofData,
+                equals,
+                isBuffer,
+                fields: proofDataFields
+            };
+
+            return {
+                source:
+                    `
+                        const proofDataRule = context.customs[${index}];
+                        if (!proofDataRule.isBuffer(value) || value.length === 0) {
+                            ${this.makeError({type: "proofData", actual: "value", messages})}
+                            return value;
+                        }
+
+                        let proofData;
+                        try {
+                            proofData = proofDataRule.decodeProofData(value);
+                        } catch {
+                            ${this.makeError({type: "proofData", actual: "value", messages})}
+                            return value;
+                        }
+
+                        const reencodedProofDataInput = {};
+                        for (const field of proofDataRule.fields) {
+                            const fieldValue = proofData[field.name];
+                            if (!proofDataRule.isBuffer(fieldValue) || fieldValue.length !== field.length) {
+                                ${this.makeError({type: "proofData", actual: "value", messages})}
+                                return value;
+                            }
+
+                            if (!field.allowZero) {
+                                let fieldIsZeroFilled = true;
+                                for (let i = 0; i < fieldValue.length; i++) {
+                                    if (fieldValue[i] !== 0) {
+                                        fieldIsZeroFilled = false;
+                                        break;
+                                    }
+                                }
+
+                                if (fieldIsZeroFilled) {
+                                    ${this.makeError({type: "proofData", actual: "value", messages})}
+                                    return value;
+                                }
+                            }
+
+                            reencodedProofDataInput[field.name] = fieldValue;
+                        }
+
+                        const reencodedProofData = proofDataRule.encodeProofData(reencodedProofDataInput);
+                        if (!proofDataRule.equals(value, reencodedProofData)) {
+                            ${this.makeError({type: "proofData", actual: "value", messages})}
+                        }
+
+                        return value;
+                    `
+            };
+        });
+        // index is a number assigned by fastest-validator to this compiled rule.
+        // Use it as a key for helpers needed by the generated validator function.
+        // Example: index = 6 -> _context.customs[6] stores decodeApproval.
+        this.#validator.add("proof_proposal_approval", function ({schema, messages, index}, _path, _context) {
+            _context.customs[index] = {
+                schema,
+                decodeApproval,
+                encodeApproval,
+                equals,
+                isBuffer,
+                addressLength,
+                signatureByteLength: SIGNATURE_BYTE_LENGTH
+            };
+
+            return {
+                source:
+                    `
+                        // If index was 6 during compilation, this becomes context.customs[6].
+                        const proofProposalApprovalRule = context.customs[${index}];
+                        if (!proofProposalApprovalRule.isBuffer(value) || value.length === 0) {
+                            ${this.makeError({type: "proofProposalApproval", actual: "value", messages})}
+                            return value;
+                        }
+
+                        let approval;
+                        try {
+                            approval = proofProposalApprovalRule.decodeApproval(value);
+                        } catch {
+                            ${this.makeError({type: "proofProposalApproval", actual: "value", messages})}
+                            return value;
+                        }
+
+                        const approver = approval.approver;
+                        const approvalSignature = approval.approval_sig;
+
+                        if (!proofProposalApprovalRule.isBuffer(approver) || approver.length !== proofProposalApprovalRule.addressLength) {
+                            ${this.makeError({type: "proofProposalApproval", actual: "value", messages})}
+                            return value;
+                        }
+
+                        if (!proofProposalApprovalRule.isBuffer(approvalSignature) || approvalSignature.length !== proofProposalApprovalRule.signatureByteLength) {
+                            ${this.makeError({type: "proofProposalApproval", actual: "value", messages})}
+                            return value;
+                        }
+
+                        let approverIsEmpty = true;
+                        for (let i = 0; i < approver.length; i++) {
+                            if (approver[i] !== 0) {
+                                approverIsEmpty = false;
+                                break;
+                            }
+                        }
+
+                        let approvalSignatureIsEmpty = true;
+                        for (let i = 0; i < approvalSignature.length; i++) {
+                            if (approvalSignature[i] !== 0) {
+                                approvalSignatureIsEmpty = false;
+                                break;
+                            }
+                        }
+
+                        if (approverIsEmpty || approvalSignatureIsEmpty) {
+                            ${this.makeError({type: "proofProposalApproval", actual: "value", messages})}
+                            return value;
+                        }
+
+                        const reencodedApproval = proofProposalApprovalRule.encodeApproval({
+                            approver,
+                            approval_sig: approvalSignature
+                        });
+
+                        if (!proofProposalApprovalRule.equals(value, reencodedApproval)) {
+                            ${this.makeError({type: "proofProposalApproval", actual: "value", messages})}
+                        }
+
                         return value;
                     `
             };
@@ -99,6 +269,7 @@ class Check {
         this.#validateTransactionOperationSchema = this.#compileTransactionOperationSchema();
         this.#validateTransferOperationSchema = this.#compileTransferOperationSchema();
         this.#validateBalanceInitializationSchema = this.#compileBalanceInitializationSchema();
+        this.#validateSetEpochOperationSchema = this.#compileSetEpochOperationSchema();
 
     }
 
@@ -133,11 +304,11 @@ class Check {
                 strict: true,
                 type: 'object',
                 props: {
-                    tx: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx hash
-                    txv: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx validity
-                    iw: { type: 'buffer', length: WRITER_BYTE_LENGTH, required: true }, // writer key of the admin
-                    in: { type: 'buffer', length: NONCE_BYTE_LENGTH, required: true }, // nonce
-                    is: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true }, // signature
+                    tx: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx hash
+                    txv: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx validity
+                    iw: {type: 'buffer', length: WRITER_BYTE_LENGTH, required: true}, // writer key of the admin
+                    in: {type: 'buffer', length: NONCE_BYTE_LENGTH, required: true}, // nonce
+                    is: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true}, // signature
                 }
             }
         };
@@ -167,17 +338,17 @@ class Check {
                     return value;
                 }
             },
-            address: { type: 'buffer', length: this.#config.addressLength, required: true },
+            address: {type: 'buffer', length: this.#config.addressLength, required: true},
             bio: {
                 strict: true,
                 type: 'object',
                 props: {
-                    tx: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx hash
-                    txv: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx validity
-                    ia: { type: 'buffer', length: this.#config.addressLength, required: true }, // selected address to specific operation.
-                    am: { type: 'buffer', length: AMOUNT_BYTE_LENGTH, required: true }, // amount to transfer
-                    in: { type: 'buffer', length: NONCE_BYTE_LENGTH, required: true }, // nonce of the invoker
-                    is: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true }, // signature of the invoker
+                    tx: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx hash
+                    txv: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx validity
+                    ia: {type: 'buffer', length: this.#config.addressLength, required: true}, // selected address to specific operation.
+                    am: {type: 'buffer', length: AMOUNT_BYTE_LENGTH, required: true}, // amount to transfer
+                    in: {type: 'buffer', length: NONCE_BYTE_LENGTH, required: true}, // nonce of the invoker
+                    is: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true}, // signature of the invoker
                 }
             }
         };
@@ -220,11 +391,11 @@ class Check {
                 strict: true,
                 type: 'object',
                 props: {
-                    tx: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx hash
-                    txv: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx validity
-                    ia: { type: 'buffer', length: this.#config.addressLength, required: true }, // incoming address - selected address for specific operation
-                    in: { type: 'buffer', length: NONCE_BYTE_LENGTH, required: true }, // nonce
-                    is: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true }, // signature
+                    tx: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx hash
+                    txv: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx validity
+                    ia: {type: 'buffer', length: this.#config.addressLength, required: true}, // incoming address - selected address for specific operation
+                    in: {type: 'buffer', length: NONCE_BYTE_LENGTH, required: true}, // nonce
+                    is: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true}, // signature
                 }
             }
         };
@@ -265,19 +436,19 @@ class Check {
                 strict: true,
                 type: 'object',
                 props: {
-                    tx: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx hash
-                    txv: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx validity
-                    iw: { type: 'buffer', length: WRITER_BYTE_LENGTH, required: true }, // writing key of the invoker
-                    in: { type: 'buffer', length: NONCE_BYTE_LENGTH, required: true }, // nonce of the invoker
-                    is: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true }, // signature
-                    va: { type: 'buffer', length: this.#config.addressLength, optional: true },
-                    vn: { type: 'buffer', length: NONCE_BYTE_LENGTH, optional: true },
-                    vs: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, optional: true }
+                    tx: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx hash
+                    txv: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx validity
+                    iw: {type: 'buffer', length: WRITER_BYTE_LENGTH, required: true}, // writing key of the invoker
+                    in: {type: 'buffer', length: NONCE_BYTE_LENGTH, required: true}, // nonce of the invoker
+                    is: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true}, // signature
+                    va: {type: 'buffer', length: this.#config.addressLength, optional: true},
+                    vn: {type: 'buffer', length: NONCE_BYTE_LENGTH, optional: true},
+                    vs: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, optional: true}
 
                 },
                 custom: (value, errors) => {
                     if (!value || typeof value !== 'object') return value;
-                    const { vn, vs, va } = value;
+                    const {vn, vs, va} = value;
                     const vnPresent = vn !== undefined
                     const vsPresent = vs !== undefined
                     const vaPresent = va !== undefined
@@ -334,21 +505,21 @@ class Check {
                 strict: true,
                 type: 'object',
                 props: {
-                    tx: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx hash
-                    txv: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx validity
-                    iw: { type: 'buffer', length: WRITER_BYTE_LENGTH, required: true }, // Writing key of the requesting node (external subnetwork)
-                    ch: { type: 'buffer', length: NONCE_BYTE_LENGTH, required: true }, // Content hash (hash of the transaction's data)
-                    bs: { type: 'buffer', length: BOOTSTRAP_BYTE_LENGTH, required: true }, // External bootstrap contract
-                    mbs: { type: 'buffer', length: BOOTSTRAP_BYTE_LENGTH, required: true }, // MSB bootstrap key
-                    in: { type: 'buffer', length: NONCE_BYTE_LENGTH, required: true }, // Nonce of the requesting node
-                    is: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true }, // Requester's signature
-                    va: { type: 'buffer', length: this.#config.addressLength, optional: true }, //validator address
-                    vn: { type: 'buffer', length: NONCE_BYTE_LENGTH, optional: true }, //validator nonce
-                    vs: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, optional: true }, //validator signature
+                    tx: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx hash
+                    txv: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx validity
+                    iw: {type: 'buffer', length: WRITER_BYTE_LENGTH, required: true}, // Writing key of the requesting node (external subnetwork)
+                    ch: {type: 'buffer', length: NONCE_BYTE_LENGTH, required: true}, // Content hash (hash of the transaction's data)
+                    bs: {type: 'buffer', length: BOOTSTRAP_BYTE_LENGTH, required: true}, // External bootstrap contract
+                    mbs: {type: 'buffer', length: BOOTSTRAP_BYTE_LENGTH, required: true}, // MSB bootstrap key
+                    in: {type: 'buffer', length: NONCE_BYTE_LENGTH, required: true}, // Nonce of the requesting node
+                    is: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true}, // Requester's signature
+                    va: {type: 'buffer', length: this.#config.addressLength, optional: true}, //validator address
+                    vn: {type: 'buffer', length: NONCE_BYTE_LENGTH, optional: true}, //validator nonce
+                    vs: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, optional: true}, //validator signature
                 },
                 custom: (value, errors) => {
                     if (!value || typeof value !== 'object') return value;
-                    const { vn, vs, va } = value;
+                    const {vn, vs, va} = value;
                     const vnPresent = vn !== undefined;
                     const vsPresent = vs !== undefined;
                     const vaPresent = va !== undefined;
@@ -406,19 +577,19 @@ class Check {
                 strict: true,
                 type: "object",
                 props: {
-                    tx: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true },
-                    txv: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true },
-                    bs: { type: 'buffer', length: BOOTSTRAP_BYTE_LENGTH, required: true },
-                    ic: { type: 'buffer', length: CHANNEL_BYTE_LENGTH, required: true },
-                    in: { type: 'buffer', length: NONCE_BYTE_LENGTH, required: true },
-                    is: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true },
-                    va: { type: 'buffer', length: this.#config.addressLength, optional: true },
-                    vn: { type: 'buffer', length: NONCE_BYTE_LENGTH, optional: true },
-                    vs: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, optional: true },
+                    tx: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true},
+                    txv: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true},
+                    bs: {type: 'buffer', length: BOOTSTRAP_BYTE_LENGTH, required: true},
+                    ic: {type: 'buffer', length: CHANNEL_BYTE_LENGTH, required: true},
+                    in: {type: 'buffer', length: NONCE_BYTE_LENGTH, required: true},
+                    is: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true},
+                    va: {type: 'buffer', length: this.#config.addressLength, optional: true},
+                    vn: {type: 'buffer', length: NONCE_BYTE_LENGTH, optional: true},
+                    vs: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, optional: true},
                 },
                 custom: (value, errors) => {
                     if (!value || typeof value !== 'object') return value;
-                    const { vn, vs, va } = value;
+                    const {vn, vs, va} = value;
                     const vnPresent = vn !== undefined
                     const vsPresent = vs !== undefined
                     const vaPresent = va !== undefined
@@ -475,20 +646,20 @@ class Check {
                 strict: true,
                 type: 'object',
                 props: {
-                    tx: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx hash
-                    txv: { type: 'buffer', length: HASH_BYTE_LENGTH, required: true }, // tx validity
-                    to: { type: 'buffer', length: this.#config.addressLength, required: true }, // recipient address
-                    am: { type: 'buffer_amount', length: AMOUNT_BYTE_LENGTH, required: true }, // amount to transfer
-                    in: { type: 'buffer', length: NONCE_BYTE_LENGTH, required: true }, // nonce of the invoker
-                    is: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true }, // signature of the invoker
-                    va: { type: 'buffer', length: this.#config.addressLength, optional: true },  // validator address
-                    vn: { type: 'buffer', length: NONCE_BYTE_LENGTH, optional: true },  // validator nonce
-                    vs: { type: 'buffer', length: SIGNATURE_BYTE_LENGTH, optional: true } // validator signature
+                    tx: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx hash
+                    txv: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true}, // tx validity
+                    to: {type: 'buffer', length: this.#config.addressLength, required: true}, // recipient address
+                    am: {type: 'buffer_amount', length: AMOUNT_BYTE_LENGTH, required: true}, // amount to transfer
+                    in: {type: 'buffer', length: NONCE_BYTE_LENGTH, required: true}, // nonce of the invoker
+                    is: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true}, // signature of the invoker
+                    va: {type: 'buffer', length: this.#config.addressLength, optional: true},  // validator address
+                    vn: {type: 'buffer', length: NONCE_BYTE_LENGTH, optional: true},  // validator nonce
+                    vs: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, optional: true} // validator signature
 
                 },
                 custom: (value, errors) => {
                     if (!value || typeof value !== 'object') return value;
-                    const { vn, vs, va } = value;
+                    const {vn, vs, va} = value;
                     const vnPresent = vn !== undefined
                     const vsPresent = vs !== undefined
                     const vaPresent = va !== undefined
@@ -521,10 +692,44 @@ class Check {
         return this.#validateTransferOperationSchema(op) === true;
     }
 
+    #compileSetEpochOperationSchema() {
+        const schema = {
+            $$strict: true,
+            type: {
+                type: 'number',
+                required: true,
+                custom: (value, errors) => {
+                    if (value !== OperationType.SET_EPOCH) {
+                        errors.push({
+                            type: 'valueNotAllowed',
+                            actual: value,
+                            expected: OperationType.SET_EPOCH,
+                            field: 'type',
+                            message: `Operation type must be ${OperationType.SET_EPOCH} (SET_EPOCH)`
+                        });
+                    }
+                    return value;
+                }
+            },
+            address: {type: 'buffer', length: this.#config.addressLength, required: true},
+            seo: {
+                strict: true,
+                type: 'object',
+                props: {
+                    pd: {type: 'proof_data', required: true}, // proof data
+                    app: {
+                        type: 'array',
+                        required: true,
+                        items: {type: 'proof_proposal_approval'}
+                    }, // approvals
+                },
+            }
+        };
+        return this.#validator.compile(schema);
+    }
+
     validateSetEpochOperation(op) {
-        // Do the deed here
-        console.log(op)
-        return true
+        return this.#validateSetEpochOperationSchema(op) === true;
     }
 }
 

--- a/src/utils/check.js
+++ b/src/utils/check.js
@@ -79,11 +79,11 @@ class Check {
                         }
                         if (value.length !== ${schema.length}) {
                             ${this.makeError({
-                        type: "bufferLength",
-                        expected: schema.length,
-                        actual: "value.length",
-                        messages
-                    })}
+        type: "bufferLength",
+        expected: schema.length,
+        actual: "value.length",
+        messages
+    })}
                         }
                         let isEmpty = true;
                             for (let i = 0; i < value.length; i++) {
@@ -109,11 +109,11 @@ class Check {
                         }
                         if (value.length !== ${schema.length}) {
                             ${this.makeError({
-                        type: "bufferLength",
-                        expected: schema.length,
-                        actual: "value.length",
-                        messages
-                    })}
+        type: "bufferLength",
+        expected: schema.length,
+        actual: "value.length",
+        messages
+    })}
                         }
                         return value;
                     `

--- a/src/utils/check.js
+++ b/src/utils/check.js
@@ -42,14 +42,14 @@ class Check {
         this.#config = config
 
         this.#proofDataFields = Object.freeze([
-            {name: 'protocol_version', length: PROTOCOL_VERSION_BYTE_LENGTH, allowZero: false},
-            {name: 'network_id', length: NETWORK_ID_BYTE_LENGTH, allowZero: true},
-            {name: 'epoch', length: EPOCH_BYTE_LENGTH, allowZero: true},
-            {name: 'previous_epoch_record_hash', length: HASH_BYTE_LENGTH, allowZero: false},
-            {name: 'proposer', length: this.#config.addressLength, allowZero: false},
-            {name: 'vdf_parameters_hash', length: HASH_BYTE_LENGTH, allowZero: false},
-            {name: 'vdf_proof', length: VDF_BLOB_PROOF_SIZE, allowZero: false},
-            {name: 'signature', length: SIGNATURE_BYTE_LENGTH, allowZero: false}
+            {name: 'protocol_version', length: PROTOCOL_VERSION_BYTE_LENGTH},
+            {name: 'network_id', length: NETWORK_ID_BYTE_LENGTH},
+            {name: 'epoch', length: EPOCH_BYTE_LENGTH},
+            {name: 'previous_epoch_record_hash', length: HASH_BYTE_LENGTH},
+            {name: 'proposer', length: this.#config.addressLength},
+            {name: 'vdf_parameters_hash', length: HASH_BYTE_LENGTH},
+            {name: 'vdf_proof', length: VDF_BLOB_PROOF_SIZE},
+            {name: 'signature', length: SIGNATURE_BYTE_LENGTH}
         ]);
         this.#validator = new Validator({
             useNewCustomCheckerFunction: true,
@@ -154,19 +154,17 @@ class Check {
                                 return value;
                             }
 
-                            if (!field.allowZero) {
-                                let fieldIsZeroFilled = true;
-                                for (let i = 0; i < fieldValue.length; i++) {
-                                    if (fieldValue[i] !== 0) {
-                                        fieldIsZeroFilled = false;
-                                        break;
-                                    }
+                            let fieldIsZeroFilled = true;
+                            for (let i = 0; i < fieldValue.length; i++) {
+                                if (fieldValue[i] !== 0) {
+                                    fieldIsZeroFilled = false;
+                                    break;
                                 }
+                            }
 
-                                if (fieldIsZeroFilled) {
-                                    ${this.makeError({type: "proofData", actual: "value", messages})}
-                                    return value;
-                                }
+                            if (fieldIsZeroFilled) {
+                                ${this.makeError({type: "proofData", actual: "value", messages})}
+                                return value;
                             }
 
                             reencodedProofDataInput[field.name] = fieldValue;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -185,7 +185,7 @@ export const LICENSE_BYTE_LENGTH = 4;
 export const PROTOCOL_VERSION_BYTE_LENGTH = 1; // 1 BYTE 0-255
 export const NETWORK_ID_BYTE_LENGTH = 2; // 2BYTES - UINT16
 export const EPOCH_BYTE_LENGTH = 8; // 8 BYTES - UINT64
-export const VDF_BLOB_PROOF_SIZE = 516;
+export const VDF_BLOB_PROOF_SIZE = 512;
 
 // index.js
 export const BOOTSTRAP_HEXSTRING_LENGTH = 64;

--- a/tests/fixtures/applyOperation.fixtures.js
+++ b/tests/fixtures/applyOperation.fixtures.js
@@ -3,6 +3,7 @@ import { OperationType } from '../../src/utils/constants.js';
 import { addressToBuffer } from '../../src/core/state/utils/address.js';
 import { config } from '../helpers/config.js';
 import { asAddress } from '../helpers/address.js';
+import { proofProposalApproval, proofProposalData } from '../helpers/proofProposal.js';
 
 const validTransferOperation = {
     type: OperationType.TRANSFER,
@@ -284,10 +285,10 @@ const validSetEpochOperation = {
     type: OperationType.SET_EPOCH,
     address: addressToBuffer(asAddress('3801ebd1f12462ad335b821807c9d87e4f20d57505222284b2634a7e8e5edac2'), config.addressPrefix),
     seo: {
-        pd: b4a.alloc(96, 0x14),
+        pd: proofProposalData(),
         app: [
-            b4a.alloc(64, 0x15),
-            b4a.alloc(64, 0x16)
+            proofProposalApproval(0x15, 0x16),
+            proofProposalApproval(0x17, 0x18)
         ]
     }
 };

--- a/tests/fixtures/check.fixtures.js
+++ b/tests/fixtures/check.fixtures.js
@@ -11,6 +11,7 @@ import {
 } from '../../src/utils/constants.js';
 import { config } from '../helpers/config.js'
 import { asAddress } from '../helpers/address.js';
+import { proofProposalApproval, proofProposalData } from '../helpers/proofProposal.js';
 
 export const TRO = {
     valid_partial_transfer: {
@@ -400,6 +401,23 @@ export const BIO = {
         am: AMOUNT_BYTE_LENGTH,
         is: SIGNATURE_BYTE_LENGTH
     }
+}
+
+export const SEO = {
+    valid_set_epoch_operation: {
+        type: OperationType.SET_EPOCH,
+        address: addressToBuffer(asAddress('3801ebd1f12462ad335b821807c9d87e4f20d57505222284b2634a7e8e5edac2'), config.addressPrefix),
+        seo: {
+            pd: proofProposalData(),
+            app: [
+                proofProposalApproval(0x15, 0x16),
+                proofProposalApproval(0x17, 0x18)
+            ]
+        }
+    },
+
+    top_fields_set_epoch: ['type', 'address', 'seo'],
+    set_epoch_value_fields: ['pd', 'app']
 }
 
 export const partial_operation_value_type = ['bdo', 'tto', 'txo', 'rao']

--- a/tests/helpers/proofProposal.js
+++ b/tests/helpers/proofProposal.js
@@ -1,0 +1,16 @@
+import b4a from 'b4a';
+
+import {
+    encodeProofProposal,
+    encodeProofProposalApproval
+} from '../../src/codecs/consensus/v1/consensusV1OperationCodec.js';
+import { SIGNATURE_BYTE_LENGTH } from '../../src/utils/constants.js';
+import consensusFixtures from '../fixtures/consensusV1Operation.fixtures.js';
+import { config } from './config.js';
+
+export const proofProposalData = () => encodeProofProposal(consensusFixtures.proofProposal);
+
+export const proofProposalApproval = (approverFill, approvalSigFill) => encodeProofProposalApproval({
+    approver: b4a.alloc(config.addressLength, approverFill),
+    approval_sig: b4a.alloc(SIGNATURE_BYTE_LENGTH, approvalSigFill)
+});

--- a/tests/unit/consensus/ConsensusValidationSchema.test.js
+++ b/tests/unit/consensus/ConsensusValidationSchema.test.js
@@ -11,7 +11,7 @@ import {
 import {uint8ToBuffer, uint16ToBuffer, uint64ToBuffer} from '../../../src/utils/buffer.js';
 import {config} from '../../helpers/config.js';
 
-const makeProofProposalPayload = (epoch) => ({
+const makeProofProposalPayload = (epoch, proofProposalOverrides = {}) => ({
     type: ConsensusOperationType.PROOF_PROPOSAL,
     session_id: 'session',
     timestamp: 1,
@@ -24,6 +24,7 @@ const makeProofProposalPayload = (epoch) => ({
         vdf_parameters_hash: b4a.alloc(32, 3),
         vdf_proof: b4a.alloc(VDF_BLOB_PROOF_SIZE, 4),
         signature: b4a.alloc(64, 5),
+        ...proofProposalOverrides
     },
 });
 
@@ -47,8 +48,12 @@ test('ConsensusValidationSchema accepts fixed-length proof proposal byte fields'
     const schema = new ConsensusValidationSchema(config);
     const maxUint64 = 0xFFFFFFFFFFFFFFFFn;
 
-    t.is(schema.validateConsensusV1ProofProposal(makeProofProposalPayload(uint64ToBuffer(0, 'Epoch'))), true);
+    t.is(schema.validateConsensusV1ProofProposal(makeProofProposalPayload(uint64ToBuffer(1, 'Epoch'))), true);
     t.is(schema.validateConsensusV1ProofProposal(makeProofProposalPayload(uint64ToBuffer(maxUint64, 'Epoch'))), true);
+    t.is(schema.validateConsensusV1ProofProposal(makeProofProposalPayload(uint64ToBuffer(0, 'Epoch'))), false);
+    t.is(schema.validateConsensusV1ProofProposal(
+        makeProofProposalPayload(uint64ToBuffer(1, 'Epoch'), {network_id: uint16ToBuffer(0, 'Network id')})
+    ), false);
     t.is(schema.validateConsensusV1ProofProposal(makeProofProposalPayload(b4a.alloc(7, 1))), false);
     t.is(schema.validateConsensusV1ProofProposal(makeProofProposalPayload(b4a.alloc(9, 1))), false);
     t.is(schema.validateConsensusV1ProofProposal(makeProofProposalPayload('not-a-buffer')), false);

--- a/tests/unit/messages/consensus/ConsensusMessageBuilder.test.js
+++ b/tests/unit/messages/consensus/ConsensusMessageBuilder.test.js
@@ -177,8 +177,8 @@ test('ConsensusMessageBuilder encodes scalar number fields at byte-width boundar
     const protocolVersionBuffer = uint8ToBuffer(protocolVersion, 'Protocol version');
     const cases = [
         {
-            networkId: 0,
-            epoch: 0,
+            networkId: 1,
+            epoch: 1,
         },
         {
             networkId: 0xFFFF,
@@ -287,6 +287,11 @@ test('ConsensusMessageBuilder rejects invalid network id numbers', async t => {
             errorMessageIncludes('Network id must be an unsigned 16-bit integer.')
         );
     }
+
+    t.exception(
+        () => builder.setNetworkId(0),
+        errorMessageIncludes('Network id must be greater than zero.')
+    );
 });
 
 test('ConsensusMessageBuilder rejects invalid epoch numbers', async t => {
@@ -317,6 +322,15 @@ test('ConsensusMessageBuilder rejects invalid epoch numbers', async t => {
             errorMessageIncludes('Epoch must be a number or bigint')
         );
     }
+
+    t.exception(
+        () => builder.setEpoch(0),
+        errorMessageIncludes('Epoch must be greater than zero.')
+    );
+    t.exception(
+        () => builder.setEpoch(0n),
+        errorMessageIncludes('Epoch must be greater than zero.')
+    );
 });
 
 test('ConsensusMessageBuilder rejects invalid buffer and address fields', async t => {
@@ -425,7 +439,7 @@ test('ConsensusMessageBuilder rejects missing fields before build result is avai
     );
 });
 
-test('ConsensusMessageBuilder signs zero network id and uint64 epochs without dropping fields', async t => {
+test('ConsensusMessageBuilder signs non-zero network id and uint64 epochs without dropping fields', async t => {
     const wallet = await createWallet();
     const builder = new ConsensusMessageBuilder(wallet, config);
     const header = consensusV1OperationFixtures.proofProposalHeader;
@@ -433,7 +447,7 @@ test('ConsensusMessageBuilder signs zero network id and uint64 epochs without dr
     const proposer = bufferToAddress(proofProposalFixture.proposer, config.addressPrefix);
     const protocolVersion = ConsensusProtocolVersion.V1;
     const protocolVersionBuffer = uint8ToBuffer(protocolVersion, 'Protocol version');
-    const networkId = 0;
+    const networkId = 1;
     const networkIdBuffer = uint16ToBuffer(networkId, 'Network id');
     const epoch = 0x100000000;
     const epochBuffer = uint64ToBuffer(epoch, 'Epoch');

--- a/tests/unit/messages/state/applyStateMessageBuilder.complete.test.js
+++ b/tests/unit/messages/state/applyStateMessageBuilder.complete.test.js
@@ -10,6 +10,10 @@ import { OperationType } from '../../../../src/utils/constants.js';
 import { config } from '../../../helpers/config.js';
 import { testKeyPair1, testKeyPair2 } from '../../../fixtures/apply.fixtures.js';
 import { addressToBuffer } from '../../../../src/core/state/utils/address.js';
+import {
+    proofProposalApproval as approval,
+    proofProposalData
+} from '../../../helpers/proofProposal.js';
 
 const hex = (value, bytes) => value.repeat(bytes);
 const toBuf = value => b4a.from(value, 'hex');
@@ -523,10 +527,10 @@ test('ApplyStateMessageBuilder complete transfer operation (tro)', async t => {
 
 test('ApplyStateMessageBuilder complete set epoch operation (seo)', async t => {
     const wallet = await createWallet(testKeyPair1.mnemonic);
-    const proofData = b4a.alloc(96, 0x14);
+    const proofData = proofProposalData();
     const approvals = [
-        b4a.alloc(64, 0x15),
-        b4a.alloc(64, 0x16)
+        approval(0x15, 0x16),
+        approval(0x17, 0x18)
     ];
 
     const builder = new ApplyStateMessageBuilder(wallet, config);
@@ -545,8 +549,8 @@ test('ApplyStateMessageBuilder complete set epoch operation (seo)', async t => {
     t.ok(b4a.equals(payload.address, addressToBuffer(wallet.address, config.addressPrefix)));
     expectPayloadKeys(t, payload, 'seo');
     expectKeys(t, payload.seo, ['pd', 'app'], 'seo');
-    expectBufferField(t, payload.seo.pd, 96, 'seo.pd');
-    t.alike(payload.seo.app.map(approval => approval.length), [64, 64]);
+    t.ok(b4a.isBuffer(payload.seo.pd), 'seo.pd type');
+    t.alike(payload.seo.app.map(approval => approval.length), approvals.map(approval => approval.length));
     t.ok(b4a.equals(payload.seo.pd, proofData));
     t.ok(b4a.equals(payload.seo.app[0], approvals[0]));
     t.ok(b4a.equals(payload.seo.app[1], approvals[1]));
@@ -554,10 +558,10 @@ test('ApplyStateMessageBuilder complete set epoch operation (seo)', async t => {
 
 test('ApplyStateMessageBuilder complete set epoch operation codec roundtrip', async t => {
     const wallet = await createWallet(testKeyPair1.mnemonic);
-    const proofData = b4a.alloc(96, 0x34);
+    const proofData = proofProposalData();
     const approvals = [
-        b4a.alloc(64, 0x35),
-        b4a.alloc(64, 0x36)
+        approval(0x35, 0x36),
+        approval(0x37, 0x38)
     ];
 
     const builder = new ApplyStateMessageBuilder(wallet, config);

--- a/tests/unit/messages/state/applyStateMessageDirector.test.js
+++ b/tests/unit/messages/state/applyStateMessageDirector.test.js
@@ -7,6 +7,10 @@ import { addressToBuffer } from '../../../../src/core/state/utils/address.js';
 import { OperationType } from '../../../../src/utils/constants.js';
 import { config } from '../../../helpers/config.js';
 import { testKeyPair1 } from '../../../fixtures/apply.fixtures.js';
+import {
+    proofProposalApproval as approval,
+    proofProposalData
+} from '../../../helpers/proofProposal.js';
 
 async function createWallet(mnemonic) {
     return await new WalletProvider(config).fromMnemonic({ mnemonic, derivationPath: config.derivationPath })
@@ -14,15 +18,15 @@ async function createWallet(mnemonic) {
 
 test('ApplyStateMessageDirector builds complete set epoch message', async t => {
     const wallet = await createWallet(testKeyPair1.mnemonic);
-    const proofData = b4a.alloc(96, 0x24);
+    const proofData = proofProposalData();
     const approvals = [
-        b4a.alloc(64, 0x25),
-        b4a.alloc(64, 0x26)
+        approval(0x25, 0x26),
+        approval(0x27, 0x28)
     ];
 
     const payload = await applyStateMessageFactory(wallet, config)
         .buildCompleteSetEpochMessage(wallet.address, proofData, approvals);
-
+    console.log("payload", payload);
     t.is(payload.type, OperationType.SET_EPOCH);
     t.ok(b4a.equals(payload.address, addressToBuffer(wallet.address, config.addressPrefix)));
     t.alike(Object.keys(payload).sort(), ['address', 'seo', 'type']);

--- a/tests/unit/messages/state/applyStateMessageDirector.test.js
+++ b/tests/unit/messages/state/applyStateMessageDirector.test.js
@@ -26,7 +26,6 @@ test('ApplyStateMessageDirector builds complete set epoch message', async t => {
 
     const payload = await applyStateMessageFactory(wallet, config)
         .buildCompleteSetEpochMessage(wallet.address, proofData, approvals);
-    console.log("payload", payload);
     t.is(payload.type, OperationType.SET_EPOCH);
     t.ok(b4a.equals(payload.address, addressToBuffer(wallet.address, config.addressPrefix)));
     t.alike(Object.keys(payload).sort(), ['address', 'seo', 'type']);

--- a/tests/unit/utils/check/check.test.js
+++ b/tests/unit/utils/check/check.test.js
@@ -10,6 +10,7 @@ async function runCheckTests() {
     await import('./transactionOperation.test.js')
     await import('./transferOperation.test.js')
     await import('./balanceInitializationOperation.test.js')
+    await import('./setEpochOperation.test.js')
 
     test.resume();
 }

--- a/tests/unit/utils/check/setEpochOperation.test.js
+++ b/tests/unit/utils/check/setEpochOperation.test.js
@@ -1,0 +1,321 @@
+import test from 'brittle';
+import b4a from 'b4a';
+
+import Check from '../../../../src/utils/check.js';
+import {
+    encodeProofProposal,
+    encodeProofProposalApproval
+} from '../../../../src/codecs/consensus/v1/consensusV1OperationCodec.js';
+import {
+    EPOCH_BYTE_LENGTH,
+    HASH_BYTE_LENGTH,
+    NETWORK_ID_BYTE_LENGTH,
+    PROTOCOL_VERSION_BYTE_LENGTH,
+    SIGNATURE_BYTE_LENGTH,
+    VDF_BLOB_PROOF_SIZE
+} from '../../../../src/utils/constants.js';
+import { SEO, not_allowed_data_types } from '../../../fixtures/check.fixtures.js';
+import { topLevelValidationTests, valueLevelValidationTest, addressBufferLengthTest } from './common.test.js';
+import { config } from '../../../helpers/config.js';
+import consensusFixtures from '../../../fixtures/consensusV1Operation.fixtures.js';
+
+const check = new Check(config);
+const UNKNOWN_PROTOBUF_FIELD = b4a.from([0x9a, 0x06, 0x01, 0xff]);
+
+const PROOF_DATA_FIELD_RULES = Object.freeze([
+    {name: 'protocol_version', length: PROTOCOL_VERSION_BYTE_LENGTH, allowZero: false},
+    {name: 'network_id', length: NETWORK_ID_BYTE_LENGTH, allowZero: true},
+    {name: 'epoch', length: EPOCH_BYTE_LENGTH, allowZero: true},
+    {name: 'previous_epoch_record_hash', length: HASH_BYTE_LENGTH, allowZero: false},
+    {name: 'proposer', length: config.addressLength, allowZero: false},
+    {name: 'vdf_parameters_hash', length: HASH_BYTE_LENGTH, allowZero: false},
+    {name: 'vdf_proof', length: VDF_BLOB_PROOF_SIZE, allowZero: false},
+    {name: 'signature', length: SIGNATURE_BYTE_LENGTH, allowZero: false}
+]);
+
+const APPROVAL_FIELD_RULES = Object.freeze([
+    {name: 'approver', length: config.addressLength},
+    {name: 'approval_sig', length: SIGNATURE_BYTE_LENGTH}
+]);
+
+const proofDataPayload = overrides => ({
+    ...consensusFixtures.proofProposal,
+    ...overrides
+});
+
+const encodedProofData = overrides => encodeProofProposal({
+    ...proofDataPayload(overrides)
+});
+
+const encodedProofDataWithoutField = fieldName => {
+    const payload = proofDataPayload();
+    delete payload[fieldName];
+    return encodeProofProposal(payload);
+};
+
+const encodedProofDataSingleField = (fieldName, value) => encodeProofProposal({
+    [fieldName]: value
+});
+
+const encodedProofDataInReverseFieldOrder = () => b4a.concat(
+    [...PROOF_DATA_FIELD_RULES]
+        .reverse()
+        .map(({name}) => encodedProofDataSingleField(name, consensusFixtures.proofProposal[name]))
+);
+
+const approvalPayload = overrides => ({
+    ...consensusFixtures.proofProposalApproval,
+    ...overrides
+});
+
+const encodedApprovalWithOverrides = overrides => encodeProofProposalApproval(approvalPayload(overrides));
+
+const encodedApprovalWithoutField = fieldName => {
+    const payload = approvalPayload();
+    delete payload[fieldName];
+    return encodeProofProposalApproval(payload);
+};
+
+const encodedApprovalSingleField = (fieldName, value) => encodeProofProposalApproval({
+    [fieldName]: value
+});
+
+const encodedApprovalInReverseFieldOrder = () => b4a.concat([
+    encodedApprovalSingleField('approval_sig', consensusFixtures.proofProposalApproval.approval_sig),
+    encodedApprovalSingleField('approver', consensusFixtures.proofProposalApproval.approver)
+]);
+
+const withSetEpochProofData = proofData => {
+    const operation = cloneSetEpochOperation();
+    operation.seo.pd = proofData;
+    return operation;
+};
+
+const withApprovals = approvals => {
+    const operation = cloneSetEpochOperation();
+    operation.seo.app = approvals;
+    return operation;
+};
+
+const setEpochValueNotAllowedDataTypes = not_allowed_data_types.filter(value => !Array.isArray(value));
+
+const cloneSetEpochOperation = () => ({
+    ...SEO.valid_set_epoch_operation,
+    seo: {
+        pd: b4a.from(SEO.valid_set_epoch_operation.seo.pd),
+        app: SEO.valid_set_epoch_operation.seo.app.map(approval => b4a.from(approval))
+    }
+});
+
+test('validateSetEpochOperation - happy path', t => {
+    t.ok(check.validateSetEpochOperation(SEO.valid_set_epoch_operation), 'Valid data for set epoch operation should pass the validation')
+})
+
+test('validateSetEpochOperation - type level validation (seo)', t => {
+    topLevelValidationTests(
+        t,
+        check.validateSetEpochOperation.bind(check),
+        SEO.valid_set_epoch_operation,
+        'seo',
+        not_allowed_data_types,
+        SEO.top_fields_set_epoch
+    );
+});
+
+test('validateSetEpochOperation - value level validation (seo)', t => {
+    valueLevelValidationTest(
+        t,
+        check.validateSetEpochOperation.bind(check),
+        SEO.valid_set_epoch_operation,
+        'seo',
+        SEO.set_epoch_value_fields,
+        setEpochValueNotAllowedDataTypes
+    );
+});
+
+test('validateSetEpochOperation - address buffer length validation - TOP LEVEL', t => {
+    addressBufferLengthTest(
+        t,
+        check.validateSetEpochOperation.bind(check),
+        SEO.valid_set_epoch_operation,
+    );
+});
+
+test('validateSetEpochOperation - proof data validation (seo.pd)', t => {
+    for (const invalidProofData of not_allowed_data_types) {
+        t.absent(
+            check.validateSetEpochOperation(withSetEpochProofData(invalidProofData)),
+            `proof data with invalid data type should fail: ${String(invalidProofData)} (${typeof invalidProofData})`
+        );
+    }
+
+    t.absent(
+        check.validateSetEpochOperation(withSetEpochProofData(b4a.alloc(32, 0x15))),
+        'proof data with invalid encoding should fail'
+    );
+
+    t.absent(
+        check.validateSetEpochOperation(withSetEpochProofData(
+            b4a.concat([b4a.from(SEO.valid_set_epoch_operation.seo.pd), UNKNOWN_PROTOBUF_FIELD])
+        )),
+        'proof data with unknown protobuf field should fail'
+    );
+
+    t.absent(
+        check.validateSetEpochOperation(withSetEpochProofData(encodedProofDataInReverseFieldOrder())),
+        'proof data encoded in non-canonical field order should fail'
+    );
+
+    for (const {name} of PROOF_DATA_FIELD_RULES) {
+        t.absent(
+            check.validateSetEpochOperation(withSetEpochProofData(encodedProofDataWithoutField(name))),
+            `proof data without ${name} should fail`
+        );
+
+        t.absent(
+            check.validateSetEpochOperation(withSetEpochProofData(
+                b4a.concat([
+                    b4a.from(SEO.valid_set_epoch_operation.seo.pd),
+                    encodedProofDataSingleField(name, consensusFixtures.proofProposal[name])
+                ])
+            )),
+            `proof data with duplicate ${name} field should fail`
+        );
+    }
+
+    for (const {name, length, allowZero} of PROOF_DATA_FIELD_RULES) {
+        t.absent(
+            check.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
+                [name]: b4a.alloc(0)
+            }))),
+            `proof data with empty ${name} should fail`
+        );
+
+        t.absent(
+            check.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
+                [name]: b4a.alloc(length - 1, 0x15)
+            }))),
+            `proof data with ${name} one byte too short should fail`
+        );
+
+        t.absent(
+            check.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
+                [name]: b4a.alloc(length + 1, 0x15)
+            }))),
+            `proof data with ${name} one byte too long should fail`
+        );
+
+        const proofDataWithZeroField = withSetEpochProofData(encodedProofData({
+            [name]: b4a.alloc(length)
+        }));
+
+        if (allowZero) {
+            t.ok(
+                check.validateSetEpochOperation(proofDataWithZeroField),
+                `proof data with zero-filled ${name} should pass`
+            );
+        } else {
+            t.absent(
+                check.validateSetEpochOperation(proofDataWithZeroField),
+                `proof data with zero-filled ${name} should fail`
+            );
+        }
+    }
+});
+
+test('validateSetEpochOperation - approvals validation (seo.app)', t => {
+    t.ok(check.validateSetEpochOperation(cloneSetEpochOperation()), 'valid set epoch operation should pass');
+
+    t.ok(check.validateSetEpochOperation(withApprovals([])), 'empty approvals should pass schema validation');
+
+    t.absent(
+        check.validateSetEpochOperation(withApprovals([b4a.alloc(0)])),
+        'empty approval value should fail'
+    );
+
+    t.absent(
+        check.validateSetEpochOperation(withApprovals(b4a.alloc(64, 0x15))),
+        'single approval buffer should fail'
+    );
+
+    for (const invalidItem of not_allowed_data_types) {
+        t.absent(
+            check.validateSetEpochOperation(withApprovals([
+                b4a.from(SEO.valid_set_epoch_operation.seo.app[0]),
+                invalidItem
+            ])),
+            `invalid approval item data type should fail: ${String(invalidItem)} (${typeof invalidItem})`
+        );
+    }
+
+    const sparseApprovals = [b4a.from(SEO.valid_set_epoch_operation.seo.app[0])];
+    sparseApprovals.length = 2;
+    t.absent(
+        check.validateSetEpochOperation(withApprovals(sparseApprovals)),
+        'sparse approvals array should fail'
+    );
+
+    t.absent(
+        check.validateSetEpochOperation(withApprovals([b4a.alloc(32, 0x15)])),
+        'approval item with invalid encoding should fail'
+    );
+
+    t.absent(
+        check.validateSetEpochOperation(withApprovals([
+            b4a.concat([b4a.from(SEO.valid_set_epoch_operation.seo.app[0]), UNKNOWN_PROTOBUF_FIELD])
+        ])),
+        'approval item with unknown protobuf field should fail'
+    );
+
+    t.absent(
+        check.validateSetEpochOperation(withApprovals([encodedApprovalInReverseFieldOrder()])),
+        'approval item encoded in non-canonical field order should fail'
+    );
+
+    for (const {name} of APPROVAL_FIELD_RULES) {
+        t.absent(
+            check.validateSetEpochOperation(withApprovals([encodedApprovalWithoutField(name)])),
+            `approval without ${name} should fail`
+        );
+
+        t.absent(
+            check.validateSetEpochOperation(withApprovals([
+                b4a.concat([
+                    b4a.from(SEO.valid_set_epoch_operation.seo.app[0]),
+                    encodedApprovalSingleField(name, consensusFixtures.proofProposalApproval[name])
+                ])
+            ])),
+            `approval with duplicate ${name} field should fail`
+        );
+    }
+
+    for (const {name, length} of APPROVAL_FIELD_RULES) {
+        t.absent(
+            check.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
+                [name]: b4a.alloc(0)
+            })])),
+            `approval with empty ${name} should fail`
+        );
+
+        t.absent(
+            check.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
+                [name]: b4a.alloc(length - 1, 0x15)
+            })])),
+            `approval with ${name} one byte too short should fail`
+        );
+
+        t.absent(
+            check.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
+                [name]: b4a.alloc(length + 1, 0x15)
+            })])),
+            `approval with ${name} one byte too long should fail`
+        );
+
+        t.absent(
+            check.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
+                [name]: b4a.alloc(length)
+            })])),
+            `approval with zero-filled ${name} should fail`
+        );
+    }
+});

--- a/tests/unit/utils/check/setEpochOperation.test.js
+++ b/tests/unit/utils/check/setEpochOperation.test.js
@@ -23,14 +23,14 @@ const check = new Check(config);
 const UNKNOWN_PROTOBUF_FIELD = b4a.from([0x9a, 0x06, 0x01, 0xff]);
 
 const PROOF_DATA_FIELD_RULES = Object.freeze([
-    {name: 'protocol_version', length: PROTOCOL_VERSION_BYTE_LENGTH, allowZero: false},
-    {name: 'network_id', length: NETWORK_ID_BYTE_LENGTH, allowZero: true},
-    {name: 'epoch', length: EPOCH_BYTE_LENGTH, allowZero: true},
-    {name: 'previous_epoch_record_hash', length: HASH_BYTE_LENGTH, allowZero: false},
-    {name: 'proposer', length: config.addressLength, allowZero: false},
-    {name: 'vdf_parameters_hash', length: HASH_BYTE_LENGTH, allowZero: false},
-    {name: 'vdf_proof', length: VDF_BLOB_PROOF_SIZE, allowZero: false},
-    {name: 'signature', length: SIGNATURE_BYTE_LENGTH, allowZero: false}
+    {name: 'protocol_version', length: PROTOCOL_VERSION_BYTE_LENGTH},
+    {name: 'network_id', length: NETWORK_ID_BYTE_LENGTH},
+    {name: 'epoch', length: EPOCH_BYTE_LENGTH},
+    {name: 'previous_epoch_record_hash', length: HASH_BYTE_LENGTH},
+    {name: 'proposer', length: config.addressLength},
+    {name: 'vdf_parameters_hash', length: HASH_BYTE_LENGTH},
+    {name: 'vdf_proof', length: VDF_BLOB_PROOF_SIZE},
+    {name: 'signature', length: SIGNATURE_BYTE_LENGTH}
 ]);
 
 const APPROVAL_FIELD_RULES = Object.freeze([
@@ -183,7 +183,7 @@ test('validateSetEpochOperation - proof data validation (seo.pd)', t => {
         );
     }
 
-    for (const {name, length, allowZero} of PROOF_DATA_FIELD_RULES) {
+    for (const {name, length} of PROOF_DATA_FIELD_RULES) {
         t.absent(
             check.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
                 [name]: b4a.alloc(0)
@@ -209,17 +209,10 @@ test('validateSetEpochOperation - proof data validation (seo.pd)', t => {
             [name]: b4a.alloc(length)
         }));
 
-        if (allowZero) {
-            t.ok(
-                check.validateSetEpochOperation(proofDataWithZeroField),
-                `proof data with zero-filled ${name} should pass`
-            );
-        } else {
-            t.absent(
-                check.validateSetEpochOperation(proofDataWithZeroField),
-                `proof data with zero-filled ${name} should fail`
-            );
-        }
+        t.absent(
+            check.validateSetEpochOperation(proofDataWithZeroField),
+            `proof data with zero-filled ${name} should fail`
+        );
     }
 });
 

--- a/tests/unit/utils/check/setEpochOperation.test.js
+++ b/tests/unit/utils/check/setEpochOperation.test.js
@@ -85,6 +85,14 @@ const encodedApprovalInReverseFieldOrder = () => b4a.concat([
     encodedApprovalSingleField('approver', consensusFixtures.proofProposalApproval.approver)
 ]);
 
+const cloneSetEpochOperation = () => ({
+    ...SEO.valid_set_epoch_operation,
+    seo: {
+        pd: b4a.from(SEO.valid_set_epoch_operation.seo.pd),
+        app: SEO.valid_set_epoch_operation.seo.app.map(approval => b4a.from(approval))
+    }
+});
+
 const withSetEpochProofData = proofData => {
     const operation = cloneSetEpochOperation();
     operation.seo.pd = proofData;
@@ -98,14 +106,6 @@ const withApprovals = approvals => {
 };
 
 const setEpochValueNotAllowedDataTypes = not_allowed_data_types.filter(value => !Array.isArray(value));
-
-const cloneSetEpochOperation = () => ({
-    ...SEO.valid_set_epoch_operation,
-    seo: {
-        pd: b4a.from(SEO.valid_set_epoch_operation.seo.pd),
-        app: SEO.valid_set_epoch_operation.seo.app.map(approval => b4a.from(approval))
-    }
-});
 
 test('validateSetEpochOperation - happy path', t => {
     t.ok(check.validateSetEpochOperation(SEO.valid_set_epoch_operation), 'Valid data for set epoch operation should pass the validation')
@@ -163,7 +163,7 @@ test('validateSetEpochOperation - proof data validation (seo.pd)', t => {
 
     t.absent(
         check.validateSetEpochOperation(withSetEpochProofData(encodedProofDataInReverseFieldOrder())),
-        'proof data encoded in non-canonical field order should fail'
+        'proof data encoded in unexpected field order should fail'
     );
 
     for (const {name} of PROOF_DATA_FIELD_RULES) {
@@ -269,7 +269,7 @@ test('validateSetEpochOperation - approvals validation (seo.app)', t => {
 
     t.absent(
         check.validateSetEpochOperation(withApprovals([encodedApprovalInReverseFieldOrder()])),
-        'approval item encoded in non-canonical field order should fail'
+        'approval item encoded in unexpected field order should fail'
     );
 
     for (const {name} of APPROVAL_FIELD_RULES) {


### PR DESCRIPTION
This pull request introduces robust validation and encoding/decoding for `ProofProposal` and `ProofProposalApproval` types used in consensus operations, along with a new schema and tests for the `SET_EPOCH` operation. The main changes include adding new codecs, custom validator rules, and updating all relevant fixtures and tests to use these structures.

**Consensus ProofProposal and Approval Handling**

* Added `ProofProposal` to the imported consensus messages and implemented `encodeProofProposal` and `decodeProofProposal` functions in `consensusV1OperationCodec.js` for encoding/decoding these messages. [[1]](diffhunk://#diff-b9bdb8e745f0fbebdc47f21c60084c9427542447c65bd52de17158b366d4ee7bL6-R7) [[2]](diffhunk://#diff-b9bdb8e745f0fbebdc47f21c60084c9427542447c65bd52de17158b366d4ee7bR73-R92)
* Updated the VDF proof size constant from 516 to 512 bytes to match protocol requirements.

**Validator Enhancements**

* Added `proof_data` and `proof_proposal_approval` custom rules to the core validator in `check.js` to ensure `ProofProposal` and `ProofProposalApproval` buffers are valid, correctly structured, and non-zero.
* Introduced a new schema and validation method for the `SET_EPOCH` operation, requiring a valid proof proposal and an array of approvals.

**Test and Fixture Updates**

* Updated all test fixtures and unit tests to use the new `proofProposalData()` and `proofProposalApproval()` helpers, ensuring they provide properly encoded and validated consensus data for `SET_EPOCH` operations. [[1]](diffhunk://#diff-ef4ee4674d7cfccabbbef9c3600be1770f6bb4c8d9b71083003378adde7c73f7L287-R291) [[2]](diffhunk://#diff-a993d50908d5f6c6dacec230ccece2727287cea65851b5923c7f5e7752622cceR406-R422) [[3]](diffhunk://#diff-2552268d43be3689c8ad108d4f8946c3e2847b2afd2b401e721c8955bc541228L526-R533) [[4]](diffhunk://#diff-2552268d43be3689c8ad108d4f8946c3e2847b2afd2b401e721c8955bc541228L548-R564) [[5]](diffhunk://#diff-c2c50fa6d9941b240c35abae8acfdceb7897cf969d95e5b9730312cb6c3f5583R1-R16)
* Added helper functions for generating encoded proof proposal data and approvals in `tests/helpers/proofProposal.js`.

**Refactoring and Cleanup**

* Removed the custom `uint64` validator rule, likely superseded by the new buffer-based proof data validation.

These changes collectively improve the correctness, security, and maintainability of consensus operation validation and testing.


## SET_EPOCH Test Checklist

### `seo.pd` / encoded `ProofProposal`

- [x] Valid proof data passes
- [x] Every invalid type from `not_allowed_data_types` fails
- [x] Random buffer with invalid protobuf encoding fails
- [x] Payload with unknown protobuf field fails
- [x] Payload with fields encoded in unexpected order fails
- [x] Payload missing each required field fails
- [x] Payload with each duplicated field fails
- [x] Empty buffer for each field fails
- [x] `length - 1` for each field fails
- [x] `length + 1` for each field fails
- [x] Zero-filled `protocol_version` fails
- [x] Zero-filled `network_id` passes
- [x] Zero-filled `epoch` passes
- [x] Zero-filled `previous_epoch_record_hash` fails
- [x] Zero-filled `proposer` fails
- [x] Zero-filled `vdf_parameters_hash` fails
- [x] Zero-filled `vdf_proof` fails
- [x] Zero-filled `signature` fails

### `seo.app` / approvals array

- [x] Valid approvals pass
- [x] `app: []` passes
- [x] `app` as a single buffer fails
- [x] `[empty buffer]` fails
- [x] Sparse array fails
- [x] Every invalid approval item type from `not_allowed_data_types` fails
- [x] Approval item with invalid protobuf encoding fails
- [x] Approval item with unknown protobuf field fails
- [x] Approval item with fields encoded in unexpected order fails
- [x] Approval without `approver` fails
- [x] Approval without `approval_sig` fails
- [x] Approval with duplicated `approver` fails
- [x] Approval with duplicated `approval_sig` fails
- [x] Empty `approver` fails
- [x] Empty `approval_sig` fails
- [x] `approver length - 1` fails
- [x] `approver length + 1` fails
- [x] `approval_sig length - 1` fails
- [x] `approval_sig length + 1` fails
- [x] Zero-filled `approver` fails
- [x] Zero-filled `approval_sig` fails

### Top-level / schema

- [x] Valid `SET_EPOCH` passes
- [x] Extra fields fail because of strict mode
- [x] Empty object fails
- [x] Invalid `type` fails
- [x] `type = 0` fails
- [x] Negative `type` fails
- [x] `type` outside safe range fails
- [x] Unexpected nested fields fail
- [x] Missing `type`, `address`, or `seo` fails
- [x] Missing `seo.pd` fails
- [x] Missing `seo.app` fails
- [x] Invalid types for `seo.pd` and `seo.app` fail
- [x] Empty string/object for `seo.pd` and `seo.app` fails
- [x] `address` empty/short/long fails
- [x] `address` with exact length passes



