### PR TITLE
feat: create indexer observer service

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -70,11 +70,6 @@ export class Config {
         return !!this.#config.enableRoleRequester
     }
 
-    get enableValidatorObserver() {
-        if (this.#isOverriden('enableValidatorObserver')) return !!this.#options.enableValidatorObserver
-        return !!this.#config.enableValidatorObserver
-    }
-
     get enableTxApplyLogs() {
         if (this.#isOverriden('enableTxApplyLogs')) return !!this.#options.enableTxApplyLogs
         return !!this.#config.enableTxApplyLogs

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -20,7 +20,6 @@ const configData = {
         channel: '1111trac1network1msb1testnet1111',
         dhtBootstrap: ['116.202.214.149:10001','157.180.12.214:10001','node1.hyperdht.org:49737','node2.hyperdht.org:49737','node3.hyperdht.org:49737'], // these are used to peer discovery
         derivationPath: address.TESNET_DERIVATION_PATH,
-        enableValidatorObserver: true,
         pollInterval: 500, // Validator observer poll interval
         adminCacheTTL: 10_000, // Admin cache TTL ms
         validatorConnectionAttemptDelay: 5, // Delay between validator connection attempts (ms)
@@ -74,7 +73,6 @@ const configData = {
         channel: '0000trac0network0msb0mainnet0000',
         dhtBootstrap: ['116.202.214.149:10001','157.180.12.214:10001','node1.hyperdht.org:49737','node2.hyperdht.org:49737','node3.hyperdht.org:49737'],
         derivationPath: address.MAINNET_DERIVATION_PATH,
-        enableValidatorObserver: true,
         pollInterval: 500, // Validator observer poll interval
         adminCacheTTL: 3_600_000, // Admin cache TTL ms
         validatorConnectionAttemptDelay: 5, // Delay between validator connection attempts (ms)
@@ -128,7 +126,6 @@ const configData = {
         channel: '12312313123123',
         dhtBootstrap: ['116.202.214.149:10001','157.180.12.214:10001','node1.hyperdht.org:49737','node2.hyperdht.org:49737','node3.hyperdht.org:49737'],
         derivationPath: address.MAINNET_DERIVATION_PATH,
-        enableValidatorObserver: true,
         pollInterval: 500, // Validator observer poll interval
         adminCacheTTL: 60_000, // Admin cache TTL ms
         validatorConnectionAttemptDelay: 5, // Delay between validator connection attempts (ms)

--- a/src/core/consensus/protocols/ConsensusMessages.js
+++ b/src/core/consensus/protocols/ConsensusMessages.js
@@ -10,7 +10,7 @@ class ConsensusMessages {
         this.#consensusRouter = new ConsensusRouterV1(state, wallet, config, pendingRequestService);
     }
 
-    async setupProtomuxMessages(connection) {
+    setupProtomuxMessages(connection) {
         connection.consensusProtocolSession = new ConsensusV1Protocol(
             this.#consensusRouter,
             connection,

--- a/src/core/consensus/services/IndexerConnectionManager.js
+++ b/src/core/consensus/services/IndexerConnectionManager.js
@@ -73,6 +73,10 @@ class IndexerConnectionManager {
         console.log(`Connection count: ${this.#indexers.size}`);
         console.log(`Indexer map keys:\n${Array.from(this.#indexers.keys()).join('\n')}`);
     }
+
+    clear() {
+        this.#indexers.clear();
+    }
 }
 
 export default IndexerConnectionManager;

--- a/src/core/consensus/services/IndexerObserverService.js
+++ b/src/core/consensus/services/IndexerObserverService.js
@@ -1,0 +1,106 @@
+import SchedulableService from "../../../utils/scheduler/SchedulableService.js";
+import { Logger } from "../../../utils/logger.js";
+import { CONNECTION_STATUS } from "../../../utils/constants.js"
+import b4a from "b4a";
+import { bufferToAddress } from "../../../core/state/utils/address.js";
+import tracCryptoApi from "trac-crypto-api";
+import { publicKeyToAddress } from "../../../utils/helpers.js";
+
+
+class IndexerObserverService extends SchedulableService {
+    #network
+    #state
+    #config
+    #logger
+    #address
+
+    constructor(network, state, address, config) {
+        super();
+
+        this.#network = network;
+        this.#state = state;
+        this.#address = address;
+        this.#config = config;
+        this.#logger = new Logger(config);
+    }
+
+    #shouldRun() {
+        return !this.isInterrupted;
+    }
+
+    getScheduleInterval() {
+        return this.#config.pollInterval;
+    }
+
+    async start() {
+        super.start();
+        this.#logger.info("IndexerObserverService started");
+    }
+
+    async stop(waitForCurrent = true) {
+        const stopped = await super.stop(waitForCurrent);
+        if (!stopped) return;
+        this.#logger.info("IndexerObserverService stopped");
+    }
+
+    async #tryConnect(candidate) {
+        try {
+            const result = await this.#network.tryConnect(candidate.publicKeyHex, "indexer");
+            if (result && result !== CONNECTION_STATUS.IGNORED) {
+                this.#logger.info(`IndexerObserver: connected to indexer ${publicKeyToAddress(candidate.publicKeyHex, this.#config)} (${result})`);
+            }
+            return result;
+        } catch (err) {
+            this.#logger.error(`Indexer connection attempt failed: ${err.message}`);
+        }
+    }
+
+    async #getIndexersCandidates() {
+        const entries = await this.#state.getIndexersEntry();
+        const candidates = [];
+
+        for (const entry of entries) {
+            const writerKeyHex = b4a.toString(entry.key, 'hex');
+            const addressBuffer = await this.#state.getRegisteredWriterKey(writerKeyHex);
+            if (!addressBuffer) continue;
+
+            const addr = bufferToAddress(addressBuffer, this.#config.addressPrefix);
+            if (!addr || addr === this.#address) continue;
+
+            const publicKey = tracCryptoApi.address.decode(addr);
+            const publicKeyHex = b4a.toString(publicKey, 'hex');
+            candidates.push({ publicKey, publicKeyHex });
+        }
+
+        return candidates;
+    }
+
+    async #processCandidates(candidates) {
+        for (const candidate of candidates) {
+            if (!this.#shouldRun()) break;
+
+            const isConnected = this.#network.indexerConnectionManager.connected(candidate.publicKey);
+            const isPending = this.#network.isConnectionPending(candidate.publicKeyHex);
+
+            if (isConnected || isPending) continue;
+
+            await this.#tryConnect(candidate);
+        }
+    }
+
+    async worker(next) {
+        const interval = this.#config.pollInterval;
+        if (!this.#shouldRun()) return next(interval);
+
+        try {
+            const candidates = await this.#getIndexersCandidates();
+            if (candidates.length > 0) await this.#processCandidates(candidates);
+        } catch (err) {
+            this.#logger.error(`IndexerObserver worker error: ${err.message}`);
+        }
+
+        next(interval);
+    }
+}
+
+export default IndexerObserverService;

--- a/src/core/network/Network.js
+++ b/src/core/network/Network.js
@@ -4,13 +4,10 @@ import w from 'protomux-wakeup';
 import b4a from 'b4a';
 import TransactionPoolService from './services/TransactionPoolService.js';
 import ValidatorObserverService from './services/ValidatorObserverService.js';
+import IndexerObserverService from '../consensus/services/IndexerObserverService.js';
 import NetworkMessages from './protocols/NetworkMessages.js';
-import { publicKeyToAddress, sleep } from '../../utils/helpers.js';
-import {
-    TRAC_NAMESPACE,
-    EventType,
-    CONNECTION_STATUS
-} from '../../utils/constants.js';
+import { sleep } from '../../utils/helpers.js';
+import { TRAC_NAMESPACE, CONNECTION_STATUS } from '../../utils/constants.js';
 import ConnectionManager from './services/ConnectionManager.js';
 import MessageOrchestrator from './services/MessageOrchestrator.js';
 import TransactionRateLimiterService from './services/TransactionRateLimiterService.js';
@@ -33,6 +30,7 @@ class Network extends ReadyResource {
     #networkMessages;
     #transactionPoolService;
     #validatorObserverService;
+    #indexerObserverService;
     #validatorConnectionManager;
     #validatorMessageOrchestrator;
     #config;
@@ -67,6 +65,7 @@ class Network extends ReadyResource {
         this.#transactionCommitService = new TransactionCommitService(this.#config);
         this.#transactionPoolService = new TransactionPoolService(state, wallet?.address, this.#transactionCommitService ,this.#config);
         this.#validatorObserverService = new ValidatorObserverService(this, state, wallet?.address, this.#config);
+        this.#indexerObserverService = new IndexerObserverService(this, state, wallet?.address, this.#config);
         this.#validatorConnectionManager = new ConnectionManager(this.#config);
         this.#validatorMessageOrchestrator = new MessageOrchestrator(this.#validatorConnectionManager, state, this.#config);
         this.#validatorPendingRequestService = new ValidatorPendingRequestService(this.#config);
@@ -107,10 +106,9 @@ class Network extends ReadyResource {
         this.validatorObserverService.start();
         await this.#replicate();
 
-        const isAdmin = await this.#state.isAdmin();
-
-        if (this.#state.isIndexer() && !isAdmin) {
+        if (this.#state.isIndexer()) {
             this.#epochProofProposalService.start();
+            this.#indexerObserverService.start();
         }
     }
 
@@ -119,8 +117,8 @@ class Network extends ReadyResource {
         await this.transactionPoolService.stop();
         await sleep(100);
         await this.#validatorObserverService.stop();
+        await this.#indexerObserverService.stop();
 
-        this.cleanupNetworkListeners();
         this.cleanupPendingConnections();
         await this.#validatorHealthCheckService.close();
         await this.#epochProofProposalService.close();
@@ -150,48 +148,10 @@ class Network extends ReadyResource {
             this.disconnectValidatorPeer(publicKey, 'peer became unwritable');
         });
 
-        this.on(EventType.VALIDATOR_CONNECTION_TIMEOUT, ({ publicKey, type, timeoutMs }) => {
-            this.#logger.debug(`Network Event: VALIDATOR_CONNECTION_TIMEOUT | PublicKey: ${publicKey} | Type: ${type} | TimeoutMs: ${timeoutMs}`);
-            this.#pendingConnections.delete(publicKey);
-        });
-
-        this.on(EventType.VALIDATOR_CONNECTION_READY, async ({ publicKey, type, connection }) => {
-            this.#logger.debug(`Network Event: VALIDATOR_CONNECTION_READY | PublicKey: ${publicKey} | Type: ${type}`);
-            const { timeoutId } = this.#pendingConnections.get(publicKey);
-
-            if (!timeoutId) return;
-
-            clearTimeout(timeoutId);
-            this.#pendingConnections.delete(publicKey);
-
-            if (type === 'validator') {
-                try {
-                    if (!connection.protocolSession.isProbed()) await connection.protocolSession.probe();
-                } catch (err) {
-                    this.#logger.debug(`failed to probe peer with publicKey ${publicKey}: ${err?.message ?? err}`);
-                }
-
-                this.#validatorConnectionManager.addValidator(publicKey, connection);
-
-                let healthCheckSupported = false;
-                try {
-                    healthCheckSupported = connection.protocolSession.isHealthCheckSupported();
-                } catch (err) {
-                    this.#logger.debug(`health check support unknown for peer with publicKey ${publicKey}: ${err?.message ?? err}`);
-                }
-
-                if (healthCheckSupported) {
-                    this.#validatorHealthCheckService.start(publicKey);
-                } else {
-                    this.#validatorHealthCheckService.stop(publicKey);
-                }
-            }
-
-        });
-
-        this.#state.on(CustomEventType.IS_INDEXER, (bufferAddress) => {
+        this.#state.on(CustomEventType.IS_INDEXER, bufferAddress => {
             const address = tracCryptoApi.address.encode(this.#config.addressPrefix, bufferAddress);
             if (address === this.#wallet.address) {
+                this.#indexerObserverService.start();
                 this.#epochProofProposalService.start();
             }
         });
@@ -199,14 +159,11 @@ class Network extends ReadyResource {
         this.#state.on(CustomEventType.IS_NON_INDEXER, (bufferAddress) => {
             const address = tracCryptoApi.address.encode(this.#config.addressPrefix, bufferAddress);
             if (address === this.#wallet.address) {
+                this.#indexerObserverService.stop();
                 this.#epochProofProposalService.stop();
+                this.#indexerConnectionManager.clear();
             }
         });
-    }
-
-    cleanupNetworkListeners() {
-        this.removeAllListeners(EventType.VALIDATOR_CONNECTION_TIMEOUT);
-        this.removeAllListeners(EventType.VALIDATOR_CONNECTION_READY);
     }
 
     cleanupPendingConnections() {
@@ -255,57 +212,31 @@ class Network extends ReadyResource {
 
             this.#logger.info(`Channel: ${b4a.toString(this.#config.channel)}`);
 
-            this.#swarm.prependListener('connection', async (connection) => {
-                await this.#networkMessages.setupProtomuxMessages(connection);
-                await this.#consensusMessages.setupProtomuxMessages(connection);
-            });
-
-            this.#swarm.on('connection', async (connection) => {
-                // Per-peer connection initialization:
-                // - attach Protomux (legacy + v1 channels/messages)
-                // - attach connection.protocolSession (used later by tryConnect / orchestrators to send messages)
-
-                // Adds indexers to consensus connection manager
-                const address = publicKeyToAddress(connection.remotePublicKey, this.#config);
-                if (await this.#state.isIndexerAddress(address) && !await this.#state.isAdminAddress(address)) {
-                    this.#indexerConnectionManager.add(connection.remotePublicKey, connection);
-                }
-
+            this.#swarm.prependListener('connection', connection => {
+                this.#networkMessages.setupProtomuxMessages(connection);
+                this.#consensusMessages.setupProtomuxMessages(connection);
                 // ATTENTION: Must be called AFTER the protomux init above
                 const stream = this.#store.replicate(connection);
                 wakeup.addStream(stream);
+            });
 
+            this.#swarm.on('connection', async (connection) => {
                 const publicKey = b4a.toString(connection.remotePublicKey, 'hex');
-                if (this.#pendingConnections.has(publicKey)) {
-                    const { type } = this.#pendingConnections.get(publicKey);
-                    await this.#finalizeConnection(publicKey, type, connection);
-                }
+                // This function will ignore connections that havent been triggered by the observer. In this case, the promotion will happen during tryConnect when the connection entity will be qualified.
+                await this.#promotePendingConnection(publicKey, connection);
+                
 
                 connection.on('close', () => {
-                    this.#validatorPendingRequestService.rejectPendingRequestsForPeer(
-                        publicKey,
-                        new Error('Connection closed before response')
-                    );
-                    this.#indexerPendingRequestService.rejectPendingRequestsForPeer(
-                        publicKey,
-                        new Error('Connection closed before response')
-                    );
+                    this.#rejectAllPendingRequests(publicKey, new Error('Connection closed before response'));
                     this.#swarm.leavePeer(connection.remotePublicKey);
                     this.#validatorConnectionManager.remove(publicKey);
                     this.#indexerConnectionManager.remove(publicKey);
-                    connection.protocolSession.close();
+                    connection.protocolSession?.close();
                     connection.consensusProtocolSession?.close();
                 });
 
                 connection.on('error', (error) => {
-                    this.#validatorPendingRequestService.rejectPendingRequestsForPeer(
-                        publicKey,
-                        error ?? new Error('Connection error before response')
-                    );
-                    this.#indexerPendingRequestService.rejectPendingRequestsForPeer(
-                        publicKey,
-                        error ?? new Error('Connection error before response')
-                    );
+                    this.#rejectAllPendingRequests(publicKey, error ?? new Error('Connection error before response'));
                     if (
                         error && error.message && (
                             error.message.includes('connection reset by peer') ||
@@ -400,42 +331,71 @@ class Network extends ReadyResource {
         }
 
         const timeoutId = setTimeout(() => {
-            if (!this.#pendingConnections.has(publicKey)) return;
-            this.emit(EventType.VALIDATOR_CONNECTION_TIMEOUT, { publicKey, type, timeoutMs: this.#config.connectTimeoutMs });
+            // timeout is here to manage the scenario which we will join peer and estabilish a connection (a bit more overhead for validators)
+            if (this.#pendingConnections.has(publicKey)) {
+                this.#pendingConnections.delete(publicKey)
+            }
         }, this.#config.connectTimeoutMs);
         this.#pendingConnections.set(publicKey, { type, timeoutId });
 
         const target = b4a.from(publicKey, 'hex');
         if (!this.#swarm.peers.has(publicKey)) {
+            // if the connection is not managed by the swarm, we actively connect and the flow will be managed by the on('connection') subscriber
             this.#swarm.joinPeer(target);
-        }
+            return CONNECTION_STATUS.PENDING;
+        } 
 
         const peerInfo = this.#swarm.peers.get(publicKey);
-        if (peerInfo) {
-            const connection = this.#swarm._allConnections.get(peerInfo.publicKey);
+        if (!peerInfo) return;
 
-            if (connection &&
-                connection.protocolSession &&
-                !this.#validatorPendingRequestService.isProbePending(connection.remotePublicKey.toString('hex'))
-            ) {
-                await this.#finalizeConnection(publicKey, type, connection);
-                return CONNECTION_STATUS.CONNECTED;
-            }
-        }
+        const connection = this.#swarm._allConnections.get(peerInfo.publicKey);
+        if (!connection) return CONNECTION_STATUS.PENDING;
+
+        const isConnectionReady = (connection.protocolSession && !this.#validatorPendingRequestService.isProbePending(connection.remotePublicKey.toString('hex'))) || connection.consensusProtocolSession
+        if (isConnectionReady) {
+            await this.#promotePendingConnection(publicKey, connection);
+            return CONNECTION_STATUS.CONNECTED;
+        } 
         
         return CONNECTION_STATUS.PENDING;
     }
 
-    async #finalizeConnection(publicKey, type, connection) {
-        if (!this.#pendingConnections.has(publicKey)) return;
-        this.emit(EventType.VALIDATOR_CONNECTION_READY, { publicKey, type, connection });
-        this.#logger.debug(`Network.finalizeConnection: Connected to peer: ${publicKey} as type: ${type}`);
+    async #promotePendingConnection(publicKey, connection) {
+        const pending = this.#pendingConnections.get(publicKey);
+        if (pending) {
+            clearTimeout(pending.timeoutId);
+            this.#pendingConnections.delete(publicKey);
+
+            if (pending.type === 'indexer') {
+                this.#indexerConnectionManager.add(connection.remotePublicKey, connection);
+            }
+            if (pending.type === 'validator') {
+                try {
+                    if (!connection.protocolSession.isProbed()) await connection.protocolSession.probe();
+                } catch (err) {
+                    this.#logger.debug(`failed to probe peer with publicKey ${publicKey}: ${err?.message ?? err}`);
+                }
+
+                this.#validatorConnectionManager.addValidator(publicKey, connection);
+
+                if (connection.protocolSession.isHealthCheckSupported()) {
+                    this.#validatorHealthCheckService.start(publicKey);
+                } else {
+                    this.#validatorHealthCheckService.stop(publicKey);
+                }
+            }
+        }
     }
 
     #normalizePublicKey(publicKey) {
         if (typeof publicKey === 'string') return publicKey;
         if (b4a.isBuffer(publicKey)) return b4a.toString(publicKey, 'hex');
         return null;
+    }
+
+    #rejectAllPendingRequests(publicKey, error) {
+        this.#validatorPendingRequestService.rejectPendingRequestsForPeer(publicKey, error);
+        this.#indexerPendingRequestService.rejectPendingRequestsForPeer(publicKey, error);
     }
 
     #clearPendingValidatorConnection(publicKeyHex) {

--- a/src/core/network/protocols/NetworkMessages.js
+++ b/src/core/network/protocols/NetworkMessages.js
@@ -42,7 +42,7 @@ class NetworkMessages {
         );
     }
 
-    async setupProtomuxMessages(connection) {
+    setupProtomuxMessages(connection) {
         // Attach a Protomux instance to this Hyperswarm connection.
         // Protomux multiplexes multiple logical protocol channels over a single encrypted stream.
 

--- a/src/core/network/protocols/ProtocolSession.js
+++ b/src/core/network/protocols/ProtocolSession.js
@@ -136,10 +136,7 @@ class ProtocolSession {
      * @returns {Boolean} True if health checks are supported in the preferred protocol, false otherwise.
      */
     isHealthCheckSupported() {
-        if (this.#preferredProtocol === null) {
-            throw new Error('ProtocolSession: preferred protocol not set. Call probe() first.');
-        }
-        return this.#preferredProtocol === this.#supportedProtocols.V1;
+        return this.isProbed() && this.#preferredProtocol === this.#supportedProtocols.V1;
     }
 
     // TODO: Consider moving this method to be used only in V1 internally, just like 'encode'

--- a/src/core/network/services/ValidatorObserverService.js
+++ b/src/core/network/services/ValidatorObserverService.js
@@ -157,7 +157,7 @@ class ValidatorObserverService extends SchedulableService {
      * @returns {boolean} True if the observer is enabled and not interrupted.
      */
     #shouldRun() {
-        return this.#config.enableValidatorObserver && !this.isInterrupted;
+        return !this.isInterrupted;
     }
     
     /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -141,8 +141,6 @@ export const EventType = Object.freeze({
     WRITABLE: 'writable',
     UNWRITABLE: 'unwritable',
     WARNING: 'warning',
-    VALIDATOR_CONNECTION_READY: 'validator-connection-ready',
-    VALIDATOR_CONNECTION_TIMEOUT: 'validator-connection-timeout',
     VALIDATOR_HEALTH_CHECK: 'validator-health-check',
 });
 

--- a/tests/acceptance/v1/rpc.test.mjs
+++ b/tests/acceptance/v1/rpc.test.mjs
@@ -34,7 +34,6 @@ const setupNetwork = async () => {
         channel: randomBytes(16).toString('hex'),
         enableRoleRequester: false,
         enableWallet: true,
-        enableValidatorObserver: true,
         enableInteractiveMode: false,
         disableRateLimit: true,
         enableTxApplyLogs: false,

--- a/tests/unit/consensus/services/IndexerConnectionManager.test.js
+++ b/tests/unit/consensus/services/IndexerConnectionManager.test.js
@@ -127,6 +127,21 @@ test('IndexerConnectionManager', () => {
         });
     });
 
+    test('clear', () => {
+        test('removes all indexers from the pool', async t => {
+            const manager = makeManager(testKeyPair1.publicKey, testKeyPair2.publicKey, testKeyPair3.publicKey);
+            t.is(manager.connectedIndexers().length, 3);
+            manager.clear();
+            t.is(manager.connectedIndexers().length, 0);
+        });
+
+        test('is a no-op on an empty pool', async t => {
+            const manager = new IndexerConnectionManager(0);
+            manager.clear();
+            t.is(manager.connectedIndexers().length, 0);
+        });
+    });
+
     test('sendAndForget', () => {
         test('calls consensusProtocolSession.sendAndForget with the message', async t => {
             const conn = makeConnection(testKeyPair1.publicKey);

--- a/tests/unit/consensus/services/IndexerObserverLifecycle.test.js
+++ b/tests/unit/consensus/services/IndexerObserverLifecycle.test.js
@@ -1,0 +1,310 @@
+import sinon from "sinon";
+import { test } from "brittle";
+import b4a from "b4a";
+import tracCryptoApi from "trac-crypto-api";
+import IndexerObserverService from "../../../../src/core/consensus/services/IndexerObserverService.js";
+
+if (typeof setTimeout !== "undefined" && typeof setTimeout.restore === "function") {
+    setTimeout.restore();
+}
+
+// A valid bech32 address produced from a known public key.
+// getRegisteredWriterKey returns the ASCII bytes of the bech32 string (that's the real storage format).
+const TEST_PUBLIC_KEY = b4a.alloc(32, 1);
+const TEST_ADDRESS = tracCryptoApi.address.encode("trac", TEST_PUBLIC_KEY);
+const TEST_ADDRESS_BUFFER = b4a.from(TEST_ADDRESS, "ascii");
+
+async function cleanup(service) {
+    if (service) {
+        await service.stop(false);
+    }
+}
+
+function createBaseMocks(overrides = {}) {
+    const baseState = {
+        getIndexersEntry: async () => [{ key: b4a.alloc(32, "k") }],
+        getRegisteredWriterKey: async () => TEST_ADDRESS_BUFFER,
+        getAdminEntry: async () => ({ address: "trac_admin" }),
+    };
+
+    const baseNetwork = {
+        indexerConnectionManager: {
+            connected: () => false,
+        },
+        isConnectionPending: () => false,
+        tryConnect: async () => {},
+    };
+
+    return {
+        network: {
+            ...baseNetwork,
+            ...overrides.network,
+            indexerConnectionManager: {
+                ...baseNetwork.indexerConnectionManager,
+                ...(overrides.network?.indexerConnectionManager || {}),
+            },
+        },
+        state: {
+            ...baseState,
+            ...(overrides.state || {}),
+        },
+        config: {
+            pollInterval: 10,
+            addressPrefix: "trac",
+            ...(overrides.config || {}),
+        },
+    };
+}
+
+test("connects successfully (happy path)", async (t) => {
+    const clock = sinon.useFakeTimers({ now: 0 });
+
+    let calls = 0;
+
+    const { network, state, config } = createBaseMocks({
+        network: { tryConnect: () => calls++ },
+    });
+
+    const service = new IndexerObserverService(network, state, "self", config);
+
+    try {
+        await service.start();
+
+        for (let i = 0; i < 50 && calls === 0; i++) {
+            clock.tick(10);
+            await Promise.resolve();
+        }
+
+        await service.stop(false);
+
+        t.ok(calls > 0);
+    } finally {
+        clock.restore();
+        sinon.restore();
+        await cleanup(service);
+    }
+});
+
+test("does NOT connect if already connected", async (t) => {
+    const clock = sinon.useFakeTimers({ now: 0 });
+
+    let calls = 0;
+
+    const { network, state, config } = createBaseMocks({
+        network: {
+            indexerConnectionManager: { connected: () => true },
+            tryConnect: () => calls++,
+        },
+    });
+
+    const service = new IndexerObserverService(network, state, "self", config);
+
+    try {
+        await service.start();
+
+        for (let i = 0; i < 20; i++) {
+            clock.tick(10);
+            await Promise.resolve();
+        }
+
+        await service.stop(false);
+
+        t.is(calls, 0);
+    } finally {
+        clock.restore();
+        sinon.restore();
+        await cleanup(service);
+    }
+});
+
+test("does NOT connect if already pending", async (t) => {
+    const clock = sinon.useFakeTimers({ now: 0 });
+
+    let calls = 0;
+
+    const { network, state, config } = createBaseMocks({
+        network: {
+            isConnectionPending: () => true,
+            tryConnect: () => calls++,
+        },
+    });
+
+    const service = new IndexerObserverService(network, state, "self", config);
+
+    try {
+        await service.start();
+
+        for (let i = 0; i < 20; i++) {
+            clock.tick(10);
+            await Promise.resolve();
+        }
+
+        await service.stop(false);
+
+        t.is(calls, 0);
+    } finally {
+        clock.restore();
+        sinon.restore();
+        await cleanup(service);
+    }
+});
+
+test("does NOT connect to self", async (t) => {
+    const clock = sinon.useFakeTimers({ now: 0 });
+
+    let calls = 0;
+
+    const { network, state, config } = createBaseMocks({
+        network: { tryConnect: () => calls++ },
+    });
+
+    // Pass the resolved address as self — observer must skip it
+    const service = new IndexerObserverService(network, state, TEST_ADDRESS, config);
+
+    try {
+        await service.start();
+
+        for (let i = 0; i < 20; i++) {
+            clock.tick(10);
+            await Promise.resolve();
+        }
+
+        await service.stop(false);
+
+        t.is(calls, 0);
+    } finally {
+        clock.restore();
+        sinon.restore();
+        await cleanup(service);
+    }
+});
+
+test("does NOT connect to admin", async (t) => {
+    const clock = sinon.useFakeTimers({ now: 0 });
+
+    let calls = 0;
+
+    const { network, state, config } = createBaseMocks({
+        network: { tryConnect: () => calls++ },
+        state: { getAdminEntry: async () => ({ address: TEST_ADDRESS }) },
+    });
+
+    // Self is different from the indexer entry — admin filter must block it
+    const service = new IndexerObserverService(network, state, "self", config);
+
+    try {
+        await service.start();
+
+        for (let i = 0; i < 20; i++) {
+            clock.tick(10);
+            await Promise.resolve();
+        }
+
+        await service.stop(false);
+
+        t.is(calls, 0);
+    } finally {
+        clock.restore();
+        sinon.restore();
+        await cleanup(service);
+    }
+});
+
+test("returns early when no candidates available", async (t) => {
+    const clock = sinon.useFakeTimers({ now: 0 });
+
+    let calls = 0;
+
+    const { network, state, config } = createBaseMocks({
+        network: { tryConnect: () => calls++ },
+        state: { getIndexersEntry: async () => [] },
+    });
+
+    const service = new IndexerObserverService(network, state, "self", config);
+
+    try {
+        await service.start();
+
+        for (let i = 0; i < 20; i++) {
+            clock.tick(10);
+            await Promise.resolve();
+        }
+
+        await service.stop(false);
+
+        t.is(calls, 0);
+    } finally {
+        clock.restore();
+        sinon.restore();
+        await cleanup(service);
+    }
+});
+
+test("does not start observer if it is already running", async (t) => {
+    const { network, state, config } = createBaseMocks();
+    const service = new IndexerObserverService(network, state, "self", config);
+
+    await service.start();
+    await service.start();
+    await service.stop();
+
+    t.pass();
+});
+
+test("gracefully catches exceptions in the worker loop", async (t) => {
+    const clock = sinon.useFakeTimers({ now: 0 });
+
+    const { network, state, config } = createBaseMocks({
+        state: {
+            getIndexersEntry: async () => { throw new Error("Simulated DB Crash"); },
+        },
+    });
+
+    const service = new IndexerObserverService(network, state, "self", config);
+
+    try {
+        await service.start();
+
+        for (let i = 0; i < 20; i++) {
+            clock.tick(10);
+            await Promise.resolve();
+        }
+
+        await service.stop();
+
+        t.pass();
+    } finally {
+        clock.restore();
+        sinon.restore();
+        await cleanup(service);
+    }
+});
+
+test("gracefully catches exceptions in tryConnect", async (t) => {
+    const clock = sinon.useFakeTimers({ now: 0 });
+
+    const { network, state, config } = createBaseMocks({
+        network: {
+            tryConnect: () => { throw new Error("Simulated Network Transport Error"); },
+        },
+    });
+
+    const service = new IndexerObserverService(network, state, "self", config);
+
+    try {
+        await service.start();
+
+        for (let i = 0; i < 20; i++) {
+            clock.tick(10);
+            await Promise.resolve();
+        }
+
+        await service.stop();
+
+        t.pass();
+    } finally {
+        clock.restore();
+        sinon.restore();
+        await cleanup(service);
+    }
+});

--- a/tests/unit/network/Network.test.js
+++ b/tests/unit/network/Network.test.js
@@ -12,6 +12,21 @@ function normalizePublicKey(publicKey) {
     return null;
 }
 
+function createMockConnection(publicKeyHex, { withProtocolSession = true, withConsensusSession = false } = {}) {
+    const remotePublicKey = b4a.from(publicKeyHex, 'hex');
+    return {
+        remotePublicKey,
+        protocolSession: withProtocolSession ? {
+            isProbed: () => true,
+            probe: sinon.stub().resolves(),
+            isHealthCheckSupported: () => false,
+            close: sinon.stub(),
+        } : null,
+        consensusProtocolSession: withConsensusSession ? { close: sinon.stub() } : null,
+        on: sinon.stub(),
+    };
+}
+
 async function loadNetwork() {
     const { default: esmock } = await import('esmock');
     let swarmInstance = null;
@@ -123,6 +138,46 @@ async function loadNetwork() {
         async setupProtomuxMessages() {}
     }
 
+    class ConsensusMessagesMock {
+        async setupProtomuxMessages() {}
+    }
+
+    class IndexerConnectionManagerMock {
+        constructor(max = 0) {
+            this.max = max;
+            this.indexers = new Set();
+        }
+
+        setMax(max) {
+            this.max = max;
+        }
+
+        add(publicKey) {
+            this.indexers.add(normalizePublicKey(publicKey));
+            return true;
+        }
+
+        remove(publicKey) {
+            this.indexers.delete(normalizePublicKey(publicKey));
+        }
+
+        exists(publicKey) {
+            return this.indexers.has(normalizePublicKey(publicKey));
+        }
+
+        connected(publicKey) {
+            return this.exists(publicKey);
+        }
+
+        clear() {
+            this.indexers.clear();
+        }
+    }
+
+    class WakeupMock {
+        addStream() {}
+    }
+
     class TransactionRateLimiterServiceMock {}
 
     class CorestoreMock {
@@ -144,6 +199,9 @@ async function loadNetwork() {
         '../../../src/core/network/services/ValidatorHealthCheckService.js': { default: ValidatorHealthCheckServiceMock },
         '../../../src/core/consensus/services/EpochProofProposalService.js': { default: EpochProofProposalServiceMock },
         '../../../src/core/network/protocols/NetworkMessages.js': { default: NetworkMessagesMock },
+        '../../../src/core/consensus/protocols/ConsensusMessages.js': { default: ConsensusMessagesMock },
+        '../../../src/core/consensus/services/IndexerConnectionManager.js': { default: IndexerConnectionManagerMock },
+        'protomux-wakeup': { default: WakeupMock },
         '../../../src/utils/logger.js': { Logger: LoggerMock },
     });
 
@@ -173,7 +231,6 @@ async function loadNetwork() {
     state.isAdmin = async () => false;
     state.isIndexer = () => false;
     state.indexerCount = async () => 0;
-    state.isIndexerAddress = async () => false;
     state.isAdminAddress = async () => false;
     const network = new Network(state, store, config, wallet);
     await network.ready()
@@ -231,6 +288,67 @@ if (isBareRuntime) {
         t.absent(disconnected, 'non-validator peer should be ignored by validator disconnect helper');
         t.ok(network.isConnectionPending(publicKey), 'non-validator pending connection should remain tracked');
         t.is(swarmInstance.leavePeer.callCount, 0, 'generic peer should not be left');
+        t.teardown(async () => await network.close());
+    });
+
+    test('Network#tryConnect returns CONNECTED and tracks already-connected validator', async t => {
+        const publicKey = 'e'.repeat(64);
+        const { network, swarmInstance, connectionManagerInstance } = await loadNetwork();
+
+        const publicKeyBuffer = b4a.from(publicKey, 'hex');
+        const connection = createMockConnection(publicKey);
+        swarmInstance.peers.set(publicKey, { publicKey: publicKeyBuffer });
+        swarmInstance._allConnections.set(publicKeyBuffer, connection);
+
+        const status = await network.tryConnect(publicKey, 'validator');
+        t.is(status, CONNECTION_STATUS.CONNECTED, 'returns CONNECTED for ready validator peer');
+        t.ok(connectionManagerInstance.exists(publicKey), 'validator was added to connection manager');
+        t.absent(network.isConnectionPending(publicKey), 'pending validator connection was cleared');
+        t.teardown(async () => await network.close());
+    });
+
+    test('Network#tryConnect returns CONNECTED and tracks already-connected indexer', async t => {
+        const publicKey = 'f'.repeat(64);
+        const { network, swarmInstance } = await loadNetwork();
+
+        const publicKeyBuffer = b4a.from(publicKey, 'hex');
+        const connection = createMockConnection(publicKey);
+        swarmInstance.peers.set(publicKey, { publicKey: publicKeyBuffer });
+        swarmInstance._allConnections.set(publicKeyBuffer, connection);
+
+        const status = await network.tryConnect(publicKey, 'indexer');
+        t.is(status, CONNECTION_STATUS.CONNECTED, 'returns CONNECTED for ready indexer peer');
+        t.ok(network.indexerConnectionManager.connected(publicKey), 'indexer was added to connection manager');
+        t.absent(network.isConnectionPending(publicKey), 'pending indexer connection was cleared');
+        t.teardown(async () => await network.close());
+    });
+
+    test('Network tryConnect timeout clears pending connection', async t => {
+        const publicKey = 'g'.repeat(64);
+        const { network } = await loadNetwork();
+
+        const status = await network.tryConnect(publicKey, 'validator');
+        t.is(status, CONNECTION_STATUS.PENDING, 'connection is initially pending');
+        t.ok(network.isConnectionPending(publicKey), 'pending is tracked');
+
+        await new Promise(resolve => setTimeout(resolve, 1_100));
+
+        t.absent(network.isConnectionPending(publicKey), 'pending is cleared after timeout elapses');
+        t.teardown(async () => await network.close());
+    });
+
+    test('Network swarm connection event promotes pending connection', async t => {
+        const publicKey = '12'.repeat(32);
+        const { network, swarmInstance, connectionManagerInstance } = await loadNetwork();
+
+        const status = await network.tryConnect(publicKey, 'validator');
+        t.is(status, CONNECTION_STATUS.PENDING, 'connection is pending after joinPeer');
+
+        const connection = createMockConnection(publicKey);
+        await swarmInstance.emit('connection', connection);
+
+        t.ok(connectionManagerInstance.exists(publicKey), 'validator was added after swarm connection');
+        t.absent(network.isConnectionPending(publicKey), 'pending validator connection was cleared');
         t.teardown(async () => await network.close());
     });
 

--- a/tests/unit/network/ProtocolSession.test.js
+++ b/tests/unit/network/ProtocolSession.test.js
@@ -104,7 +104,7 @@ test('ProtocolSession', (t) => {
         t.is(result, ResultCode.UNSPECIFIED);
     });
 
-    test('isHealthCheckSupported throws when not probed', async (t) => {
+    test('isHealthCheckSupported returns false when not probed', async (t) => {
         const session = new ProtocolSession(
             makeProtocol(),
             makeProtocol(),
@@ -112,6 +112,6 @@ test('ProtocolSession', (t) => {
             config
         );
 
-        await t.exception.all(() => session.isHealthCheckSupported());
+        t.is(session.isHealthCheckSupported(), false);
     });
 });

--- a/tests/unit/network/services/MessageOrchestrator.test.js
+++ b/tests/unit/network/services/MessageOrchestrator.test.js
@@ -53,13 +53,20 @@ const createConnectionManager = ({
     getSentCount: sinon.stub().returns(sentCount),
 });
 
+// A dedicated sandbox instead of sinon's global default one: sinon.stub/sinon.restore()
+// operate on shared global state, so another test file's teardown calling sinon.restore()
+// while this file's console stubs are still active (or vice versa) can yank them out from
+// under each other mid-run. A sandbox's restore() only ever touches its own stubs.
+let consoleSandbox;
+
 hook('setup', () => {
-    sinon.stub(console, 'log');
-    sinon.stub(console, 'warn');
+    consoleSandbox = sinon.createSandbox();
+    consoleSandbox.stub(console, 'log');
+    consoleSandbox.stub(console, 'warn');
 });
 
 hook('teardown', () => {
-    sinon.restore();
+    consoleSandbox.restore();
 });
 
 test('MessageOrchestrator.send returns false for unsupported protocol', async t => {

--- a/tests/unit/network/services/ValidatorObserverLifecycle.test.js
+++ b/tests/unit/network/services/ValidatorObserverLifecycle.test.js
@@ -76,7 +76,6 @@ function createBaseMocks(overrides = {}) {
             ...(overrides.state || {}),
         },
         config: {
-            enableValidatorObserver: true,
             pollInterval: 10,
             addressLength: 32,
             addressPrefix: "trac",
@@ -205,8 +204,10 @@ test("does NOT connect if not writer", async (t) => {
 
     const { network, state, config } = createBaseMocks({
         network: { tryConnect: () => calls++ },
-        state: { getNodeEntry: async () => ({ isWriter: false }) },
-        config: { enableValidatorObserver: false }
+        state: { 
+            getNodeEntry: async () => ({ isWriter: false }),
+            getRegisteredWriterKey: async () => null
+        }
     });
 
     const service = new ValidatorObserverService(network, state, "self", config);


### PR DESCRIPTION
**Implement IndexerObserverService**

Adds `IndexerObserverService` to proactively ensure indexer nodes maintain connections to all other indexers, mirroring the pattern used by `ValidatorObserverService`.

Refactoring even driven structure into a plain algorithm on Network.js
