### PR TITLE
feat: extract scheduler

### DIFF
--- a/src/core/consensus/services/EpochProofProposalService.js
+++ b/src/core/consensus/services/EpochProofProposalService.js
@@ -1,6 +1,6 @@
 import ReadyResource from 'ready-resource';
 import b4a from 'b4a';
-import Scheduler from '../../../utils/Scheduler.js';
+import Scheduler from '../../../utils/scheduler/Scheduler.js';
 import { OperationType } from '../../../utils/constants.js';
 import { Logger } from '../../../utils/logger.js';
 

--- a/src/core/network/Network.js
+++ b/src/core/network/Network.js
@@ -111,9 +111,9 @@ class Network extends ReadyResource {
 
     async _close() {
         this.#logger.info('Network: closing gracefully...');
-        await this.transactionPoolService.stopPool();
+        await this.transactionPoolService.stop();
         await sleep(100);
-        await this.#validatorObserverService.stopValidatorObserver();
+        await this.#validatorObserverService.stop();
         if (this.#validatorHealthCheckService) {
             await this.#validatorHealthCheckService.close();
         }
@@ -230,7 +230,6 @@ class Network extends ReadyResource {
 
             this.#epochProofProposalService = new EpochProofProposalService(this.#state, this.#validatorConnectionManager, this.#wallet, this.#config);
             await this.#epochProofProposalService.ready();
-            // this.#epochProofProposalService.start();
 
             this.#validatorConnectionManager.subscribeToHealthChecks(this.#validatorHealthCheckService);
 

--- a/src/core/network/services/TransactionPoolService.js
+++ b/src/core/network/services/TransactionPoolService.js
@@ -1,6 +1,6 @@
 // PoolService.js
 import { BATCH_SIZE } from '../../../utils/constants.js';
-import Scheduler from '../../../utils/Scheduler.js';
+import SchedulableService from '../../../utils/scheduler/SchedulableService.js';
 import Denque from "denque";
 import b4a from "b4a";
 
@@ -43,13 +43,12 @@ export class TransactionPoolAlreadyQueuedError extends Error {
     }
 }
 
-class TransactionPoolService {
+class TransactionPoolService extends SchedulableService {
     #state;
     #address;
     #config;
     #txPool = new Denque();
     #transactionCommitService
-    #scheduler = null;
     #queuedTxHashes
 
     /**
@@ -59,6 +58,7 @@ class TransactionPoolService {
      * @param {Config} config
      **/
     constructor(state, address, transactionCommitService, config) {
+        super();
         this.#state = state;
         this.#address = address;
         this.#transactionCommitService = transactionCommitService;
@@ -79,16 +79,15 @@ class TransactionPoolService {
             console.info('TransactionPoolService can not start. Wallet is not enabled');
             return;
         }
-        if (this.#scheduler && this.#scheduler.isRunning) {
-            console.info('TransactionPoolService is already started');
-            return;
-        }
 
-        this.#scheduler = this.#createScheduler();
-        this.#scheduler.start();
+        return super.start();
     }
 
-    async #worker(next) {
+    getScheduleInterval() {
+        return this.#config.processIntervalMs;
+    }
+
+    async worker(next) {
         try {
             await this.#processTransactions();
             if (this.#txPool.size() > 0) {
@@ -99,10 +98,6 @@ class TransactionPoolService {
         } catch (error) {
             throw new Error(`TransactionPoolService worker error: ${error.message}`);
         }
-    }
-
-    #createScheduler() {
-        return new Scheduler((next) => this.#worker(next), this.#config.processIntervalMs);
     }
 
     async #processTransactions() {
@@ -187,10 +182,8 @@ class TransactionPoolService {
         this.txPool.push(txData);
     }
 
-    async stopPool(waitForCurrent = true) {
-        if (!this.#scheduler) return;
-        await this.#scheduler.stop(waitForCurrent);
-        this.#scheduler = null;
+    async stop(waitForCurrent = true) {
+        await super.stop(waitForCurrent);
         this.#queuedTxHashes.clear();
         this.#txPool.clear();
         console.info('TransactionPoolService: closing gracefully...');

--- a/src/core/network/services/ValidatorObserverService.js
+++ b/src/core/network/services/ValidatorObserverService.js
@@ -1,4 +1,4 @@
-import Scheduler from "../../../utils/Scheduler.js";
+import SchedulableService from "../../../utils/scheduler/SchedulableService.js";
 import { Logger } from "../../../utils/logger.js";
 import b4a from "b4a";
 import { bufferToAddress } from "../../../core/state/utils/address.js";
@@ -9,18 +9,16 @@ import { WRITER_BYTE_LENGTH, CONNECTION_STATUS } from "../../../utils/constants.
 const VALIDATOR_CANDIDATES_PER_CYCLE = 10;
 const MAX_KEY_DECODE_CACHE_SIZE = 10_000;
 
-class ValidatorObserverService {
+class ValidatorObserverService extends SchedulableService {
     #network;
     #state;
     #address;
     #config;
-    #scheduler;
     #logger;
     #hasBootstrapped;    // Whether initial connection phase is complete
     #bootstrapStartedAt; // Timestamp to enforce bootstrap timeout
     #adminCache;         // Cached admin entry with TTL
     #writersCache;       // Cached writer list with dynamic TTL
-    #isInterrupted;      // Used to stop execution mid-cycle
     #keyDecodeCache;
 
     /**
@@ -30,6 +28,7 @@ class ValidatorObserverService {
      * @param {Object} config - The application configuration object.
      */
     constructor(network, state, address, config) {
+        super();
         this.#network = network;
         this.#state = state;
         this.#address = address;
@@ -39,18 +38,9 @@ class ValidatorObserverService {
         this.#bootstrapStartedAt = 0;
         this.#adminCache = { entry: null, lastUpdated: 0 };
         this.#writersCache = { list: [], lastUpdated: 0 };
-        this.#isInterrupted = false;
         this.#keyDecodeCache = new Map();
     }
 
-    /**
-     * Returns configurable poll interval.
-     * @returns {number} The poll interval in milliseconds.
-     */
-    #getPollInterval() {
-        return this.#config.pollInterval;
-    }
-    
     /**
      * Selects a subset of valid validator candidates to connect to.
      *
@@ -167,7 +157,7 @@ class ValidatorObserverService {
      * @returns {boolean} True if the observer is enabled and not interrupted.
      */
     #shouldRun() {
-        return this.#config.enableValidatorObserver && !this.#isInterrupted;
+        return this.#config.enableValidatorObserver && !this.isInterrupted;
     }
     
     /**
@@ -213,18 +203,10 @@ class ValidatorObserverService {
             this.#logger.info('ValidatorObserverService can not start. Disabled by configuration.');
             return;
         }
-        
-        if (this.#scheduler && this.#scheduler.isRunning) {
-            this.#logger.info('ValidatorObserverService is already started');
-            return;
-        }
 
-        const interval = this.#getPollInterval();
-        this.#scheduler = new Scheduler((next) => this.#worker(next), interval);
         this.#bootstrapStartedAt = Date.now();
         this.#hasBootstrapped = false;
-        this.#isInterrupted = false;
-        this.#scheduler.start();
+        super.start();
         this.#logger.debug("ValidatorObserverService started");
     }
 
@@ -233,13 +215,9 @@ class ValidatorObserverService {
      * Prevents new work and waits for the current cycle to finish if requested.
      * @param {boolean} [waitForCurrent=true] - Whether to wait for the current worker cycle to finish.
      */
-    async stopValidatorObserver(waitForCurrent = true) {
-        if (!this.#scheduler) return;
-
-        this.#isInterrupted = true;
-
-        await this.#scheduler.stop(waitForCurrent);
-        this.#scheduler = null;
+    async stop(waitForCurrent = true) {
+        const stopped = await super.stop(waitForCurrent);
+        if (!stopped) return;
         this.#logger.debug("ValidatorObserverService stopped");
     }
 
@@ -254,9 +232,16 @@ class ValidatorObserverService {
      * 5. Attempt connections (with pacing).
      * @param {Function} next - Callback to schedule the next execution.
      */
-    async #worker(next) {
-        const interval = this.#getPollInterval();
-        if (!this.#shouldRun()) return next(interval);
+    getScheduleInterval() {
+        return this.#config.pollInterval;
+    }
+
+    async worker(next) {
+        const interval = this.#config.pollInterval;
+        if (!this.#shouldRun()) {
+            next(interval);
+            return;
+        }
 
         try {
             const adminEntry = await this.#getAdminEntryCached();

--- a/src/utils/scheduler/SchedulableService.js
+++ b/src/utils/scheduler/SchedulableService.js
@@ -1,0 +1,102 @@
+import ReadyResource from 'ready-resource';
+import Scheduler from './Scheduler.js';
+
+/**
+ * Base class for services that execute recurring work through the shared scheduler.
+ *
+ * Subclasses should implement:
+ * - {@link SchedulableService#getScheduleInterval}
+ * - {@link SchedulableService#worker}
+ */
+class SchedulableService extends ReadyResource {
+    #scheduler = null;
+    #isInterrupted = false;
+
+    /**
+     * Returns the default interval in milliseconds used between scheduled runs.
+     *
+     * @protected
+     * @returns {number}
+     */
+    getScheduleInterval() {
+        return 0;
+    }
+
+    /**
+     * Runs a single scheduled cycle.
+     *
+     * Call `next(delayMs)` to override the next run delay; otherwise the scheduler uses
+     * {@link SchedulableService#getScheduleInterval}.
+     *
+     * @protected
+     * @param {(delayMs: number) => void} _next
+     * @returns {Promise<void>|void}
+     */
+    worker(_next) {}
+
+    /**
+     * Indicates whether the service has requested interruption of scheduled work.
+     *
+     * @protected
+     * @returns {boolean}
+     */
+    get isInterrupted() {
+        return this.#isInterrupted;
+    }
+
+    /**
+     * Indicates whether the scheduler is currently running.
+     *
+     * @protected
+     * @returns {boolean}
+     */
+    get isSchedulerRunning() {
+        return this.#scheduler?.isRunning ?? false;
+    }
+
+    /**
+     * Starts the scheduler if it is not already running.
+     *
+     * @param {number} [initialDelayMs=0]
+     * @returns {boolean}
+     */
+    start(initialDelayMs = 0) {
+        this.#ensureScheduler();
+        if (this.isSchedulerRunning) {
+            console.info(`${this.constructor.name} is already started`);
+            return false;
+        }
+
+        this.#isInterrupted = false;
+        this.#scheduler.start(initialDelayMs);
+        return true;
+    }
+
+    /**
+     * Stops the scheduler if it is currently running.
+     *
+     * @param {boolean} [waitForCurrent=true]
+     * @returns {Promise<boolean>}
+     */
+    async stop(waitForCurrent = true) {
+        if (!this.isSchedulerRunning) return false;
+
+        this.#isInterrupted = true;
+        await this.#scheduler.stop(waitForCurrent);
+        return true;
+    }
+
+    async _close() {
+        await this.stop(true);
+    }
+
+    #ensureScheduler() {
+        if (this.#scheduler) return;
+        this.#scheduler = new Scheduler(
+            (next) => this.worker(next),
+            this.getScheduleInterval(),
+        );
+    }
+}
+
+export default SchedulableService;

--- a/src/utils/scheduler/Scheduler.js
+++ b/src/utils/scheduler/Scheduler.js
@@ -70,7 +70,7 @@ class Scheduler {
 
         this.#currentWorkerRun = this.#worker(scheduleNext);
         try {
-            await this.#currentWorkerRun; // this await is needed here because #worker can be async
+            await this.#currentWorkerRun;
         } catch (error) {
             console.error('Worker error:', error);
             return this.defaultInterval;
@@ -102,7 +102,7 @@ class Scheduler {
         }
 
         if (waitForCurrent && this.#currentWorkerRun) {
-            await this.#currentWorkerRun; // this await is needed here because #worker can be async
+            await this.#currentWorkerRun;
         }
     }
 }

--- a/tests/unit/network/Network.test.js
+++ b/tests/unit/network/Network.test.js
@@ -17,11 +17,6 @@ async function loadNetwork() {
     let swarmInstance = null;
     let connectionManagerInstance = null;
 
-    class StateMock extends EventEmitter {
-        isAdmin() {return false}
-        isIndexer() {return false}
-    }
-
     class HyperswarmMock extends EventEmitter {
         constructor() {
             super();
@@ -82,12 +77,12 @@ async function loadNetwork() {
 
     class TransactionPoolServiceMock {
         start() {}
-        async stopPool() {}
+        async stop() {}
     }
 
     class ValidatorObserverServiceMock {
         start() {}
-        async stopValidatorObserver() {}
+        async stop() {}
     }
 
     class MessageOrchestratorMock {
@@ -173,7 +168,12 @@ async function loadNetwork() {
     };
 
     const store = new CorestoreMock();
-    const state = new StateMock();
+    const state = {
+        on() {},
+        removeAllListeners() {},
+        isAdmin: async () => false,
+        isIndexer: () => false,
+    };
     const network = new Network(state, store, config, wallet);
     await network.ready()
 

--- a/tests/unit/network/services/TransactionPoolService.test.js
+++ b/tests/unit/network/services/TransactionPoolService.test.js
@@ -86,7 +86,7 @@ test('TransactionPoolService processes queued transaction and resolves commit wi
         t.ok(Number.isSafeInteger(receipt.blockNumber), 'blockNumber is safe integer');
         t.ok(receipt.blockNumber >= 0, 'blockNumber is non-negative');
     } finally {
-        await poolService.stopPool();
+        await poolService.stop();
         txCommitService.close();
         clock.restore();
     }
@@ -137,7 +137,7 @@ test('TransactionPoolService processes batch of 10 queued transactions and resol
             t.ok(receipt.proof.length > 0, `proof is non-empty for tx ${txHash}`);
         }
     } finally {
-        await poolService.stopPool();
+        await poolService.stop();
         txCommitService.close();
         clock.restore();
     }
@@ -198,7 +198,7 @@ test('TransactionPoolService rejects pending commit when proof is unavailable', 
             t.is(error.reason, 'proof-missing');
         }
     } finally {
-        await service.stopPool();
+        await service.stop();
         txCommitService.close();
         clock.restore();
     }
@@ -239,7 +239,7 @@ test('TransactionPoolService rejects pending commit when commit receipt is missi
             t.ok(error instanceof TransactionPoolMissingCommitReceiptError);
         }
     } finally {
-        await service.stopPool();
+        await service.stop();
         txCommitService.close();
         clock.restore();
     }
@@ -280,7 +280,7 @@ test('TransactionPoolService rejects all pending commits when appendWithProofOfP
         t.is(results[0].status, 'rejected');
         t.is(results[1].reason, appendError);
     } finally {
-        await service.stopPool();
+        await service.stop();
         txCommitService.close();
         clock.restore();
     }
@@ -312,7 +312,7 @@ test('TransactionPoolService.start is idempotent when scheduler is already runni
         t.ok(logs.some(m => m.includes('TransactionPoolService is already started')));
     } finally {
         console.info = originalInfo;
-        await service.stopPool();
+        await service.stop();
     }
 });
 
@@ -341,7 +341,7 @@ test('TransactionPoolService schedules immediate follow-up run when queue remain
 
         t.ok(appendCalls >= 2, 'queue processed in at least two batches before interval');
     } finally {
-        await service.stopPool();
+        await service.stop();
         clock.restore();
     }
 });
@@ -372,7 +372,7 @@ test('TransactionPoolService wraps worker errors from validation permission chec
         t.ok(workerError, 'worker error is wrapped');
     } finally {
         console.error = originalError;
-        await service.stopPool();
+        await service.stop();
         clock.restore();
     }
 });
@@ -387,6 +387,6 @@ test('TransactionPoolService.start does nothing when wallet is disabled', async 
         t.ok(logs.some(m => m.includes('Wallet is not enabled')));
     } finally {
         console.info = originalInfo;
-        await service.stopPool();
+        await service.stop();
     }
 });

--- a/tests/unit/network/services/ValidatorObserverLifecycle.test.js
+++ b/tests/unit/network/services/ValidatorObserverLifecycle.test.js
@@ -26,7 +26,7 @@ const defaultMockDecode = (addr) => {
 async function cleanup(service) {
     tracCryptoApi.address.decode = originalDecode;
     if (service) {
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
     }
 }
 
@@ -107,7 +107,7 @@ test("connects successfully (happy path)", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.ok(calls > 0);
     } finally {
@@ -156,7 +156,7 @@ test("rotation allows multiple attempts", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.ok(calls >= 2);
     } finally {
@@ -188,7 +188,7 @@ test("does NOT connect if already connected", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.is(calls, 0);
     } finally {
@@ -219,7 +219,7 @@ test("does NOT connect if not writer", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.is(calls, 0);
     } finally {
@@ -251,7 +251,7 @@ test("does NOT connect if max reached", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.is(calls, 0);
     } finally {
@@ -283,7 +283,7 @@ test("blocks when too many pending", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.is(calls, 0);
     } finally {
@@ -315,7 +315,7 @@ test("returns early when no candidates available", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.is(calls, 0);
     } finally {
@@ -361,7 +361,7 @@ test("bootstrap switches to long TTL after timeout", async (t) => {
         clock.tick(31_000);
         await Promise.resolve();
 
-        await service.stopValidatorObserver(true);
+        await service.stop(true);
 
         t.ok(scans >= before);
     } finally {
@@ -407,7 +407,7 @@ test("does NOT drop connections when it is the admin and threshold reached", asy
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.alike(removed, []);
     } finally {
@@ -466,7 +466,7 @@ test("removes admin when threshold exceeded", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.ok(removed >= 1);
     } finally {
@@ -516,7 +516,7 @@ test("removes stale connections when writer is marked as removed", async (t) => 
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.ok(removed > 0);
     } finally {
@@ -563,7 +563,7 @@ test("does not remove stale connection if not connected", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver(false);
+        await service.stop(false);
 
         t.is(removed, 0);
     } finally {
@@ -579,7 +579,7 @@ test("does not start observer if it is already running", async (t) => {
 
     await service.start();
     await service.start();
-    await service.stopValidatorObserver();
+    await service.stop();
 
     t.pass();
 });
@@ -603,7 +603,7 @@ test("gracefully catches exceptions in the worker loop", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver();
+        await service.stop();
 
         t.pass();
     } finally {
@@ -636,7 +636,7 @@ test("gracefully catches exceptions in scanAutobaseWriters", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver();
+        await service.stop();
 
         t.pass();
     } finally {
@@ -665,7 +665,7 @@ test("gracefully catches exceptions in tryConnect", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver();
+        await service.stop();
 
         t.pass();
     } finally {
@@ -694,7 +694,7 @@ test("caches null if the address buffer is invalid or missing", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver();
+        await service.stop();
 
         t.pass();
     } finally {
@@ -722,7 +722,7 @@ test("caches null if public key fails to decode", async (t) => {
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver();
+        await service.stop();
 
         t.pass();
     } finally {
@@ -766,7 +766,7 @@ test("clears memory cache when exceeding MAX_KEY_DECODE_CACHE_SIZE", async (t) =
             await Promise.resolve();
         }
 
-        await service.stopValidatorObserver();
+        await service.stop();
 
         t.pass();
     } finally {


### PR DESCRIPTION
The purpose of this is to extract a schedulable job logic into its own class. Define a clear interface so we just use public methods and unify the lifecycle methods of the services that operate with it. Ideally, they wouldnt "know" about this.#scheduler but rather the interface of the super class that uses it. This will offload stuff from the epoch service that, right now, is extremely ugly. This also proposes a common interface of a schedulable job as something that can be "open" and "closed", "stop" and "started". Maybe in the future we could even treat them as a composite in the network or state (lets not get into this rn).