### PR TITLE
refactor: rename Check to StateValidationSchema and update references

### DIFF
--- a/src/core/network/protocols/shared/validators/PartialOperationValidator.js
+++ b/src/core/network/protocols/shared/validators/PartialOperationValidator.js
@@ -1,6 +1,6 @@
 import b4a from 'b4a';
 import tracCryptoApi from 'trac-crypto-api';
-import Check from '../../../../../utils/check.js';
+import StateValidationSchema from '../../../../state/validators/StateValidationSchema.js';
 import {bufferToAddress} from "../../../../state/utils/address.js";
 import {createMessage} from "../../../../../utils/buffer.js";
 import {OperationType, ResultCode, PUBLIC_KEY_LENGTH} from "../../../../../utils/constants.js";
@@ -14,14 +14,14 @@ const FEE_BIGINT = bufferToBigInt(FEE);
 
 class PartialOperationValidator {
     #state;
-    #check;
+    #stateValidationSchema;
     #config
     #selfAddress
 
     constructor(state, selfAddress, config) {
         this.#state = state;
         this.#config = config;
-        this.#check = new Check(this.#config);
+        this.#stateValidationSchema = new StateValidationSchema(this.#config);
         this.max_amount = MAX_AMOUNT;
         this.fee = FEE_BIGINT;
         this.#selfAddress = selfAddress;
@@ -31,8 +31,8 @@ class PartialOperationValidator {
         return this.#state;
     }
 
-    get check() {
-        return this.#check;
+    get stateValidationSchema() {
+        return this.#stateValidationSchema;
     }
 
     async validate() {
@@ -44,25 +44,25 @@ class PartialOperationValidator {
             throw new V1ProtocolError(ResultCode.TX_INVALID_PAYLOAD, 'Payload or payload type is missing.');
         }
 
-        const selectedValidator = this.#selectCheckSchemaValidator(payload.type);
+        const selectedValidator = this.#selectStateSchemaValidator(payload.type);
         const isPayloadValid = selectedValidator(payload);
         if (!isPayloadValid) {
             throw new V1ProtocolError(ResultCode.SCHEMA_VALIDATION_FAILED, 'Payload is invalid.');
         }
     }
 
-    #selectCheckSchemaValidator(type) {
+    #selectStateSchemaValidator(type) {
         switch (type) {
             case OperationType.ADD_WRITER:
             case OperationType.REMOVE_WRITER:
             case OperationType.ADMIN_RECOVERY:
-                return this.check.validateRoleAccessOperation.bind(this.check);
+                return this.stateValidationSchema.validateRoleAccessOperation.bind(this.stateValidationSchema);
             case OperationType.BOOTSTRAP_DEPLOYMENT:
-                return this.check.validateBootstrapDeploymentOperation.bind(this.check);
+                return this.stateValidationSchema.validateBootstrapDeploymentOperation.bind(this.stateValidationSchema);
             case OperationType.TX:
-                return this.check.validateTransactionOperation.bind(this.check);
+                return this.stateValidationSchema.validateTransactionOperation.bind(this.stateValidationSchema);
             case OperationType.TRANSFER:
-                return this.check.validateTransferOperation.bind(this.check);
+                return this.stateValidationSchema.validateTransferOperation.bind(this.stateValidationSchema);
             default:
                 throw new V1ProtocolError(
                     ResultCode.OPERATION_TYPE_UNKNOWN,

--- a/src/core/network/protocols/v1/validators/V1BroadcastTransactionResponse.js
+++ b/src/core/network/protocols/v1/validators/V1BroadcastTransactionResponse.js
@@ -6,7 +6,7 @@ import {unsafeDecodeApplyOperation} from "../../../../../codecs/apply/applyOpera
 import {isDeepEqualApplyPayload} from "../../../../../utils/deepEqualApplyPayload.js";
 import {addressToBuffer, bufferToAddress} from "../../../../state/utils/address.js";
 import {publicKeyToAddress} from "../../../../../utils/helpers.js";
-import Check from "../../../../../utils/check.js";
+import StateValidationSchema from "../../../../state/validators/StateValidationSchema.js";
 import {OperationType, ResultCode} from "../../../../../utils/constants.js";
 import {V1ProtocolError} from "../V1ProtocolError.js";
 
@@ -32,14 +32,14 @@ const stripValidatorMetadata = (value) => {
 
 class V1BroadcastTransactionResponse extends V1BaseOperation {
     #config;
-    #check;
+    #stateValidationSchema;
     #state;
 
     constructor(state, config) {
         super(config);
         this.#state = state;
         this.#config = config;
-        this.#check = new Check(config);
+        this.#stateValidationSchema = new StateValidationSchema(config);
     }
 
     async validate(payload, connection, pendingRequestServiceEntry) {
@@ -93,16 +93,16 @@ class V1BroadcastTransactionResponse extends V1BaseOperation {
             case OperationType.ADD_WRITER:
             case OperationType.REMOVE_WRITER:
             case OperationType.ADMIN_RECOVERY:
-                isValid =  this.#check.validateRoleAccessOperation(validatorDecodedTx);
+                isValid =  this.#stateValidationSchema.validateRoleAccessOperation(validatorDecodedTx);
                 break;
             case OperationType.BOOTSTRAP_DEPLOYMENT:
-                isValid =  this.#check.validateBootstrapDeploymentOperation(validatorDecodedTx);
+                isValid =  this.#stateValidationSchema.validateBootstrapDeploymentOperation(validatorDecodedTx);
                 break;
             case OperationType.TX:
-                isValid = this.#check.validateTransactionOperation(validatorDecodedTx);
+                isValid = this.#stateValidationSchema.validateTransactionOperation(validatorDecodedTx);
                 break;
             case OperationType.TRANSFER:
-                isValid = this.#check.validateTransferOperation(validatorDecodedTx);
+                isValid = this.#stateValidationSchema.validateTransferOperation(validatorDecodedTx);
                 break;
             default:
                 throw new V1ProtocolError(

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -100,9 +100,6 @@ class State extends ReadyResource {
     }
 
     async _close() {
-        [CustomEventType.IS_INDEXER, CustomEventType.IS_NON_INDEXER].forEach(event => {
-            this.removeAllListeners(event);
-        })
         console.log("State: closing gracefully...");
         if (this.#bee !== null) {
             await this.#bee.close();
@@ -140,12 +137,8 @@ class State extends ReadyResource {
     }
 
     async currentEpoch() {
-        const epochId = await this.currentEpochId()
-        return await this.getSigned(keys.EPOCH_DATA(epochId));
-    }
-
-    async getEpochHash(epochId) {
-        return await this.getSigned(keys.EPOCH_HASH(epochId))
+        const latestEpochNumber = await this.getSigned(keys.CURRENT_INDEX)
+        return await this.getSigned(keys.EPOCH(latestEpochNumber))
     }
 
     getFee() {
@@ -3298,7 +3291,7 @@ class State extends ReadyResource {
         return Status.SUCCESS;
     }
 
-    async #handleApplySetEpochOperation(op, view, base, node, batch) {
+    async #handleApplySetEpochOperation(op, view, base, node, _batch) {
         if (!this.stateValidationSchema.validateSetEpochOperation(op)) {
             this.#safeLogApply(OperationType.SET_EPOCH, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -56,6 +56,7 @@ class State extends ReadyResource {
     #writingKey;
     #config
     #wallet
+    #stateValidationSchema;
     #activeWriterCountCache = new Map();
 
     /**
@@ -70,7 +71,7 @@ class State extends ReadyResource {
         this.#wallet = wallet
         this.#store = store;
 
-        this.stateValidationSchema = new StateValidationSchema(config);
+        this.#stateValidationSchema = new StateValidationSchema(config);
         this.#base = new Autobase(this.#store, this.#config.bootstrap, {
             ackInterval: ACK_INTERVAL,
             valueEncoding: AUTOBASE_VALUE_ENCODING,
@@ -87,6 +88,10 @@ class State extends ReadyResource {
 
     get writingKey() {
         return this.#writingKey;
+    }
+
+    get stateValidationSchema() {
+        return this.#stateValidationSchema;
     }
 
     get applyHandler() {
@@ -540,7 +545,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyInitializeBalanceOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateBalanceInitialization(op)) {
+        if (!this.#stateValidationSchema.validateBalanceInitialization(op)) {
             this.#safeLogApply(OperationType.BALANCE_INITIALIZATION, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -685,7 +690,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyDisableBalanceInitializationOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateCoreAdminOperation(op)) {
+        if (!this.#stateValidationSchema.validateCoreAdminOperation(op)) {
             this.#safeLogApply(OperationType.DISABLE_INITIALIZATION, "Schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -796,7 +801,7 @@ class State extends ReadyResource {
             INITIALIZATION, THEIR STAKED BALANCE WILL BE REDUCED (PUNISHMENT).
         */
 
-        if (!this.stateValidationSchema.validateCoreAdminOperation(op)) {
+        if (!this.#stateValidationSchema.validateCoreAdminOperation(op)) {
             this.#safeLogApply(OperationType.ADD_ADMIN, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -933,7 +938,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyAdminRecoveryOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateRoleAccessOperation(op)) {
+        if (!this.#stateValidationSchema.validateRoleAccessOperation(op)) {
             this.#safeLogApply(OperationType.ADMIN_RECOVERY, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -1184,7 +1189,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyAppendWhitelistOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateAdminControlOperation(op)) {
+        if (!this.#stateValidationSchema.validateAdminControlOperation(op)) {
             this.#safeLogApply(OperationType.APPEND_WHITELIST, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -1433,7 +1438,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyAddWriterOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateRoleAccessOperation(op)) {
+        if (!this.#stateValidationSchema.validateRoleAccessOperation(op)) {
             this.#safeLogApply(OperationType.ADD_WRITER, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -1737,7 +1742,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyRemoveWriterOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateRoleAccessOperation(op)) {
+        if (!this.#stateValidationSchema.validateRoleAccessOperation(op)) {
             this.#safeLogApply(OperationType.REMOVE_WRITER, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -2001,7 +2006,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyAddIndexerOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateAdminControlOperation(op)) {
+        if (!this.#stateValidationSchema.validateAdminControlOperation(op)) {
             this.#safeLogApply(OperationType.ADD_INDEXER, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -2219,7 +2224,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyRemoveIndexerOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateAdminControlOperation(op)) {
+        if (!this.#stateValidationSchema.validateAdminControlOperation(op)) {
             this.#safeLogApply(OperationType.REMOVE_INDEXER, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -2439,7 +2444,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyBanValidatorOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateAdminControlOperation(op)) {
+        if (!this.#stateValidationSchema.validateAdminControlOperation(op)) {
             this.#safeLogApply(OperationType.BAN_VALIDATOR, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -2640,7 +2645,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyBootstrapDeploymentOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateBootstrapDeploymentOperation(op)) {
+        if (!this.#stateValidationSchema.validateBootstrapDeploymentOperation(op)) {
             this.#safeLogApply(OperationType.BOOTSTRAP_DEPLOYMENT, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -2874,7 +2879,7 @@ class State extends ReadyResource {
 
     async #handleApplyTxOperation(op, view, base, node, batch) {
         // ATTENTION: The sanitization should be done before ANY other check, otherwise we risk crashing
-        if (!this.stateValidationSchema.validateTransactionOperation(op)) {
+        if (!this.#stateValidationSchema.validateTransactionOperation(op)) {
             this.#safeLogApply(OperationType.TX, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -3088,7 +3093,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyTransferOperation(op, view, base, node, batch) {
-        if (!this.stateValidationSchema.validateTransferOperation(op)) {
+        if (!this.#stateValidationSchema.validateTransferOperation(op)) {
             this.#safeLogApply(OperationType.TRANSFER, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -3292,7 +3297,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplySetEpochOperation(op, view, base, node, _batch) {
-        if (!this.stateValidationSchema.validateSetEpochOperation(op)) {
+        if (!this.#stateValidationSchema.validateSetEpochOperation(op)) {
             this.#safeLogApply(OperationType.SET_EPOCH, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -17,7 +17,7 @@ import {
 } from '../../utils/constants.js';
 import { isHexString, sleep, isTransactionRecordPut } from '../../utils/helpers.js';
 import tracCryptoApi from 'trac-crypto-api';
-import Check from '../../utils/check.js';
+import StateValidationSchema from './validators/StateValidationSchema.js';
 import { safeDecodeApplyOperation } from '../../codecs/apply/applyOperationCodec.js';
 import { createMessage, ZERO_WK, NULL_BUFFER } from '../../utils/buffer.js';
 import addressUtils from './utils/address.js';
@@ -70,7 +70,7 @@ class State extends ReadyResource {
         this.#wallet = wallet
         this.#store = store;
 
-        this.check = new Check(config);
+        this.stateValidationSchema = new StateValidationSchema(config);
         this.#base = new Autobase(this.#store, this.#config.bootstrap, {
             ackInterval: ACK_INTERVAL,
             valueEncoding: AUTOBASE_VALUE_ENCODING,
@@ -547,7 +547,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyInitializeBalanceOperation(op, view, base, node, batch) {
-        if (!this.check.validateBalanceInitialization(op)) {
+        if (!this.stateValidationSchema.validateBalanceInitialization(op)) {
             this.#safeLogApply(OperationType.BALANCE_INITIALIZATION, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -692,7 +692,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyDisableBalanceInitializationOperation(op, view, base, node, batch) {
-        if (!this.check.validateCoreAdminOperation(op)) {
+        if (!this.stateValidationSchema.validateCoreAdminOperation(op)) {
             this.#safeLogApply(OperationType.DISABLE_INITIALIZATION, "Schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -803,7 +803,7 @@ class State extends ReadyResource {
             INITIALIZATION, THEIR STAKED BALANCE WILL BE REDUCED (PUNISHMENT).
         */
 
-        if (!this.check.validateCoreAdminOperation(op)) {
+        if (!this.stateValidationSchema.validateCoreAdminOperation(op)) {
             this.#safeLogApply(OperationType.ADD_ADMIN, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -940,7 +940,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyAdminRecoveryOperation(op, view, base, node, batch) {
-        if (!this.check.validateRoleAccessOperation(op)) {
+        if (!this.stateValidationSchema.validateRoleAccessOperation(op)) {
             this.#safeLogApply(OperationType.ADMIN_RECOVERY, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -1191,7 +1191,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyAppendWhitelistOperation(op, view, base, node, batch) {
-        if (!this.check.validateAdminControlOperation(op)) {
+        if (!this.stateValidationSchema.validateAdminControlOperation(op)) {
             this.#safeLogApply(OperationType.APPEND_WHITELIST, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -1440,7 +1440,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyAddWriterOperation(op, view, base, node, batch) {
-        if (!this.check.validateRoleAccessOperation(op)) {
+        if (!this.stateValidationSchema.validateRoleAccessOperation(op)) {
             this.#safeLogApply(OperationType.ADD_WRITER, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -1744,7 +1744,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyRemoveWriterOperation(op, view, base, node, batch) {
-        if (!this.check.validateRoleAccessOperation(op)) {
+        if (!this.stateValidationSchema.validateRoleAccessOperation(op)) {
             this.#safeLogApply(OperationType.REMOVE_WRITER, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -2008,7 +2008,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyAddIndexerOperation(op, view, base, node, batch) {
-        if (!this.check.validateAdminControlOperation(op)) {
+        if (!this.stateValidationSchema.validateAdminControlOperation(op)) {
             this.#safeLogApply(OperationType.ADD_INDEXER, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -2226,7 +2226,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyRemoveIndexerOperation(op, view, base, node, batch) {
-        if (!this.check.validateAdminControlOperation(op)) {
+        if (!this.stateValidationSchema.validateAdminControlOperation(op)) {
             this.#safeLogApply(OperationType.REMOVE_INDEXER, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -2446,7 +2446,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyBanValidatorOperation(op, view, base, node, batch) {
-        if (!this.check.validateAdminControlOperation(op)) {
+        if (!this.stateValidationSchema.validateAdminControlOperation(op)) {
             this.#safeLogApply(OperationType.BAN_VALIDATOR, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -2647,7 +2647,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyBootstrapDeploymentOperation(op, view, base, node, batch) {
-        if (!this.check.validateBootstrapDeploymentOperation(op)) {
+        if (!this.stateValidationSchema.validateBootstrapDeploymentOperation(op)) {
             this.#safeLogApply(OperationType.BOOTSTRAP_DEPLOYMENT, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -2881,7 +2881,7 @@ class State extends ReadyResource {
 
     async #handleApplyTxOperation(op, view, base, node, batch) {
         // ATTENTION: The sanitization should be done before ANY other check, otherwise we risk crashing
-        if (!this.check.validateTransactionOperation(op)) {
+        if (!this.stateValidationSchema.validateTransactionOperation(op)) {
             this.#safeLogApply(OperationType.TX, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -3095,7 +3095,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplyTransferOperation(op, view, base, node, batch) {
-        if (!this.check.validateTransferOperation(op)) {
+        if (!this.stateValidationSchema.validateTransferOperation(op)) {
             this.#safeLogApply(OperationType.TRANSFER, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
@@ -3298,12 +3298,12 @@ class State extends ReadyResource {
         return Status.SUCCESS;
     }
 
-    async #handleApplySetEpochOperation(op, view, base, node) {
-        if (!this.check.validateSetEpochOperation(op)) {
+    async #handleApplySetEpochOperation(op, view, base, node, batch) {
+        if (!this.stateValidationSchema.validateSetEpochOperation(op)) {
             this.#safeLogApply(OperationType.SET_EPOCH, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         };
-        
+
         this.emit(CustomEventType.EPOCH_CREATED); // notify epoch committed
         return Status.SUCCESS;
     }

--- a/src/core/state/validators/StateValidationSchema.js
+++ b/src/core/state/validators/StateValidationSchema.js
@@ -14,15 +14,15 @@ import {
     NETWORK_ID_BYTE_LENGTH,
     EPOCH_BYTE_LENGTH,
     VDF_BLOB_PROOF_SIZE,
-} from './constants.js';
+} from '../../../utils/constants.js';
 import {
     decodeProofProposalApproval,
     decodeProofProposal,
     encodeProofProposalApproval,
     encodeProofProposal
-} from '../codecs/consensus/v1/consensusV1OperationCodec.js';
+} from '../../../codecs/consensus/v1/consensusV1OperationCodec.js';
 
-class Check {
+class StateValidationSchema {
     #validator;
     #validateCoreAdminOperationSchema;
     #validateAdminControlOperationSchema;
@@ -640,4 +640,4 @@ class Check {
     }
 }
 
-export default Check;
+export default StateValidationSchema;

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import { sleep, isHexString } from "./utils/helpers.js";
 import { applyStateMessageFactory } from "./messages/state/applyStateMessageFactory.js";
 import { isAddressValid } from "./core/state/utils/address.js";
 import Network from "./core/network/Network.js";
-import Check from "./utils/check.js";
 import State from "./core/state/State.js";
 import {
     EventType,
@@ -47,7 +46,6 @@ export class MainSettlementBus extends ReadyResource {
         this.#config = config
         this.#wallet = wallet;
         this.#store = new Corestore(this.#config.storesFullPath);
-        this.check = new Check(this.#config);
     }
 
     get config() {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -164,7 +164,7 @@ export const ACK_INTERVAL = 1_000;
 export const AUTOBASE_VALUE_ENCODING = 'binary';
 export const HYPERBEE_KEY_ENCODING = 'ascii';
 export const HYPERBEE_VALUE_ENCODING = 'binary';
-// check.js
+// StateValidationSchema.js
 
 //ATTENTION - THIS IS USED IN THE APPLY FUNCTION!
 export const PUBLIC_KEY_LENGTH = 32

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -45,13 +45,10 @@ async function loadMainSettlementBus() {
         }
     }
 
-    class CheckMock {}
-
     const { MainSettlementBus } = await esmock('../../src/index.js', {
         corestore: CorestoreMock,
         '../../src/core/state/State.js': StateMock,
         '../../src/core/network/Network.js': NetworkMock,
-        '../../src/utils/check.js': CheckMock,
         '../../src/utils/fileUtils.js': {
             default: {
                 ensureKeyPathDir: sinon.stub().resolves(),

--- a/tests/unit/network/shared/validators/PartialTransferValidator.test.js
+++ b/tests/unit/network/shared/validators/PartialTransferValidator.test.js
@@ -62,7 +62,7 @@ test('PartialTransferValidator.validate rejects invalid recipient address or pub
         validator.address,
         config
     );
-    invalidAddressValidator.check.validateTransferOperation = () => true;
+    invalidAddressValidator.stateValidationSchema.validateTransferOperation = () => true;
     invalidAddressValidator.validateSignature = async () => true;
     await expectSharedValidatorError(
         t,

--- a/tests/unit/network/v1/V1BroadcastTransactionResponse.test.js
+++ b/tests/unit/network/v1/V1BroadcastTransactionResponse.test.js
@@ -5,7 +5,7 @@ import Hypercore from 'hypercore';
 
 import V1BroadcastTransactionResponse, {extractRequiredVaFromDecodedTx} from '../../../../src/core/network/protocols/v1/validators/V1BroadcastTransactionResponse.js';
 import {V1ProtocolError} from '../../../../src/core/network/protocols/v1/V1ProtocolError.js';
-import Check from '../../../../src/utils/check.js';
+import StateValidationSchema from '../../../../src/core/state/validators/StateValidationSchema.js';
 import {
     unsafeEncodeApplyOperation,
     unsafeDecodeApplyOperation,
@@ -42,13 +42,13 @@ const createValidator = (stateOverrides = {}) =>
 const overrideCheckMethods = (t, overrides) => {
     const originals = {};
     for (const [name, impl] of Object.entries(overrides)) {
-        originals[name] = Check.prototype[name];
-        Check.prototype[name] = impl;
+        originals[name] = StateValidationSchema.prototype[name];
+        StateValidationSchema.prototype[name] = impl;
     }
 
     t.teardown(() => {
         for (const [name, original] of Object.entries(originals)) {
-            Check.prototype[name] = original;
+            StateValidationSchema.prototype[name] = original;
         }
     });
 };

--- a/tests/unit/state/apply/addWriter/addWriterScenarioHelpers.js
+++ b/tests/unit/state/apply/addWriter/addWriterScenarioHelpers.js
@@ -398,33 +398,33 @@ export async function assertWriterRemovalState(
 export async function applyWithRoleAccessBypass(context, invalidPayload) {
     const node = context.bootstrap ?? context.adminBootstrap;
     const state = node.state;
-    const originalValidate = state.check.validateRoleAccessOperation;
-    state.check.validateRoleAccessOperation = () => true;
+    const originalValidate = state.stateValidationSchema.validateRoleAccessOperation;
+    state.stateValidationSchema.validateRoleAccessOperation = () => true;
     try {
         await node.base.append(invalidPayload);
         await node.base.update();
         await eventFlush();
     } finally {
-        state.check.validateRoleAccessOperation = originalValidate;
+        state.stateValidationSchema.validateRoleAccessOperation = originalValidate;
     }
 }
 
 export async function applyWithMissingComponentBypass(context, invalidPayload) {
     const node = context.bootstrap ?? context.adminBootstrap;
     const state = node.state;
-    const originalValidate = state.check.validateRoleAccessOperation;
+    const originalValidate = state.stateValidationSchema.validateRoleAccessOperation;
     const originalHasOwn = Object.hasOwn;
     Object.hasOwn = (obj, prop) => {
         if (prop === 'vs') return false;
         return originalHasOwn(obj, prop);
     };
-    state.check.validateRoleAccessOperation = () => true;
+    state.stateValidationSchema.validateRoleAccessOperation = () => true;
     try {
         await node.base.append(invalidPayload);
         await node.base.update();
         await eventFlush();
     } finally {
-        state.check.validateRoleAccessOperation = originalValidate;
+        state.stateValidationSchema.validateRoleAccessOperation = originalValidate;
         Object.hasOwn = originalHasOwn;
     }
 }

--- a/tests/unit/state/apply/adminRecovery/adminRecoveryScenarioHelpers.js
+++ b/tests/unit/state/apply/adminRecovery/adminRecoveryScenarioHelpers.js
@@ -632,33 +632,33 @@ export async function assertAdminRecoveryFailureState(t, context, { skipSync } =
 export async function applyWithRoleAccessBypass(context, invalidPayload) {
     const { validatorPeer1 } = context.adminRecovery;
     const state = validatorPeer1.state;
-    const originalValidate = state.check.validateRoleAccessOperation;
-    state.check.validateRoleAccessOperation = () => true;
+    const originalValidate = state.stateValidationSchema.validateRoleAccessOperation;
+    state.stateValidationSchema.validateRoleAccessOperation = () => true;
     try {
         await validatorPeer1.base.append(invalidPayload);
         await validatorPeer1.base.update();
         await eventFlush();
     } finally {
-        state.check.validateRoleAccessOperation = originalValidate;
+        state.stateValidationSchema.validateRoleAccessOperation = originalValidate;
     }
 }
 
 export async function applyWithMissingComponentBypass(context, invalidPayload, { missingKey = 'vs' } = {}) {
     const { validatorPeer1 } = context.adminRecovery;
     const state = validatorPeer1.state;
-    const originalValidate = state.check.validateRoleAccessOperation;
+    const originalValidate = state.stateValidationSchema.validateRoleAccessOperation;
     const originalHasOwn = Object.hasOwn;
     Object.hasOwn = (obj, prop) => {
         if (prop === missingKey) return false;
         return originalHasOwn(obj, prop);
     };
-    state.check.validateRoleAccessOperation = () => true;
+    state.stateValidationSchema.validateRoleAccessOperation = () => true;
     try {
         await validatorPeer1.base.append(invalidPayload);
         await validatorPeer1.base.update();
         await eventFlush();
     } finally {
-        state.check.validateRoleAccessOperation = originalValidate;
+        state.stateValidationSchema.validateRoleAccessOperation = originalValidate;
         Object.hasOwn = originalHasOwn;
     }
 }

--- a/tests/unit/state/apply/balanceInitialization/invalidAmountScenario.js
+++ b/tests/unit/state/apply/balanceInitialization/invalidAmountScenario.js
@@ -32,14 +32,14 @@ async function bypassSchemaAndApply(context, invalidPayload) {
         throw new Error('Invalid amount scenario requires admin bootstrap context.');
     }
 
-    const originalValidator = adminNode.state.check.validateBalanceInitialization;
-    adminNode.state.check.validateBalanceInitialization = () => true;
+    const originalValidator = adminNode.state.stateValidationSchema.validateBalanceInitialization;
+    adminNode.state.stateValidationSchema.validateBalanceInitialization = () => true;
 
     try {
         await adminNode.base.append(invalidPayload);
         await adminNode.base.update();
         await eventFlush();
     } finally {
-        adminNode.state.check.validateBalanceInitialization = originalValidator;
+        adminNode.state.stateValidationSchema.validateBalanceInitialization = originalValidator;
     }
 }

--- a/tests/unit/state/apply/transfer/transferScenarioHelpers.js
+++ b/tests/unit/state/apply/transfer/transferScenarioHelpers.js
@@ -463,16 +463,16 @@ export async function applyInvalidTransferWithSchemaBypass(context, invalidPaylo
 		context.bootstrap ??
 		context.peers?.[0];
 
-    if (!node?.state?.check) {
+    if (!node?.state?.stateValidationSchema) {
         throw new Error('applyInvalidTransferWithSchemaBypass requires a node with state and check.');
     }
 
-    const originalValidate = node.state.check.validateTransferOperation;
-    node.state.check.validateTransferOperation = () => true;
+    const originalValidate = node.state.stateValidationSchema.validateTransferOperation;
+    node.state.stateValidationSchema.validateTransferOperation = () => true;
     try {
         await appendInvalidTransferPayload(context, invalidPayload, { node });
     } finally {
-        node.state.check.validateTransferOperation = originalValidate;
+        node.state.stateValidationSchema.validateTransferOperation = originalValidate;
     }
 }
 
@@ -483,13 +483,13 @@ export async function applyInvalidTransferMissingValidatorFields(context, invali
 		context.bootstrap ??
 		context.peers?.[0];
 
-    if (!node?.state?.check) {
+    if (!node?.state?.stateValidationSchema) {
         throw new Error('applyInvalidTransferMissingValidatorFields requires a node with state and check.');
     }
 
-    const originalValidate = node.state.check.validateTransferOperation;
+    const originalValidate = node.state.stateValidationSchema.validateTransferOperation;
     const originalHasOwn = Object.hasOwn;
-    node.state.check.validateTransferOperation = () => true;
+    node.state.stateValidationSchema.validateTransferOperation = () => true;
     Object.hasOwn = (obj, prop) => {
         if (prop === 'vs' || prop === 'va' || prop === 'vn') return false;
         return originalHasOwn(obj, prop);
@@ -498,7 +498,7 @@ export async function applyInvalidTransferMissingValidatorFields(context, invali
     try {
         await appendInvalidTransferPayload(context, invalidPayload, { node });
     } finally {
-        node.state.check.validateTransferOperation = originalValidate;
+        node.state.stateValidationSchema.validateTransferOperation = originalValidate;
         Object.hasOwn = originalHasOwn;
     }
 }

--- a/tests/unit/state/apply/transfer/transferScenarioHelpers.js
+++ b/tests/unit/state/apply/transfer/transferScenarioHelpers.js
@@ -464,7 +464,7 @@ export async function applyInvalidTransferWithSchemaBypass(context, invalidPaylo
 		context.peers?.[0];
 
     if (!node?.state?.stateValidationSchema) {
-        throw new Error('applyInvalidTransferWithSchemaBypass requires a node with state and check.');
+        throw new Error('applyInvalidTransferWithSchemaBypass requires a node with state and stateValidationSchema.');
     }
 
     const originalValidate = node.state.stateValidationSchema.validateTransferOperation;

--- a/tests/unit/state/apply/transfer/transferScenarioHelpers.js
+++ b/tests/unit/state/apply/transfer/transferScenarioHelpers.js
@@ -484,7 +484,7 @@ export async function applyInvalidTransferMissingValidatorFields(context, invali
 		context.peers?.[0];
 
     if (!node?.state?.stateValidationSchema) {
-        throw new Error('applyInvalidTransferMissingValidatorFields requires a node with state and check.');
+        throw new Error('applyInvalidTransferMissingValidatorFields requires a node with state and stateValidationSchema.');
     }
 
     const originalValidate = node.state.stateValidationSchema.validateTransferOperation;

--- a/tests/unit/utils/check/adminControlOperation.test.js
+++ b/tests/unit/utils/check/adminControlOperation.test.js
@@ -1,10 +1,10 @@
 import test from 'brittle'
-import Check from '../../../../src/utils/check.js'
+import StateValidationSchema from '../../../../src/core/state/validators/StateValidationSchema.js'
 import { ACO, not_allowed_data_types } from '../../../fixtures/check.fixtures.js'
 import { topLevelValidationTests, valueLevelValidationTest, addressBufferLengthTest, fieldsBufferLengthTest } from './common.test.js';
 import { config } from '../../../helpers/config.js';
 
-const check = new Check(config)
+const stateValidationSchema = new StateValidationSchema(config)
 
 test('validateAdminControlOperation- happy paths for all operation types', t => {
     const validInputs = [
@@ -15,14 +15,14 @@ test('validateAdminControlOperation- happy paths for all operation types', t => 
     ]
 
     for (const validInput of validInputs) {
-        t.ok(check.validateAdminControlOperation(validInput), `Valid payload for ${validInput.type} should pass`)
+        t.ok(stateValidationSchema.validateAdminControlOperation(validInput), `Valid payload for ${validInput.type} should pass`)
     }
 })
 
 test('validateAdminControlOperation - type level validation (aco)', t => {
     topLevelValidationTests(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validAppendWhitelistOperation,
         'aco',
         not_allowed_data_types,
@@ -31,7 +31,7 @@ test('validateAdminControlOperation - type level validation (aco)', t => {
 
     topLevelValidationTests(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validAddIndexerOperation,
         'aco',
         not_allowed_data_types,
@@ -40,7 +40,7 @@ test('validateAdminControlOperation - type level validation (aco)', t => {
 
     topLevelValidationTests(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validRemoveIndexerOperation,
         'aco',
         not_allowed_data_types,
@@ -49,7 +49,7 @@ test('validateAdminControlOperation - type level validation (aco)', t => {
 
     topLevelValidationTests(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validBanValidatorOperation,
         'aco',
         not_allowed_data_types,
@@ -60,7 +60,7 @@ test('validateAdminControlOperation - type level validation (aco)', t => {
 test('validateAdminControlOperation - value level validation (aco)', t => {
     valueLevelValidationTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validAppendWhitelistOperation,
         'aco',
         ACO.adminControlValueFields,
@@ -69,7 +69,7 @@ test('validateAdminControlOperation - value level validation (aco)', t => {
 
     valueLevelValidationTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validAddIndexerOperation,
         'aco',
         ACO.adminControlValueFields,
@@ -78,7 +78,7 @@ test('validateAdminControlOperation - value level validation (aco)', t => {
 
     valueLevelValidationTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validRemoveIndexerOperation,
         'aco',
         ACO.adminControlValueFields,
@@ -87,7 +87,7 @@ test('validateAdminControlOperation - value level validation (aco)', t => {
 
     valueLevelValidationTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validBanValidatorOperation,
         'aco',
         ACO.adminControlValueFields,
@@ -98,25 +98,25 @@ test('validateAdminControlOperation - value level validation (aco)', t => {
 test('validateAdminControlOperation - address buffer length validation - TOP LEVEL', t => {
     addressBufferLengthTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validAppendWhitelistOperation,
     );
 
     addressBufferLengthTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validAddIndexerOperation,
     );
 
     addressBufferLengthTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validRemoveIndexerOperation,
     );
 
     addressBufferLengthTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validBanValidatorOperation,
     );
 });
@@ -124,7 +124,7 @@ test('validateAdminControlOperation - address buffer length validation - TOP LEV
 test('validateAdminControlOperation - fields buffer length validation - VALUE LEVEL (aco)', t => {
     fieldsBufferLengthTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validAppendWhitelistOperation,
         'aco',
         ACO.requiredLengthOfFieldsForAdminControl
@@ -132,7 +132,7 @@ test('validateAdminControlOperation - fields buffer length validation - VALUE LE
 
     fieldsBufferLengthTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validAddIndexerOperation,
         'aco',
         ACO.requiredLengthOfFieldsForAdminControl
@@ -140,7 +140,7 @@ test('validateAdminControlOperation - fields buffer length validation - VALUE LE
 
     fieldsBufferLengthTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validRemoveIndexerOperation,
         'aco',
         ACO.requiredLengthOfFieldsForAdminControl
@@ -148,7 +148,7 @@ test('validateAdminControlOperation - fields buffer length validation - VALUE LE
 
     fieldsBufferLengthTest(
         t,
-        check.validateAdminControlOperation.bind(check),
+        stateValidationSchema.validateAdminControlOperation.bind(stateValidationSchema),
         ACO.validBanValidatorOperation,
         'aco',
         ACO.requiredLengthOfFieldsForAdminControl

--- a/tests/unit/utils/check/balanceInitializationOperation.test.js
+++ b/tests/unit/utils/check/balanceInitializationOperation.test.js
@@ -1,14 +1,14 @@
 import test from 'brittle'
-import Check from '../../../../src/utils/check.js'
+import StateValidationSchema from '../../../../src/core/state/validators/StateValidationSchema.js'
 import { BIO, not_allowed_data_types } from '../../../fixtures/check.fixtures.js'
 import { topLevelValidationTests, valueLevelValidationTest, addressBufferLengthTest, fieldsBufferLengthTest } from './common.test.js';
 import { config } from '../../../helpers/config.js';
 
-const check = new Check(config)
+const stateValidationSchema = new StateValidationSchema(config)
 
 test('validateBalanceInitialization - happy path', t => {
 
-    const complete_result = check.validateBalanceInitialization(BIO.valid_balance_initialization_operation)
+    const complete_result = stateValidationSchema.validateBalanceInitialization(BIO.valid_balance_initialization_operation)
     t.ok(complete_result, 'Valid data for complete balance initialization operation should pass the validation')
 
 })
@@ -16,7 +16,7 @@ test('validateBalanceInitialization - happy path', t => {
 test('validateBalanceInitialization - type level validation (bio)', t => {
     topLevelValidationTests(
         t,
-        check.validateBalanceInitialization.bind(check),
+        stateValidationSchema.validateBalanceInitialization.bind(stateValidationSchema),
         BIO.valid_balance_initialization_operation,
         'bio',
         not_allowed_data_types,
@@ -27,7 +27,7 @@ test('validateBalanceInitialization - type level validation (bio)', t => {
 test('validateBalanceInitialization - value level validation (bio)', t => {
     valueLevelValidationTest(
         t,
-        check.validateBalanceInitialization.bind(check),
+        stateValidationSchema.validateBalanceInitialization.bind(stateValidationSchema),
         BIO.valid_balance_initialization_operation,
         'bio',
         BIO.balance_initialization_operation_value_fields,
@@ -38,7 +38,7 @@ test('validateBalanceInitialization - value level validation (bio)', t => {
 test('validateBalanceInitialization - address buffer length validation - TOP LEVEL', t => {
     addressBufferLengthTest(
         t,
-        check.validateBalanceInitialization.bind(check),
+        stateValidationSchema.validateBalanceInitialization.bind(stateValidationSchema),
         BIO.valid_balance_initialization_operation,
     );
 });
@@ -46,7 +46,7 @@ test('validateBalanceInitialization - address buffer length validation - TOP LEV
 test('validateAdminControlOperation - fields buffer length validation - VALUE LEVEL (aco)', t => {
     fieldsBufferLengthTest(
         t,
-        check.validateBalanceInitialization.bind(check),
+        stateValidationSchema.validateBalanceInitialization.bind(stateValidationSchema),
         BIO.valid_balance_initialization_operation,
         'bio',
         BIO.required_length_of_fields_for_balance_initialization

--- a/tests/unit/utils/check/bootstrapDeploymentOperation.test.js
+++ b/tests/unit/utils/check/bootstrapDeploymentOperation.test.js
@@ -1,14 +1,14 @@
 import test from 'brittle'
-import Check from '../../../../src/utils/check.js';
+import StateValidationSchema from '../../../../src/core/state/validators/StateValidationSchema.js';
 import {BDO, not_allowed_data_types} from '../../../fixtures/check.fixtures.js';
 import { topLevelValidationTests, valueLevelValidationTest, addressBufferLengthTest, fieldsBufferLengthTest, partialTypeCommonTests } from './common.test.js';
 import { config } from '../../../helpers/config.js';
 
-const check = new Check(config)
+const stateValidationSchema = new StateValidationSchema(config)
 
 test('validateBootstrapDeployment - happy-path case', t => {
-    const partial_result = check.validateBootstrapDeploymentOperation(BDO.valid_partial_bootstrap_deployment)
-    const complete_result = check.validateBootstrapDeploymentOperation(BDO.valid_complete_bootstrap_deployment)
+    const partial_result = stateValidationSchema.validateBootstrapDeploymentOperation(BDO.valid_partial_bootstrap_deployment)
+    const complete_result = stateValidationSchema.validateBootstrapDeploymentOperation(BDO.valid_complete_bootstrap_deployment)
     t.ok(partial_result, 'Valid data for partial bootstrap deployment operation should pass the validation')
     t.ok(complete_result, 'Valid data for complete bootstrap deployment operation should pass the validation')
 })
@@ -16,7 +16,7 @@ test('validateBootstrapDeployment - happy-path case', t => {
 test('validateBootstrapDeployment - ssss', t => {
     partialTypeCommonTests(
         t,
-        check.validateBootstrapDeploymentOperation.bind(check),
+        stateValidationSchema.validateBootstrapDeploymentOperation.bind(stateValidationSchema),
         BDO.valid_complete_bootstrap_deployment,
         'bdo'
     )
@@ -26,7 +26,7 @@ test('validateBootstrapDeployment - data type validation TOP LEVEL', t => {
     //complete
     topLevelValidationTests(
         t,
-        check.validateBootstrapDeploymentOperation.bind(check),
+        stateValidationSchema.validateBootstrapDeploymentOperation.bind(stateValidationSchema),
         BDO.valid_complete_bootstrap_deployment,
         'bdo',
         not_allowed_data_types,
@@ -36,7 +36,7 @@ test('validateBootstrapDeployment - data type validation TOP LEVEL', t => {
     //partial
     topLevelValidationTests(
         t,
-        check.validateBootstrapDeploymentOperation.bind(check),
+        stateValidationSchema.validateBootstrapDeploymentOperation.bind(stateValidationSchema),
         BDO.valid_partial_bootstrap_deployment,
         'bdo',
         not_allowed_data_types,
@@ -49,7 +49,7 @@ test('validateBootstrapDeployment - value level validation (bdo)', t => {
     //complete
     valueLevelValidationTest(
         t,
-        check.validateBootstrapDeploymentOperation.bind(check),
+        stateValidationSchema.validateBootstrapDeploymentOperation.bind(stateValidationSchema),
         BDO.valid_complete_bootstrap_deployment,
         'bdo',
         BDO.complete_bootstrap_deployment_value_fields,
@@ -58,7 +58,7 @@ test('validateBootstrapDeployment - value level validation (bdo)', t => {
     //partial
     valueLevelValidationTest(
         t,
-        check.validateBootstrapDeploymentOperation.bind(check),
+        stateValidationSchema.validateBootstrapDeploymentOperation.bind(stateValidationSchema),
         BDO.valid_partial_bootstrap_deployment,
         'bdo',
         BDO.partial_bootstrap_deployment_value_fields,
@@ -72,13 +72,13 @@ test('validateBootstrapDeployment - address buffer length validation - TOP LEVEL
     //complete
     addressBufferLengthTest(
         t,
-        check.validateBootstrapDeploymentOperation.bind(check),
+        stateValidationSchema.validateBootstrapDeploymentOperation.bind(stateValidationSchema),
         BDO.valid_complete_bootstrap_deployment,
     );
     //partial
     addressBufferLengthTest(
         t,
-        check.validateBootstrapDeploymentOperation.bind(check),
+        stateValidationSchema.validateBootstrapDeploymentOperation.bind(stateValidationSchema),
         BDO.valid_partial_bootstrap_deployment,
     );
 });
@@ -87,7 +87,7 @@ test('validateBootstrapDeployment - Buffer length validation - VALUE LEVEL (bdo)
     //complete
     fieldsBufferLengthTest(
         t,
-        check.validateBootstrapDeploymentOperation.bind(check),
+        stateValidationSchema.validateBootstrapDeploymentOperation.bind(stateValidationSchema),
         BDO.valid_complete_bootstrap_deployment,
         'bdo',
         BDO.required_length_of_fields_for_complete_bootstrap_deployment
@@ -96,7 +96,7 @@ test('validateBootstrapDeployment - Buffer length validation - VALUE LEVEL (bdo)
     //partial
     fieldsBufferLengthTest(
         t,
-        check.validateBootstrapDeploymentOperation.bind(check),
+        stateValidationSchema.validateBootstrapDeploymentOperation.bind(stateValidationSchema),
         BDO.valid_partial_bootstrap_deployment,
         'bdo',
         BDO.required_length_of_fields_for_partial_bootstrap_deployment

--- a/tests/unit/utils/check/coreAdminOperation.test.js
+++ b/tests/unit/utils/check/coreAdminOperation.test.js
@@ -1,10 +1,10 @@
 import test from 'brittle'
-import Check from '../../../../src/utils/check.js'
+import StateValidationSchema from '../../../../src/core/state/validators/StateValidationSchema.js'
 import { CAO, not_allowed_data_types } from '../../../fixtures/check.fixtures.js'
 import { topLevelValidationTests, valueLevelValidationTest, addressBufferLengthTest, fieldsBufferLengthTest } from './common.test.js';
 import { config } from '../../../helpers/config.js';
 
-const check = new Check(config)
+const stateValidationSchema = new StateValidationSchema(config)
 
 test('validateCoreAdminOperation- happy paths for all operation types', t => {
     const validInputs = [
@@ -13,7 +13,7 @@ test('validateCoreAdminOperation- happy paths for all operation types', t => {
     ]
 
     for (const validInput of validInputs) {
-        t.ok(check.validateCoreAdminOperation(validInput), `Valid payload for ${validInput.type} should pass`)
+        t.ok(stateValidationSchema.validateCoreAdminOperation(validInput), `Valid payload for ${validInput.type} should pass`)
     }
 })
 
@@ -21,7 +21,7 @@ test('validateCoreAdminOperation - data type validation TOP LEVEL', t => {
     // ADD_ADMIN
     topLevelValidationTests(
         t,
-        check.validateCoreAdminOperation.bind(check),
+        stateValidationSchema.validateCoreAdminOperation.bind(stateValidationSchema),
         CAO.validAddAdminOperation,
         'cao',
         not_allowed_data_types,
@@ -30,7 +30,7 @@ test('validateCoreAdminOperation - data type validation TOP LEVEL', t => {
     // DISABLE_INITIALIZATION
     topLevelValidationTests(
         t,
-        check.validateCoreAdminOperation.bind(check),
+        stateValidationSchema.validateCoreAdminOperation.bind(stateValidationSchema),
         CAO.validDisableInitializationOperation,
         'cao',
         not_allowed_data_types,
@@ -42,7 +42,7 @@ test('validateCoreAdminOperation - value level validation (cao)', t => {
     // ADD_ADMIN
     valueLevelValidationTest(
         t,
-        check.validateCoreAdminOperation.bind(check),
+        stateValidationSchema.validateCoreAdminOperation.bind(stateValidationSchema),
         CAO.validAddAdminOperation,
         'cao',
         CAO.coreAdminOperationValuesFields,
@@ -51,7 +51,7 @@ test('validateCoreAdminOperation - value level validation (cao)', t => {
     // DISABLE_INITIALIZATION
     valueLevelValidationTest(
         t,
-        check.validateCoreAdminOperation.bind(check),
+        stateValidationSchema.validateCoreAdminOperation.bind(stateValidationSchema),
         CAO.validDisableInitializationOperation,
         'cao',
         CAO.coreAdminOperationValuesFields,
@@ -64,13 +64,13 @@ test('validateCoreAdminOperation - address buffer length validation - TOP LEVEL'
     // ADD_ADMIN
     addressBufferLengthTest(
         t,
-        check.validateCoreAdminOperation.bind(check),
+        stateValidationSchema.validateCoreAdminOperation.bind(stateValidationSchema),
         CAO.validAddAdminOperation,
     );
     // DISABLE_INITIALIZATION
     addressBufferLengthTest(
         t,
-        check.validateCoreAdminOperation.bind(check),
+        stateValidationSchema.validateCoreAdminOperation.bind(stateValidationSchema),
         CAO.validDisableInitializationOperation,
     );
 });
@@ -79,7 +79,7 @@ test('validateCoreAdminOperation - fields buffer length validation - VALUE LEVEL
     // ADD_ADMIN
     fieldsBufferLengthTest(
         t,
-        check.validateCoreAdminOperation.bind(check),
+        stateValidationSchema.validateCoreAdminOperation.bind(stateValidationSchema),
         CAO.validAddAdminOperation,
         'cao',
         CAO.requiredLengthOfFieldsForCoreAdmin
@@ -87,7 +87,7 @@ test('validateCoreAdminOperation - fields buffer length validation - VALUE LEVEL
     // DISABLE_INITIALIZATION
     fieldsBufferLengthTest(
         t,
-        check.validateCoreAdminOperation.bind(check),
+        stateValidationSchema.validateCoreAdminOperation.bind(stateValidationSchema),
         CAO.validDisableInitializationOperation,
         'cao',
         CAO.requiredLengthOfFieldsForCoreAdmin

--- a/tests/unit/utils/check/roleAccessOperation.test.js
+++ b/tests/unit/utils/check/roleAccessOperation.test.js
@@ -1,31 +1,31 @@
 import test from 'brittle'
 
-import Check from '../../../../src/utils/check.js';
+import StateValidationSchema from '../../../../src/core/state/validators/StateValidationSchema.js';
 import { RAO, not_allowed_data_types } from '../../../fixtures/check.fixtures.js';
 import { topLevelValidationTests, valueLevelValidationTest, addressBufferLengthTest, fieldsBufferLengthTest, partialTypeCommonTests } from './common.test.js';
 import { config } from '../../../helpers/config.js';
 
-const check = new Check(config)
+const stateValidationSchema = new StateValidationSchema(config)
 
 test('validateRoleAccessOperation - happy-path case', t => {
     // ADD_WRITER
-    t.ok(check.validateRoleAccessOperation(RAO.valid_partial_add_writer), 'Valid data for partial ADD_WRITER operation should pass the validation')
-    t.ok(check.validateRoleAccessOperation(RAO.valid_complete_add_writer), 'Valid data for complete ADD_WRITER operation should pass the validation')
+    t.ok(stateValidationSchema.validateRoleAccessOperation(RAO.valid_partial_add_writer), 'Valid data for partial ADD_WRITER operation should pass the validation')
+    t.ok(stateValidationSchema.validateRoleAccessOperation(RAO.valid_complete_add_writer), 'Valid data for complete ADD_WRITER operation should pass the validation')
 
     // REMOVE_WRITER
-    t.ok(check.validateRoleAccessOperation(RAO.valid_partial_remove_writer), 'Valid data for partial REMOVE_WRITER operation should pass the validation')
-    t.ok(check.validateRoleAccessOperation(RAO.valid_complete_remove_writer), 'Valid data for complete REMOVE_WRITER operation should pass the validation')
+    t.ok(stateValidationSchema.validateRoleAccessOperation(RAO.valid_partial_remove_writer), 'Valid data for partial REMOVE_WRITER operation should pass the validation')
+    t.ok(stateValidationSchema.validateRoleAccessOperation(RAO.valid_complete_remove_writer), 'Valid data for complete REMOVE_WRITER operation should pass the validation')
 
     // ADMIN_RECOVERY
-    t.ok(check.validateRoleAccessOperation(RAO.valid_partial_admin_recovery), 'Valid data for partial ADMIN_RECOVERY operation should pass the validation')
-    t.ok(check.validateRoleAccessOperation(RAO.valid_complete_admin_recovery), 'Valid data for complete ADMIN_RECOVERY operation should pass the validation')
+    t.ok(stateValidationSchema.validateRoleAccessOperation(RAO.valid_partial_admin_recovery), 'Valid data for partial ADMIN_RECOVERY operation should pass the validation')
+    t.ok(stateValidationSchema.validateRoleAccessOperation(RAO.valid_complete_admin_recovery), 'Valid data for complete ADMIN_RECOVERY operation should pass the validation')
 })
 
 test('validateRoleAccessOperation - type level validation (rao)', t => {
     // ADD_WRITER complete
     topLevelValidationTests(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_add_writer,
         'rao',
         not_allowed_data_types,
@@ -35,7 +35,7 @@ test('validateRoleAccessOperation - type level validation (rao)', t => {
     // ADD_WRITER partial
     topLevelValidationTests(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_add_writer,
         'rao',
         not_allowed_data_types,
@@ -45,7 +45,7 @@ test('validateRoleAccessOperation - type level validation (rao)', t => {
     // REMOVE_WRITER complete
     topLevelValidationTests(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_remove_writer,
         'rao',
         not_allowed_data_types,
@@ -55,7 +55,7 @@ test('validateRoleAccessOperation - type level validation (rao)', t => {
     // REMOVE_WRITER partial
     topLevelValidationTests(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_remove_writer,
         'rao',
         not_allowed_data_types,
@@ -65,7 +65,7 @@ test('validateRoleAccessOperation - type level validation (rao)', t => {
     // ADMIN_RECOVERY complete
     topLevelValidationTests(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_admin_recovery,
         'rao',
         not_allowed_data_types,
@@ -75,7 +75,7 @@ test('validateRoleAccessOperation - type level validation (rao)', t => {
     // ADMIN_RECOVERY partial
     topLevelValidationTests(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_admin_recovery,
         'rao',
         not_allowed_data_types,
@@ -87,7 +87,7 @@ test('validateRoleAccessOperation - value level validation (rao)', t => {
     // ADD_WRITER complete
     valueLevelValidationTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_add_writer,
         'rao',
         RAO.complete_role_access_value_fields,
@@ -97,7 +97,7 @@ test('validateRoleAccessOperation - value level validation (rao)', t => {
     // ADD_WRITER partial
     valueLevelValidationTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_add_writer,
         'rao',
         RAO.partial_role_access_value_fields,
@@ -107,7 +107,7 @@ test('validateRoleAccessOperation - value level validation (rao)', t => {
     // REMOVE_WRITER complete
     valueLevelValidationTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_remove_writer,
         'rao',
         RAO.complete_role_access_value_fields,
@@ -117,7 +117,7 @@ test('validateRoleAccessOperation - value level validation (rao)', t => {
     // REMOVE_WRITER partial
     valueLevelValidationTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_remove_writer,
         'rao',
         RAO.partial_role_access_value_fields,
@@ -127,7 +127,7 @@ test('validateRoleAccessOperation - value level validation (rao)', t => {
     // ADMIN_RECOVERY complete
     valueLevelValidationTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_admin_recovery,
         'rao',
         RAO.complete_role_access_value_fields,
@@ -137,7 +137,7 @@ test('validateRoleAccessOperation - value level validation (rao)', t => {
     // ADMIN_RECOVERY partial
     valueLevelValidationTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_admin_recovery,
         'rao',
         RAO.partial_role_access_value_fields,
@@ -149,42 +149,42 @@ test('validateRoleAccessOperation - address buffer length validation - TOP LEVEL
     // ADD_WRITER complete
     addressBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_add_writer
     )
 
     // ADD_WRITER partial
     addressBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_add_writer
     )
 
     // REMOVE_WRITER complete
     addressBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_remove_writer
     )
 
     // REMOVE_WRITER partial
     addressBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_remove_writer
     )
 
     // ADMIN_RECOVERY complete
     addressBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_admin_recovery
     )
 
     // ADMIN_RECOVERY partial
     addressBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_admin_recovery
     )
 })
@@ -193,7 +193,7 @@ test('validateRoleAccessOperation - fields buffer length validation - VALUE LEVE
     // ADD_WRITER complete
     fieldsBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_add_writer,
         'rao',
         RAO.required_length_of_fields_for_complete_role_access
@@ -202,7 +202,7 @@ test('validateRoleAccessOperation - fields buffer length validation - VALUE LEVE
     // ADD_WRITER partial
     fieldsBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_add_writer,
         'rao',
         RAO.required_length_of_fields_for_partial_role_access
@@ -211,7 +211,7 @@ test('validateRoleAccessOperation - fields buffer length validation - VALUE LEVE
     // REMOVE_WRITER complete
     fieldsBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_remove_writer,
         'rao',
         RAO.required_length_of_fields_for_complete_role_access
@@ -220,7 +220,7 @@ test('validateRoleAccessOperation - fields buffer length validation - VALUE LEVE
     // REMOVE_WRITER partial
     fieldsBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_remove_writer,
         'rao',
         RAO.required_length_of_fields_for_partial_role_access
@@ -229,7 +229,7 @@ test('validateRoleAccessOperation - fields buffer length validation - VALUE LEVE
     // ADMIN_RECOVERY complete
     fieldsBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_admin_recovery,
         'rao',
         RAO.required_length_of_fields_for_complete_role_access
@@ -238,7 +238,7 @@ test('validateRoleAccessOperation - fields buffer length validation - VALUE LEVE
     // ADMIN_RECOVERY partial
     fieldsBufferLengthTest(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_partial_admin_recovery,
         'rao',
         RAO.required_length_of_fields_for_partial_role_access
@@ -248,7 +248,7 @@ test('validateRoleAccessOperation - fields buffer length validation - VALUE LEVE
 test('validateRoleAccessOperation - optional fields va, vn, vs', t => {
     partialTypeCommonTests(
         t,
-        check.validateRoleAccessOperation.bind(check),
+        stateValidationSchema.validateRoleAccessOperation.bind(stateValidationSchema),
         RAO.valid_complete_add_writer,
         'rao'
     )

--- a/tests/unit/utils/check/setEpochOperation.test.js
+++ b/tests/unit/utils/check/setEpochOperation.test.js
@@ -1,7 +1,7 @@
 import test from 'brittle';
 import b4a from 'b4a';
 
-import Check from '../../../../src/utils/check.js';
+import StateValidationSchema from '../../../../src/core/state/validators/StateValidationSchema.js';
 import {
     encodeProofProposal,
     encodeProofProposalApproval
@@ -19,18 +19,18 @@ import { topLevelValidationTests, valueLevelValidationTest, addressBufferLengthT
 import { config } from '../../../helpers/config.js';
 import consensusFixtures from '../../../fixtures/consensusV1Operation.fixtures.js';
 
-const check = new Check(config);
+const stateValidationSchema = new StateValidationSchema(config);
 const UNKNOWN_PROTOBUF_FIELD = b4a.from([0x9a, 0x06, 0x01, 0xff]);
 
 const PROOF_DATA_FIELD_RULES = Object.freeze([
-    {name: 'protocol_version', length: PROTOCOL_VERSION_BYTE_LENGTH},
-    {name: 'network_id', length: NETWORK_ID_BYTE_LENGTH},
-    {name: 'epoch', length: EPOCH_BYTE_LENGTH},
-    {name: 'previous_epoch_record_hash', length: HASH_BYTE_LENGTH},
-    {name: 'proposer', length: config.addressLength},
-    {name: 'vdf_parameters_hash', length: HASH_BYTE_LENGTH},
-    {name: 'vdf_proof', length: VDF_BLOB_PROOF_SIZE},
-    {name: 'signature', length: SIGNATURE_BYTE_LENGTH}
+    {name: 'protocol_version', length: PROTOCOL_VERSION_BYTE_LENGTH, allowZero: false},
+    {name: 'network_id', length: NETWORK_ID_BYTE_LENGTH, allowZero: true},
+    {name: 'epoch', length: EPOCH_BYTE_LENGTH, allowZero: true},
+    {name: 'previous_epoch_record_hash', length: HASH_BYTE_LENGTH, allowZero: false},
+    {name: 'proposer', length: config.addressLength, allowZero: false},
+    {name: 'vdf_parameters_hash', length: HASH_BYTE_LENGTH, allowZero: false},
+    {name: 'vdf_proof', length: VDF_BLOB_PROOF_SIZE, allowZero: false},
+    {name: 'signature', length: SIGNATURE_BYTE_LENGTH, allowZero: false}
 ]);
 
 const APPROVAL_FIELD_RULES = Object.freeze([
@@ -108,13 +108,13 @@ const withApprovals = approvals => {
 const setEpochValueNotAllowedDataTypes = not_allowed_data_types.filter(value => !Array.isArray(value));
 
 test('validateSetEpochOperation - happy path', t => {
-    t.ok(check.validateSetEpochOperation(SEO.valid_set_epoch_operation), 'Valid data for set epoch operation should pass the validation')
+    t.ok(stateValidationSchema.validateSetEpochOperation(SEO.valid_set_epoch_operation), 'Valid data for set epoch operation should pass the validation')
 })
 
 test('validateSetEpochOperation - type level validation (seo)', t => {
     topLevelValidationTests(
         t,
-        check.validateSetEpochOperation.bind(check),
+        stateValidationSchema.validateSetEpochOperation.bind(stateValidationSchema),
         SEO.valid_set_epoch_operation,
         'seo',
         not_allowed_data_types,
@@ -125,7 +125,7 @@ test('validateSetEpochOperation - type level validation (seo)', t => {
 test('validateSetEpochOperation - value level validation (seo)', t => {
     valueLevelValidationTest(
         t,
-        check.validateSetEpochOperation.bind(check),
+        stateValidationSchema.validateSetEpochOperation.bind(stateValidationSchema),
         SEO.valid_set_epoch_operation,
         'seo',
         SEO.set_epoch_value_fields,
@@ -136,7 +136,7 @@ test('validateSetEpochOperation - value level validation (seo)', t => {
 test('validateSetEpochOperation - address buffer length validation - TOP LEVEL', t => {
     addressBufferLengthTest(
         t,
-        check.validateSetEpochOperation.bind(check),
+        stateValidationSchema.validateSetEpochOperation.bind(stateValidationSchema),
         SEO.valid_set_epoch_operation,
     );
 });
@@ -144,36 +144,36 @@ test('validateSetEpochOperation - address buffer length validation - TOP LEVEL',
 test('validateSetEpochOperation - proof data validation (seo.pd)', t => {
     for (const invalidProofData of not_allowed_data_types) {
         t.absent(
-            check.validateSetEpochOperation(withSetEpochProofData(invalidProofData)),
+            stateValidationSchema.validateSetEpochOperation(withSetEpochProofData(invalidProofData)),
             `proof data with invalid data type should fail: ${String(invalidProofData)} (${typeof invalidProofData})`
         );
     }
 
     t.absent(
-        check.validateSetEpochOperation(withSetEpochProofData(b4a.alloc(32, 0x15))),
+        stateValidationSchema.validateSetEpochOperation(withSetEpochProofData(b4a.alloc(32, 0x15))),
         'proof data with invalid encoding should fail'
     );
 
     t.absent(
-        check.validateSetEpochOperation(withSetEpochProofData(
+        stateValidationSchema.validateSetEpochOperation(withSetEpochProofData(
             b4a.concat([b4a.from(SEO.valid_set_epoch_operation.seo.pd), UNKNOWN_PROTOBUF_FIELD])
         )),
         'proof data with unknown protobuf field should fail'
     );
 
     t.absent(
-        check.validateSetEpochOperation(withSetEpochProofData(encodedProofDataInReverseFieldOrder())),
+        stateValidationSchema.validateSetEpochOperation(withSetEpochProofData(encodedProofDataInReverseFieldOrder())),
         'proof data encoded in unexpected field order should fail'
     );
 
     for (const {name} of PROOF_DATA_FIELD_RULES) {
         t.absent(
-            check.validateSetEpochOperation(withSetEpochProofData(encodedProofDataWithoutField(name))),
+            stateValidationSchema.validateSetEpochOperation(withSetEpochProofData(encodedProofDataWithoutField(name))),
             `proof data without ${name} should fail`
         );
 
         t.absent(
-            check.validateSetEpochOperation(withSetEpochProofData(
+            stateValidationSchema.validateSetEpochOperation(withSetEpochProofData(
                 b4a.concat([
                     b4a.from(SEO.valid_set_epoch_operation.seo.pd),
                     encodedProofDataSingleField(name, consensusFixtures.proofProposal[name])
@@ -183,23 +183,23 @@ test('validateSetEpochOperation - proof data validation (seo.pd)', t => {
         );
     }
 
-    for (const {name, length} of PROOF_DATA_FIELD_RULES) {
+    for (const {name, length, allowZero} of PROOF_DATA_FIELD_RULES) {
         t.absent(
-            check.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
+            stateValidationSchema.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
                 [name]: b4a.alloc(0)
             }))),
             `proof data with empty ${name} should fail`
         );
 
         t.absent(
-            check.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
+            stateValidationSchema.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
                 [name]: b4a.alloc(length - 1, 0x15)
             }))),
             `proof data with ${name} one byte too short should fail`
         );
 
         t.absent(
-            check.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
+            stateValidationSchema.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
                 [name]: b4a.alloc(length + 1, 0x15)
             }))),
             `proof data with ${name} one byte too long should fail`
@@ -209,31 +209,38 @@ test('validateSetEpochOperation - proof data validation (seo.pd)', t => {
             [name]: b4a.alloc(length)
         }));
 
-        t.absent(
-            check.validateSetEpochOperation(proofDataWithZeroField),
-            `proof data with zero-filled ${name} should fail`
-        );
+        if (allowZero) {
+            t.ok(
+                stateValidationSchema.validateSetEpochOperation(proofDataWithZeroField),
+                `proof data with zero-filled ${name} should pass`
+            );
+        } else {
+            t.absent(
+                stateValidationSchema.validateSetEpochOperation(proofDataWithZeroField),
+                `proof data with zero-filled ${name} should fail`
+            );
+        }
     }
 });
 
 test('validateSetEpochOperation - approvals validation (seo.app)', t => {
-    t.ok(check.validateSetEpochOperation(cloneSetEpochOperation()), 'valid set epoch operation should pass');
+    t.ok(stateValidationSchema.validateSetEpochOperation(cloneSetEpochOperation()), 'valid set epoch operation should pass');
 
-    t.ok(check.validateSetEpochOperation(withApprovals([])), 'empty approvals should pass schema validation');
+    t.ok(stateValidationSchema.validateSetEpochOperation(withApprovals([])), 'empty approvals should pass schema validation');
 
     t.absent(
-        check.validateSetEpochOperation(withApprovals([b4a.alloc(0)])),
+        stateValidationSchema.validateSetEpochOperation(withApprovals([b4a.alloc(0)])),
         'empty approval value should fail'
     );
 
     t.absent(
-        check.validateSetEpochOperation(withApprovals(b4a.alloc(64, 0x15))),
+        stateValidationSchema.validateSetEpochOperation(withApprovals(b4a.alloc(64, 0x15))),
         'single approval buffer should fail'
     );
 
     for (const invalidItem of not_allowed_data_types) {
         t.absent(
-            check.validateSetEpochOperation(withApprovals([
+            stateValidationSchema.validateSetEpochOperation(withApprovals([
                 b4a.from(SEO.valid_set_epoch_operation.seo.app[0]),
                 invalidItem
             ])),
@@ -244,35 +251,35 @@ test('validateSetEpochOperation - approvals validation (seo.app)', t => {
     const sparseApprovals = [b4a.from(SEO.valid_set_epoch_operation.seo.app[0])];
     sparseApprovals.length = 2;
     t.absent(
-        check.validateSetEpochOperation(withApprovals(sparseApprovals)),
+        stateValidationSchema.validateSetEpochOperation(withApprovals(sparseApprovals)),
         'sparse approvals array should fail'
     );
 
     t.absent(
-        check.validateSetEpochOperation(withApprovals([b4a.alloc(32, 0x15)])),
+        stateValidationSchema.validateSetEpochOperation(withApprovals([b4a.alloc(32, 0x15)])),
         'approval item with invalid encoding should fail'
     );
 
     t.absent(
-        check.validateSetEpochOperation(withApprovals([
+        stateValidationSchema.validateSetEpochOperation(withApprovals([
             b4a.concat([b4a.from(SEO.valid_set_epoch_operation.seo.app[0]), UNKNOWN_PROTOBUF_FIELD])
         ])),
         'approval item with unknown protobuf field should fail'
     );
 
     t.absent(
-        check.validateSetEpochOperation(withApprovals([encodedApprovalInReverseFieldOrder()])),
+        stateValidationSchema.validateSetEpochOperation(withApprovals([encodedApprovalInReverseFieldOrder()])),
         'approval item encoded in unexpected field order should fail'
     );
 
     for (const {name} of APPROVAL_FIELD_RULES) {
         t.absent(
-            check.validateSetEpochOperation(withApprovals([encodedApprovalWithoutField(name)])),
+            stateValidationSchema.validateSetEpochOperation(withApprovals([encodedApprovalWithoutField(name)])),
             `approval without ${name} should fail`
         );
 
         t.absent(
-            check.validateSetEpochOperation(withApprovals([
+            stateValidationSchema.validateSetEpochOperation(withApprovals([
                 b4a.concat([
                     b4a.from(SEO.valid_set_epoch_operation.seo.app[0]),
                     encodedApprovalSingleField(name, consensusFixtures.proofProposalApproval[name])
@@ -284,28 +291,28 @@ test('validateSetEpochOperation - approvals validation (seo.app)', t => {
 
     for (const {name, length} of APPROVAL_FIELD_RULES) {
         t.absent(
-            check.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
+            stateValidationSchema.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
                 [name]: b4a.alloc(0)
             })])),
             `approval with empty ${name} should fail`
         );
 
         t.absent(
-            check.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
+            stateValidationSchema.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
                 [name]: b4a.alloc(length - 1, 0x15)
             })])),
             `approval with ${name} one byte too short should fail`
         );
 
         t.absent(
-            check.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
+            stateValidationSchema.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
                 [name]: b4a.alloc(length + 1, 0x15)
             })])),
             `approval with ${name} one byte too long should fail`
         );
 
         t.absent(
-            check.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
+            stateValidationSchema.validateSetEpochOperation(withApprovals([encodedApprovalWithOverrides({
                 [name]: b4a.alloc(length)
             })])),
             `approval with zero-filled ${name} should fail`

--- a/tests/unit/utils/check/setEpochOperation.test.js
+++ b/tests/unit/utils/check/setEpochOperation.test.js
@@ -23,14 +23,14 @@ const stateValidationSchema = new StateValidationSchema(config);
 const UNKNOWN_PROTOBUF_FIELD = b4a.from([0x9a, 0x06, 0x01, 0xff]);
 
 const PROOF_DATA_FIELD_RULES = Object.freeze([
-    {name: 'protocol_version', length: PROTOCOL_VERSION_BYTE_LENGTH, allowZero: false},
-    {name: 'network_id', length: NETWORK_ID_BYTE_LENGTH, allowZero: true},
-    {name: 'epoch', length: EPOCH_BYTE_LENGTH, allowZero: true},
-    {name: 'previous_epoch_record_hash', length: HASH_BYTE_LENGTH, allowZero: false},
-    {name: 'proposer', length: config.addressLength, allowZero: false},
-    {name: 'vdf_parameters_hash', length: HASH_BYTE_LENGTH, allowZero: false},
-    {name: 'vdf_proof', length: VDF_BLOB_PROOF_SIZE, allowZero: false},
-    {name: 'signature', length: SIGNATURE_BYTE_LENGTH, allowZero: false}
+    {name: 'protocol_version', length: PROTOCOL_VERSION_BYTE_LENGTH},
+    {name: 'network_id', length: NETWORK_ID_BYTE_LENGTH},
+    {name: 'epoch', length: EPOCH_BYTE_LENGTH},
+    {name: 'previous_epoch_record_hash', length: HASH_BYTE_LENGTH},
+    {name: 'proposer', length: config.addressLength},
+    {name: 'vdf_parameters_hash', length: HASH_BYTE_LENGTH},
+    {name: 'vdf_proof', length: VDF_BLOB_PROOF_SIZE},
+    {name: 'signature', length: SIGNATURE_BYTE_LENGTH}
 ]);
 
 const APPROVAL_FIELD_RULES = Object.freeze([
@@ -183,7 +183,7 @@ test('validateSetEpochOperation - proof data validation (seo.pd)', t => {
         );
     }
 
-    for (const {name, length, allowZero} of PROOF_DATA_FIELD_RULES) {
+    for (const {name, length} of PROOF_DATA_FIELD_RULES) {
         t.absent(
             stateValidationSchema.validateSetEpochOperation(withSetEpochProofData(encodedProofData({
                 [name]: b4a.alloc(0)
@@ -209,17 +209,10 @@ test('validateSetEpochOperation - proof data validation (seo.pd)', t => {
             [name]: b4a.alloc(length)
         }));
 
-        if (allowZero) {
-            t.ok(
-                stateValidationSchema.validateSetEpochOperation(proofDataWithZeroField),
-                `proof data with zero-filled ${name} should pass`
-            );
-        } else {
-            t.absent(
-                stateValidationSchema.validateSetEpochOperation(proofDataWithZeroField),
-                `proof data with zero-filled ${name} should fail`
-            );
-        }
+        t.absent(
+            stateValidationSchema.validateSetEpochOperation(proofDataWithZeroField),
+            `proof data with zero-filled ${name} should fail`
+        );
     }
 });
 

--- a/tests/unit/utils/check/transactionOperation.test.js
+++ b/tests/unit/utils/check/transactionOperation.test.js
@@ -1,15 +1,15 @@
 import test from 'brittle'
-import Check from '../../../../src/utils/check.js';
+import StateValidationSchema from '../../../../src/core/state/validators/StateValidationSchema.js';
 import { TXO, not_allowed_data_types } from '../../../fixtures/check.fixtures.js';
 import { topLevelValidationTests, valueLevelValidationTest, addressBufferLengthTest, fieldsBufferLengthTest, partialTypeCommonTests } from './common.test.js';
 import { config } from '../../../helpers/config.js';
 
-const check = new Check(config)
+const stateValidationSchema = new StateValidationSchema(config)
 
 test('validateTransactionOperation - happy-path case', t => {
     // ADD_WRITER
-    const partial_result = check.validateTransactionOperation(TXO.valid_partial_transaction_operation)
-    const complete_result = check.validateTransactionOperation(TXO.valid_complete_transaction_operation)
+    const partial_result = stateValidationSchema.validateTransactionOperation(TXO.valid_partial_transaction_operation)
+    const complete_result = stateValidationSchema.validateTransactionOperation(TXO.valid_complete_transaction_operation)
     t.ok(partial_result, 'Valid data for partial transaction operation should pass the validation')
     t.ok(complete_result, 'Valid data for complete transaction operation should pass the validation')
 })
@@ -17,7 +17,7 @@ test('validateTransactionOperation - happy-path case', t => {
 test('validateTransactionOperation - optional fields va, vn, vs', t => {
     partialTypeCommonTests(
         t,
-        check.validateTransactionOperation.bind(check),
+        stateValidationSchema.validateTransactionOperation.bind(stateValidationSchema),
         TXO.valid_complete_transaction_operation,
         'txo'
 
@@ -28,7 +28,7 @@ test('validateTransactionOperation - data type validation TOP LEVEL', t => {
     //complete
     topLevelValidationTests(
         t,
-        check.validateTransactionOperation.bind(check),
+        stateValidationSchema.validateTransactionOperation.bind(stateValidationSchema),
         TXO.valid_complete_transaction_operation,
         'txo',
         not_allowed_data_types,
@@ -37,7 +37,7 @@ test('validateTransactionOperation - data type validation TOP LEVEL', t => {
     //partial
     topLevelValidationTests(
         t,
-        check.validateTransactionOperation.bind(check),
+        stateValidationSchema.validateTransactionOperation.bind(stateValidationSchema),
         TXO.valid_partial_transaction_operation,
         'txo',
         not_allowed_data_types,
@@ -50,7 +50,7 @@ test('validateTransactionOperation - value level validation (txo)', t => {
     //complete
     valueLevelValidationTest(
         t,
-        check.validateTransactionOperation.bind(check),
+        stateValidationSchema.validateTransactionOperation.bind(stateValidationSchema),
         TXO.valid_complete_transaction_operation,
         'txo',
         TXO.complete_transaction_operation_value_fields,
@@ -59,7 +59,7 @@ test('validateTransactionOperation - value level validation (txo)', t => {
     // partial
     valueLevelValidationTest(
         t,
-        check.validateTransactionOperation.bind(check),
+        stateValidationSchema.validateTransactionOperation.bind(stateValidationSchema),
         TXO.valid_partial_transaction_operation,
         'txo',
         TXO.partial_transaction_operation_value_fields,
@@ -74,13 +74,13 @@ test('validateTransactionOperation - address buffer length validation - TOP LEVE
     //complete
     addressBufferLengthTest(
         t,
-        check.validateTransactionOperation.bind(check),
+        stateValidationSchema.validateTransactionOperation.bind(stateValidationSchema),
         TXO.valid_complete_transaction_operation,
     );
     //partial
     addressBufferLengthTest(
         t,
-        check.validateTransactionOperation.bind(check),
+        stateValidationSchema.validateTransactionOperation.bind(stateValidationSchema),
         TXO.valid_partial_transaction_operation,
     );
 });
@@ -90,7 +90,7 @@ test('validateTransactionOperation - Buffer length validation - VALUE LEVEL (txo
     //complete
     fieldsBufferLengthTest(
         t,
-        check.validateTransactionOperation.bind(check),
+        stateValidationSchema.validateTransactionOperation.bind(stateValidationSchema),
         TXO.valid_complete_transaction_operation,
         'txo',
         TXO.required_length_of_fields_for_complete_transaction_operation
@@ -98,7 +98,7 @@ test('validateTransactionOperation - Buffer length validation - VALUE LEVEL (txo
     //partial
     fieldsBufferLengthTest(
         t,
-        check.validateTransactionOperation.bind(check),
+        stateValidationSchema.validateTransactionOperation.bind(stateValidationSchema),
         TXO.valid_partial_transaction_operation,
         'txo',
         TXO.required_length_of_fields_for_partial_transaction_operation

--- a/tests/unit/utils/check/transferOperation.test.js
+++ b/tests/unit/utils/check/transferOperation.test.js
@@ -1,15 +1,15 @@
 import test from 'brittle'
-import Check from '../../../../src/utils/check.js';
+import StateValidationSchema from '../../../../src/core/state/validators/StateValidationSchema.js';
 import { TRO, not_allowed_data_types } from '../../../fixtures/check.fixtures.js';
 import { topLevelValidationTests, valueLevelValidationTest, addressBufferLengthTest, fieldsBufferLengthTest, partialTypeCommonTests } from './common.test.js';
 import { config } from '../../../helpers/config.js';
 
-const check = new Check(config)
+const stateValidationSchema = new StateValidationSchema(config)
 
 test('validateTransferOperation - happy-path case', t => {
     // ADD_WRITER
-    const partial_result = check.validateTransferOperation(TRO.valid_partial_transfer)
-    const complete_result = check.validateTransferOperation(TRO.valid_complete_transfer)
+    const partial_result = stateValidationSchema.validateTransferOperation(TRO.valid_partial_transfer)
+    const complete_result = stateValidationSchema.validateTransferOperation(TRO.valid_complete_transfer)
     t.ok(partial_result, 'Valid data for partial transaction operation should pass the validation')
     t.ok(complete_result, 'Valid data for complete transaction operation should pass the validation')
 })
@@ -17,7 +17,7 @@ test('validateTransferOperation - happy-path case', t => {
 test('validateTransferOperation - optional fields va, vn, vs', t => {
     partialTypeCommonTests(
         t,
-        check.validateTransferOperation.bind(check),
+        stateValidationSchema.validateTransferOperation.bind(stateValidationSchema),
         TRO.valid_complete_transfer,
         'tro'
     )
@@ -27,7 +27,7 @@ test('validateTransferOperation - data type validation TOP LEVEL', t => {
     //complete
     topLevelValidationTests(
         t,
-        check.validateTransferOperation.bind(check),
+        stateValidationSchema.validateTransferOperation.bind(stateValidationSchema),
         TRO.valid_complete_transfer,
         'tro',
         not_allowed_data_types,
@@ -36,7 +36,7 @@ test('validateTransferOperation - data type validation TOP LEVEL', t => {
     //partial
     topLevelValidationTests(
         t,
-        check.validateTransferOperation.bind(check),
+        stateValidationSchema.validateTransferOperation.bind(stateValidationSchema),
         TRO.valid_partial_transfer,
         'tro',
         not_allowed_data_types,
@@ -48,7 +48,7 @@ test('validateTransferOperation - value level validation (tro)', t => {
     //complete
     valueLevelValidationTest(
         t,
-        check.validateTransferOperation.bind(check),
+        stateValidationSchema.validateTransferOperation.bind(stateValidationSchema),
         TRO.valid_complete_transfer,
         'tro',
         TRO.complete_transfer_value_fields,
@@ -57,7 +57,7 @@ test('validateTransferOperation - value level validation (tro)', t => {
     // partial
     valueLevelValidationTest(
         t,
-        check.validateTransferOperation.bind(check),
+        stateValidationSchema.validateTransferOperation.bind(stateValidationSchema),
         TRO.valid_partial_transfer,
         'tro',
         TRO.partial_transfer_value_fields,
@@ -70,13 +70,13 @@ test('validateTransferOperation - address buffer length validation - TOP LEVEL',
     //complete
     addressBufferLengthTest(
         t,
-        check.validateTransferOperation.bind(check),
+        stateValidationSchema.validateTransferOperation.bind(stateValidationSchema),
         TRO.valid_complete_transfer,
     );
     //partial
     addressBufferLengthTest(
         t,
-        check.validateTransferOperation.bind(check),
+        stateValidationSchema.validateTransferOperation.bind(stateValidationSchema),
         TRO.valid_partial_transfer,
     );
 });
@@ -85,7 +85,7 @@ test('validateTransferOperation - Buffer length validation - VALUE LEVEL (tro)',
     //complete
     fieldsBufferLengthTest(
         t,
-        check.validateTransferOperation.bind(check),
+        stateValidationSchema.validateTransferOperation.bind(stateValidationSchema),
         TRO.valid_complete_transfer,
         'tro',
         TRO.required_length_of_fields_for_complete_transfer
@@ -93,7 +93,7 @@ test('validateTransferOperation - Buffer length validation - VALUE LEVEL (tro)',
     //partial
     fieldsBufferLengthTest(
         t,
-        check.validateTransferOperation.bind(check),
+        stateValidationSchema.validateTransferOperation.bind(stateValidationSchema),
         TRO.valid_partial_transfer,
         'tro',
         TRO.required_length_of_fields_for_partial_transfer


### PR DESCRIPTION
This pull request refactors the codebase to replace the usage of the `Check` class with a new `StateValidationSchema` class for state and operation validation logic. The changes improve code clarity by renaming, relocating, and updating references to the validation logic throughout the core, network protocol, and state management modules.

**Validation Refactor and Code Cleanup:**

* The `Check` class was renamed and moved to `StateValidationSchema` in `src/core/state/validators/StateValidationSchema.js`, and all imports and usages were updated accordingly. [[1]](diffhunk://#diff-4086ceed275721c117c0c6f531d7341e1b40ff87916656e228af2ca94fabd6ffL17-R25) [[2]](diffhunk://#diff-4086ceed275721c117c0c6f531d7341e1b40ff87916656e228af2ca94fabd6ffL645-R645)
* All references to `this.check` in the `State` class and protocol validators were replaced with `this.stateValidationSchema`, and all validation method calls were updated to use the new class. [[1]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L73-R73) [[2]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L537-R537) [[3]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L682-R682) [[4]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L793-R793) [[5]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L930-R930) [[6]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L1181-R1181) [[7]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L1430-R1430) [[8]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L1734-R1734) [[9]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L1998-R1998) [[10]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L2216-R2216) [[11]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L2433-R2433) [[12]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L2634-R2634) [[13]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L2868-R2868) [[14]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L3082-R3082) [[15]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L3286-R3286) [[16]](diffhunk://#diff-a6685a9dd90a949ebf206008ff9b6bf485accd961d19023c5180ce5edf4fb654L3-R3) [[17]](diffhunk://#diff-a6685a9dd90a949ebf206008ff9b6bf485accd961d19023c5180ce5edf4fb654L17-R24) [[18]](diffhunk://#diff-a6685a9dd90a949ebf206008ff9b6bf485accd961d19023c5180ce5edf4fb654L34-R35) [[19]](diffhunk://#diff-a6685a9dd90a949ebf206008ff9b6bf485accd961d19023c5180ce5edf4fb654L47-R65) [[20]](diffhunk://#diff-0e4cc97ffd3f984ac1a238d185a80e404ee4381252fb873db4001d0c55378722L9-R9) [[21]](diffhunk://#diff-0e4cc97ffd3f984ac1a238d185a80e404ee4381252fb873db4001d0c55378722L35-R42) [[22]](diffhunk://#diff-0e4cc97ffd3f984ac1a238d185a80e404ee4381252fb873db4001d0c55378722L96-R105)
* The legacy `Check` class and related imports were removed from all files, including `src/index.js` and tests. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L9) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L50) [[3]](diffhunk://#diff-4d1c553a7ecea861c38acd7d95cd197a7c0e6dd1210d3c3197aa2d87a8715dc2L48-L54)

**Constants and Documentation:**

* Updated comments in `src/utils/constants.js` to reference `StateValidationSchema.js` instead of `check.js` for clarity.

**File and Import Structure:**

* Updated import paths in the refactored `StateValidationSchema` to use correct relative paths to shared codecs and constants.

This refactor centralizes and clarifies the validation logic, making it easier to maintain and extend validation rules in the future.