### PR TITLE
feat: extend builder class for apply operations to build set genesis epoch payload

### DIFF
--- a/src/messages/state/ApplyStateMessageBuilder.js
+++ b/src/messages/state/ApplyStateMessageBuilder.js
@@ -30,9 +30,10 @@ class ApplyStateMessageBuilder {
     #address;
     #amount;
     #approvals;
+    #built = false;
     #channel;
-    #config
     #contentHash;
+    #config;
     #externalBootstrap;
     #incomingAddress;
     #incomingNonce;
@@ -40,16 +41,17 @@ class ApplyStateMessageBuilder {
     #incomingWriterKey;
     #msbBootstrap;
     #operationType;
+    #output;
     #payload;
+    #payloadKey;
+    #phase;
     #proofData;
     #txHash;
     #txValidity;
+    #vdfDifficulty;
+    #vdfDiscrimintantSize;
     #wallet;
     #writingKey;
-    #phase;
-    #output;
-    #payloadKey;
-    #built=false;
 
     constructor(wallet, config) {
         this.#config = config;
@@ -361,7 +363,10 @@ class ApplyStateMessageBuilder {
                     nonce,
                     OperationType.TRANSFER
                 );
+            case OperationType.SET_GENESIS_EPOCH:
+                this.#requireFields([])
                 break;
+
             default:
                 throw new Error(`Unsupported operation type: ${this.#operationType}`);
         }

--- a/src/messages/state/ApplyStateMessageBuilder.js
+++ b/src/messages/state/ApplyStateMessageBuilder.js
@@ -50,7 +50,7 @@ class ApplyStateMessageBuilder {
     #txHash;
     #txValidity;
     #vdfDifficulty;
-    #vdfDiscrimintantSize;
+    #vdfDiscriminantSize;
     #wallet;
     #writingKey;
 
@@ -187,7 +187,7 @@ class ApplyStateMessageBuilder {
     }
 
     setVdfDiscriminantSize(vdfDiscriminantSize) {
-        this.#vdfDiscrimintantSize = this.#normalizeHexBuffer(vdfDiscriminantSize, 32, 'VDF discriminant size');
+        this.#vdfDiscriminantSize = this.#normalizeHexBuffer(vdfDiscriminantSize, 32, 'VDF discriminant size');
         return this;
     }
 
@@ -565,13 +565,13 @@ class ApplyStateMessageBuilder {
                 this.#requireFields([
                     [this.#txValidity, 'Transaction validity'],
                     [this.#vdfDifficulty, 'Difficulty'],
-                    [this.#vdfDiscrimintantSize, 'Discriminant size']
+                    [this.#vdfDiscriminantSize, 'Discriminant size']
                 ]);
                 msg = createMessage(
                     this.#config.networkId,
                     this.#txValidity,
                     this.#vdfDifficulty,
-                    this.#vdfDiscrimintantSize,
+                    this.#vdfDiscriminantSize,
                     nonce,
                     this.#operationType
                 );
@@ -670,7 +670,7 @@ class ApplyStateMessageBuilder {
                 tx,
                 txv: this.#txValidity,
                 df: this.#vdfDifficulty,
-                db: this.#vdfDiscrimintantSize,
+                db: this.#vdfDiscriminantSize,
                 in: nonce,
                 is: signature
             };

--- a/src/messages/state/ApplyStateMessageBuilder.js
+++ b/src/messages/state/ApplyStateMessageBuilder.js
@@ -12,6 +12,7 @@ import {
     isCoreAdmin,
     isRoleAccess,
     isSetEpoch,
+    isSetGenesisEpoch,
     isTransaction,
     isTransfer,
     operationToPayload
@@ -177,6 +178,16 @@ class ApplyStateMessageBuilder {
         this.#approvals = approvals.map((approval, index) => {
             return this.#normalizeBytesBuffer(approval, `Approval ${index}`);
         });
+        return this;
+    }
+
+    setVdfDifficulty(vdfDifficulty) {
+        this.#vdfDifficulty = this.#normalizeHexBuffer(vdfDifficulty, 32, 'VDF difficulty');
+        return this;
+    }
+
+    setVdfDiscriminantSize(vdfDiscriminantSize) {
+        this.#vdfDiscrimintantSize = this.#normalizeHexBuffer(vdfDiscriminantSize, 32, 'VDF discriminant size');
         return this;
     }
 
@@ -363,8 +374,6 @@ class ApplyStateMessageBuilder {
                     nonce,
                     OperationType.TRANSFER
                 );
-            case OperationType.SET_GENESIS_EPOCH:
-                this.#requireFields([])
                 break;
 
             default:
@@ -552,6 +561,21 @@ class ApplyStateMessageBuilder {
                     this.#operationType
                 );
                 break;
+            case OperationType.SET_GENESIS_EPOCH:
+                this.#requireFields([
+                    [this.#txValidity, 'Transaction validity'],
+                    [this.#vdfDifficulty, 'Difficulty'],
+                    [this.#vdfDiscrimintantSize, 'Discriminant size']
+                ]);
+                msg = createMessage(
+                    this.#config.networkId,
+                    this.#txValidity,
+                    this.#vdfDifficulty,
+                    this.#vdfDiscrimintantSize,
+                    nonce,
+                    this.#operationType
+                );
+                break;
             default:
                 throw new Error(`Unsupported operation type: ${this.#operationType}`);
         }
@@ -637,6 +661,16 @@ class ApplyStateMessageBuilder {
                 txv: this.#txValidity,
                 ia: this.#incomingAddress,
                 am: this.#amount,
+                in: nonce,
+                is: signature
+            };
+        }
+        if (isSetGenesisEpoch(this.#operationType)) {
+            return {
+                tx,
+                txv: this.#txValidity,
+                df: this.#vdfDifficulty,
+                db: this.#vdfDiscrimintantSize,
                 in: nonce,
                 is: signature
             };

--- a/src/messages/state/ApplyStateMessageDirector.js
+++ b/src/messages/state/ApplyStateMessageDirector.js
@@ -540,7 +540,7 @@ class ApplyStateMessageDirector {
      * @param {string|Buffer} vdfDiscriminantSize
      * @returns {Promise<object>}
      */
-    async buildCompleteSetGenesisEpochOperation(invokerAddress, txValidity, vdfDifficulty, vdfDiscriminantSize) {
+    async buildCompleteSetGenesisEpochMessage(invokerAddress, txValidity, vdfDifficulty, vdfDiscriminantSize) {
         if (!this.#builder) throw new Error('Builder has not been set.');
         await this.#builder
             .setPhase('complete')

--- a/src/messages/state/ApplyStateMessageDirector.js
+++ b/src/messages/state/ApplyStateMessageDirector.js
@@ -531,6 +531,28 @@ class ApplyStateMessageDirector {
             .build();
         return this.#builder.getPayload();
     }
+
+    /**
+     * Build a complete set genesis epoch payload.
+     * @param {string|Buffer} invokerAddress
+     * @param {string|Buffer} txValidity
+     * @param {string|Buffer} vdfDifficulty
+     * @param {string|Buffer} vdfDiscriminantSize
+     * @returns {Promise<object>}
+     */
+    async buildCompleteSetGenesisEpochOperation(invokerAddress, txValidity, vdfDifficulty, vdfDiscriminantSize) {
+        if (!this.#builder) throw new Error('Builder has not been set.');
+        await this.#builder
+            .setPhase('complete')
+            .setOutput('buffer')
+            .setOperationType(OperationType.SET_GENESIS_EPOCH)
+            .setAddress(invokerAddress)
+            .setTxValidity(txValidity)
+            .setVdfDifficulty(vdfDifficulty)
+            .setVdfDiscriminantSize(vdfDiscriminantSize)
+            .build();
+        return this.#builder.getPayload();
+    }
 }
 
 export default ApplyStateMessageDirector;

--- a/src/utils/applyOperations.js
+++ b/src/utils/applyOperations.js
@@ -112,5 +112,6 @@ export {
     operationToPayload,
     isTransfer,
     isBalanceInitialization,
-    isSetEpoch
+    isSetEpoch,
+    isSetGenesisEpoch
 }

--- a/src/utils/applyOperations.js
+++ b/src/utils/applyOperations.js
@@ -54,6 +54,12 @@ const isSetEpoch = type => {
     ].includes(type);
 }
 
+const isSetGenesisEpoch = type => {
+    return [
+        OperationType.SET_GENESIS_EPOCH
+    ].includes(type);
+}
+
 const operationToPayload = type => {
     const fromTo = [
         {
@@ -87,6 +93,10 @@ const operationToPayload = type => {
         {
             condition: isSetEpoch,
             jsonPath: 'seo'
+        },
+        {
+            condition: isSetGenesisEpoch,
+            jsonPath: 'sgo'
         }
     ]
     const match = fromTo.find(entry => !!entry.condition(type))

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -36,6 +36,7 @@ export const OperationType = Object.freeze({
     TX: ApplyOperationType.TX,
     TRANSFER: ApplyOperationType.TRANSFER,
     SET_EPOCH: ApplyOperationType.SET_EPOCH,
+    SET_GENESIS_EPOCH: ApplyOperationType.SET_GENESIS_EPOCH,
 });
 
 export const NetworkOperationType = Object.freeze({

--- a/tests/unit/messages/state/applyStateMessageBuilder.complete.test.js
+++ b/tests/unit/messages/state/applyStateMessageBuilder.complete.test.js
@@ -589,3 +589,72 @@ test('ApplyStateMessageBuilder complete set epoch operation codec roundtrip', as
     t.ok(b4a.equals(decoded.seo.app[0], approvals[0]));
     t.ok(b4a.equals(decoded.seo.app[1], approvals[1]));
 });
+
+test('ApplyStateMessageBuilder complete set genesis epoch operation (sgo)', async t => {
+    const wallet = await createWallet(testKeyPair1.mnemonic);
+    const txValidity = toBuf(hex('11', 32));
+    const vdfDifficulty = toBuf(hex('22', 32));
+    const vdfDiscriminantSize = toBuf(hex('33', 32));
+
+    const builder = new ApplyStateMessageBuilder(wallet, config);
+    await builder
+        .setPhase('complete')
+        .setOutput('buffer')
+        .setOperationType(OperationType.SET_GENESIS_EPOCH)
+        .setAddress(wallet.address)
+        .setTxValidity(txValidity)
+        .setVdfDifficulty(vdfDifficulty)
+        .setVdfDiscriminantSize(vdfDiscriminantSize)
+        .build();
+
+    const payload = builder.getPayload();
+    t.is(payload.type, OperationType.SET_GENESIS_EPOCH);
+    expectAddressBuffer(t, payload.address, 'address');
+    t.ok(b4a.equals(payload.address, addressToBuffer(wallet.address, config.addressPrefix)));
+    expectPayloadKeys(t, payload, 'sgo');
+    expectKeys(t, payload.sgo, ['tx', 'txv', 'df', 'db', 'in', 'is'], 'sgo');
+    expectBufferField(t, payload.sgo.tx, 32, 'sgo.tx');
+    expectBufferField(t, payload.sgo.txv, 32, 'sgo.txv');
+    expectBufferField(t, payload.sgo.df, 32, 'sgo.df');
+    expectBufferField(t, payload.sgo.db, 32, 'sgo.db');
+    expectBufferField(t, payload.sgo.in, 32, 'sgo.in');
+    expectBufferField(t, payload.sgo.is, 64, 'sgo.is');
+    t.ok(b4a.equals(payload.sgo.txv, txValidity));
+    t.ok(b4a.equals(payload.sgo.df, vdfDifficulty));
+    t.ok(b4a.equals(payload.sgo.db, vdfDiscriminantSize));
+});
+
+test('ApplyStateMessageBuilder complete set genesis epoch operation codec roundtrip', async t => {
+    const wallet = await createWallet(testKeyPair1.mnemonic);
+    const txValidity = toBuf(hex('44', 32));
+    const vdfDifficulty = toBuf(hex('55', 32));
+    const vdfDiscriminantSize = toBuf(hex('66', 32));
+
+    const builder = new ApplyStateMessageBuilder(wallet, config);
+    await builder
+        .setPhase('complete')
+        .setOutput('buffer')
+        .setOperationType(OperationType.SET_GENESIS_EPOCH)
+        .setAddress(wallet.address)
+        .setTxValidity(txValidity)
+        .setVdfDifficulty(vdfDifficulty)
+        .setVdfDiscriminantSize(vdfDiscriminantSize)
+        .build();
+
+    const payload = builder.getPayload();
+    const encoded = safeEncodeApplyOperation(payload);
+    const decoded = safeDecodeApplyOperation(encoded);
+
+    t.ok(b4a.isBuffer(encoded));
+    t.ok(encoded.length > 0);
+    t.is(decoded.type, OperationType.SET_GENESIS_EPOCH);
+    t.ok(b4a.equals(decoded.address, addressToBuffer(wallet.address, config.addressPrefix)));
+    t.alike(Object.keys(decoded).sort(), ['address', 'sgo', 'type']);
+    t.alike(Object.keys(decoded.sgo).sort(), ['db', 'df', 'in', 'is', 'tx', 'txv']);
+    t.ok(b4a.equals(decoded.sgo.tx, payload.sgo.tx));
+    t.ok(b4a.equals(decoded.sgo.txv, txValidity));
+    t.ok(b4a.equals(decoded.sgo.df, vdfDifficulty));
+    t.ok(b4a.equals(decoded.sgo.db, vdfDiscriminantSize));
+    t.ok(b4a.equals(decoded.sgo.in, payload.sgo.in));
+    t.ok(b4a.equals(decoded.sgo.is, payload.sgo.is));
+});

--- a/tests/unit/messages/state/applyStateMessageDirector.test.js
+++ b/tests/unit/messages/state/applyStateMessageDirector.test.js
@@ -35,3 +35,29 @@ test('ApplyStateMessageDirector builds complete set epoch message', async t => {
     t.ok(b4a.equals(payload.seo.app[0], approvals[0]));
     t.ok(b4a.equals(payload.seo.app[1], approvals[1]));
 });
+
+test('ApplyStateMessageDirector builds complete set genesis epoch operation', async t => {
+    const wallet = await createWallet(testKeyPair1.mnemonic);
+    const txValidity = b4a.from('11'.repeat(32), 'hex');
+    const vdfDifficulty = b4a.from('22'.repeat(32), 'hex');
+    const vdfDiscriminantSize = b4a.from('33'.repeat(32), 'hex');
+
+    const payload = await applyStateMessageFactory(wallet, config)
+        .buildCompleteSetGenesisEpochOperation(
+            wallet.address,
+            txValidity,
+            vdfDifficulty,
+            vdfDiscriminantSize
+        );
+
+    t.is(payload.type, OperationType.SET_GENESIS_EPOCH);
+    t.ok(b4a.equals(payload.address, addressToBuffer(wallet.address, config.addressPrefix)));
+    t.alike(Object.keys(payload).sort(), ['address', 'sgo', 'type']);
+    t.alike(Object.keys(payload.sgo).sort(), ['db', 'df', 'in', 'is', 'tx', 'txv']);
+    t.ok(b4a.equals(payload.sgo.txv, txValidity));
+    t.ok(b4a.equals(payload.sgo.df, vdfDifficulty));
+    t.ok(b4a.equals(payload.sgo.db, vdfDiscriminantSize));
+    t.is(payload.sgo.tx.length, 32);
+    t.is(payload.sgo.in.length, 32);
+    t.is(payload.sgo.is.length, 64);
+});

--- a/tests/unit/messages/state/applyStateMessageDirector.test.js
+++ b/tests/unit/messages/state/applyStateMessageDirector.test.js
@@ -36,14 +36,14 @@ test('ApplyStateMessageDirector builds complete set epoch message', async t => {
     t.ok(b4a.equals(payload.seo.app[1], approvals[1]));
 });
 
-test('ApplyStateMessageDirector builds complete set genesis epoch operation', async t => {
+test('ApplyStateMessageDirector builds complete set genesis epoch message', async t => {
     const wallet = await createWallet(testKeyPair1.mnemonic);
     const txValidity = b4a.from('11'.repeat(32), 'hex');
     const vdfDifficulty = b4a.from('22'.repeat(32), 'hex');
     const vdfDiscriminantSize = b4a.from('33'.repeat(32), 'hex');
 
     const payload = await applyStateMessageFactory(wallet, config)
-        .buildCompleteSetGenesisEpochOperation(
+        .buildCompleteSetGenesisEpochMessage(
             wallet.address,
             txValidity,
             vdfDifficulty,


### PR DESCRIPTION
## Summary

  Adds builder/director support for complete `SET_GENESIS_EPOCH` apply operation payloads.

  ## Changes

  - Exposes `SET_GENESIS_EPOCH` in `OperationType`.
  - Maps `SET_GENESIS_EPOCH` to `sgo` via apply operation helpers.
  - Adds builder setters for VDF params:
    - `setVdfDifficulty`
    - `setVdfDiscriminantSize`
  - Builds signed `sgo` payloads with `tx`, `txv`, `df`, `db`, `in`, `is`.
  - Adds director method: `buildCompleteSetGenesisEpochOperation(...)`.
  - Adds builder/director tests, including codec roundtrip.

  ## Why

  This lets callers construct valid complete genesis epoch operations through the existing apply message builder API.