### PR TITLE
feat: implement new operation schema for set_vdf_params

### DIFF
--- a/proto/applyOperations/applyOperations.proto
+++ b/proto/applyOperations/applyOperations.proto
@@ -12,6 +12,7 @@ import "applyOperations/messages/bootstrap_deployment_operation.proto";
 import "applyOperations/messages/tx_operation.proto";
 import "applyOperations/messages/set_epoch_operation.proto";
 import "applyOperations/messages/set_genesis_epoch_operation.proto";
+import "applyOperations/messages/set_vdf_params_operation.proto";
 
 // Main structure for the operations where messages are
 message Operation {
@@ -28,5 +29,6 @@ message Operation {
         TxOperation                       txo  = 9;
         SetEpochOperation                 seo  = 10;
         SetGenesisEpochOperation          sgo  = 11;
+        SetVdfParamsOperation             vpo  = 12;
     }
 }

--- a/proto/applyOperations/enums/operation_type.proto
+++ b/proto/applyOperations/enums/operation_type.proto
@@ -20,4 +20,5 @@ enum OperationType {
     TRANSFER               = 13; // partial
     SET_EPOCH              = 14; // complete
     SET_GENESIS_EPOCH      = 15; // complete
+    SET_VDF_PARAMS         = 16; // complete
 }

--- a/proto/applyOperations/messages/set_vdf_params_operation.proto
+++ b/proto/applyOperations/messages/set_vdf_params_operation.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package apply.operations;
+
+message SetVdfParamsOperation {
+    bytes tx     = 1; // Transaction hash (unique identifier for the transaction)
+    bytes txv    = 2; // Transaction expiration
+    bytes df     = 3; // VDF difficulty factor
+    bytes db     = 4; // VDF discriminant size bits
+    bytes in     = 5; // Nonce of the invoker (admin)
+    bytes is     = 6; // Signature of the invoker (admin)
+}

--- a/src/codecs/apply/applyOperations.generated.cjs
+++ b/src/codecs/apply/applyOperations.generated.cjs
@@ -48,6 +48,7 @@ $root.apply = (function() {
              * @property {apply.operations.ITxOperation|null} [txo] Operation txo
              * @property {apply.operations.ISetEpochOperation|null} [seo] Operation seo
              * @property {apply.operations.ISetGenesisEpochOperation|null} [sgo] Operation sgo
+             * @property {apply.operations.ISetVdfParamsOperation|null} [vpo] Operation vpo
              */
 
             /**
@@ -153,17 +154,25 @@ $root.apply = (function() {
              */
             Operation.prototype.sgo = null;
 
+            /**
+             * Operation vpo.
+             * @member {apply.operations.ISetVdfParamsOperation|null|undefined} vpo
+             * @memberof apply.operations.Operation
+             * @instance
+             */
+            Operation.prototype.vpo = null;
+
             // OneOf field names bound to virtual getters and setters
             var $oneOfFields;
 
             /**
              * Operation value.
-             * @member {"cao"|"aco"|"bio"|"tro"|"rao"|"bdo"|"txo"|"seo"|"sgo"|undefined} value
+             * @member {"cao"|"aco"|"bio"|"tro"|"rao"|"bdo"|"txo"|"seo"|"sgo"|"vpo"|undefined} value
              * @memberof apply.operations.Operation
              * @instance
              */
             Object.defineProperty(Operation.prototype, "value", {
-                get: $util.oneOfGetter($oneOfFields = ["cao", "aco", "bio", "tro", "rao", "bdo", "txo", "seo", "sgo"]),
+                get: $util.oneOfGetter($oneOfFields = ["cao", "aco", "bio", "tro", "rao", "bdo", "txo", "seo", "sgo", "vpo"]),
                 set: $util.oneOfSetter($oneOfFields)
             });
 
@@ -213,6 +222,8 @@ $root.apply = (function() {
                     $root.apply.operations.SetEpochOperation.encode(message.seo, writer.uint32(/* id 10, wireType 2 =*/82).fork()).ldelim();
                 if (message.sgo != null && Object.hasOwnProperty.call(message, "sgo"))
                     $root.apply.operations.SetGenesisEpochOperation.encode(message.sgo, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
+                if (message.vpo != null && Object.hasOwnProperty.call(message, "vpo"))
+                    $root.apply.operations.SetVdfParamsOperation.encode(message.vpo, writer.uint32(/* id 12, wireType 2 =*/98).fork()).ldelim();
                 return writer;
             };
 
@@ -293,6 +304,10 @@ $root.apply = (function() {
                             message.sgo = $root.apply.operations.SetGenesisEpochOperation.decode(reader, reader.uint32());
                             break;
                         }
+                    case 12: {
+                            message.vpo = $root.apply.operations.SetVdfParamsOperation.decode(reader, reader.uint32());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
                         break;
@@ -349,6 +364,7 @@ $root.apply = (function() {
                     case 13:
                     case 14:
                     case 15:
+                    case 16:
                         break;
                     }
                 if (message.address != null && message.hasOwnProperty("address"))
@@ -442,6 +458,16 @@ $root.apply = (function() {
                             return "sgo." + error;
                     }
                 }
+                if (message.vpo != null && message.hasOwnProperty("vpo")) {
+                    if (properties.value === 1)
+                        return "value: multiple values";
+                    properties.value = 1;
+                    {
+                        var error = $root.apply.operations.SetVdfParamsOperation.verify(message.vpo);
+                        if (error)
+                            return "vpo." + error;
+                    }
+                }
                 return null;
             };
 
@@ -528,6 +554,10 @@ $root.apply = (function() {
                 case 15:
                     message.type = 15;
                     break;
+                case "SET_VDF_PARAMS":
+                case 16:
+                    message.type = 16;
+                    break;
                 }
                 if (object.address != null)
                     if (typeof object.address === "string")
@@ -578,6 +608,11 @@ $root.apply = (function() {
                     if (typeof object.sgo !== "object")
                         throw TypeError(".apply.operations.Operation.sgo: object expected");
                     message.sgo = $root.apply.operations.SetGenesisEpochOperation.fromObject(object.sgo);
+                }
+                if (object.vpo != null) {
+                    if (typeof object.vpo !== "object")
+                        throw TypeError(".apply.operations.Operation.vpo: object expected");
+                    message.vpo = $root.apply.operations.SetVdfParamsOperation.fromObject(object.vpo);
                 }
                 return message;
             };
@@ -654,6 +689,11 @@ $root.apply = (function() {
                     if (options.oneofs)
                         object.value = "sgo";
                 }
+                if (message.vpo != null && message.hasOwnProperty("vpo")) {
+                    object.vpo = $root.apply.operations.SetVdfParamsOperation.toObject(message.vpo, options);
+                    if (options.oneofs)
+                        object.value = "vpo";
+                }
                 return object;
             };
 
@@ -706,6 +746,7 @@ $root.apply = (function() {
          * @property {number} TRANSFER=13 TRANSFER value
          * @property {number} SET_EPOCH=14 SET_EPOCH value
          * @property {number} SET_GENESIS_EPOCH=15 SET_GENESIS_EPOCH value
+         * @property {number} SET_VDF_PARAMS=16 SET_VDF_PARAMS value
          */
         operations.OperationType = (function() {
             var valuesById = {}, values = Object.create(valuesById);
@@ -725,6 +766,7 @@ $root.apply = (function() {
             values[valuesById[13] = "TRANSFER"] = 13;
             values[valuesById[14] = "SET_EPOCH"] = 14;
             values[valuesById[15] = "SET_GENESIS_EPOCH"] = 15;
+            values[valuesById[16] = "SET_VDF_PARAMS"] = 16;
             return values;
         })();
 
@@ -4335,6 +4377,381 @@ $root.apply = (function() {
             };
 
             return SetGenesisEpochOperation;
+        })();
+
+        operations.SetVdfParamsOperation = (function() {
+
+            /**
+             * Properties of a SetVdfParamsOperation.
+             * @memberof apply.operations
+             * @interface ISetVdfParamsOperation
+             * @property {Uint8Array|null} [tx] SetVdfParamsOperation tx
+             * @property {Uint8Array|null} [txv] SetVdfParamsOperation txv
+             * @property {Uint8Array|null} [df] SetVdfParamsOperation df
+             * @property {Uint8Array|null} [db] SetVdfParamsOperation db
+             * @property {Uint8Array|null} ["in"] SetVdfParamsOperation in
+             * @property {Uint8Array|null} [is] SetVdfParamsOperation is
+             */
+
+            /**
+             * Constructs a new SetVdfParamsOperation.
+             * @memberof apply.operations
+             * @classdesc Represents a SetVdfParamsOperation.
+             * @implements ISetVdfParamsOperation
+             * @constructor
+             * @param {apply.operations.ISetVdfParamsOperation=} [properties] Properties to set
+             */
+            function SetVdfParamsOperation(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * SetVdfParamsOperation tx.
+             * @member {Uint8Array} tx
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @instance
+             */
+            SetVdfParamsOperation.prototype.tx = $util.newBuffer([]);
+
+            /**
+             * SetVdfParamsOperation txv.
+             * @member {Uint8Array} txv
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @instance
+             */
+            SetVdfParamsOperation.prototype.txv = $util.newBuffer([]);
+
+            /**
+             * SetVdfParamsOperation df.
+             * @member {Uint8Array} df
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @instance
+             */
+            SetVdfParamsOperation.prototype.df = $util.newBuffer([]);
+
+            /**
+             * SetVdfParamsOperation db.
+             * @member {Uint8Array} db
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @instance
+             */
+            SetVdfParamsOperation.prototype.db = $util.newBuffer([]);
+
+            /**
+             * SetVdfParamsOperation in.
+             * @member {Uint8Array} in
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @instance
+             */
+            SetVdfParamsOperation.prototype["in"] = $util.newBuffer([]);
+
+            /**
+             * SetVdfParamsOperation is.
+             * @member {Uint8Array} is
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @instance
+             */
+            SetVdfParamsOperation.prototype.is = $util.newBuffer([]);
+
+            /**
+             * Creates a new SetVdfParamsOperation instance using the specified properties.
+             * @function create
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @static
+             * @param {apply.operations.ISetVdfParamsOperation=} [properties] Properties to set
+             * @returns {apply.operations.SetVdfParamsOperation} SetVdfParamsOperation instance
+             */
+            SetVdfParamsOperation.create = function create(properties) {
+                return new SetVdfParamsOperation(properties);
+            };
+
+            /**
+             * Encodes the specified SetVdfParamsOperation message. Does not implicitly {@link apply.operations.SetVdfParamsOperation.verify|verify} messages.
+             * @function encode
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @static
+             * @param {apply.operations.ISetVdfParamsOperation} message SetVdfParamsOperation message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            SetVdfParamsOperation.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.tx != null && Object.hasOwnProperty.call(message, "tx"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.tx);
+                if (message.txv != null && Object.hasOwnProperty.call(message, "txv"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.txv);
+                if (message.df != null && Object.hasOwnProperty.call(message, "df"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.df);
+                if (message.db != null && Object.hasOwnProperty.call(message, "db"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.db);
+                if (message["in"] != null && Object.hasOwnProperty.call(message, "in"))
+                    writer.uint32(/* id 5, wireType 2 =*/42).bytes(message["in"]);
+                if (message.is != null && Object.hasOwnProperty.call(message, "is"))
+                    writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.is);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified SetVdfParamsOperation message, length delimited. Does not implicitly {@link apply.operations.SetVdfParamsOperation.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @static
+             * @param {apply.operations.ISetVdfParamsOperation} message SetVdfParamsOperation message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            SetVdfParamsOperation.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a SetVdfParamsOperation message from the specified reader or buffer.
+             * @function decode
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {apply.operations.SetVdfParamsOperation} SetVdfParamsOperation
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            SetVdfParamsOperation.decode = function decode(reader, length, error) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.apply.operations.SetVdfParamsOperation();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    if (tag === error)
+                        break;
+                    switch (tag >>> 3) {
+                    case 1: {
+                            message.tx = reader.bytes();
+                            break;
+                        }
+                    case 2: {
+                            message.txv = reader.bytes();
+                            break;
+                        }
+                    case 3: {
+                            message.df = reader.bytes();
+                            break;
+                        }
+                    case 4: {
+                            message.db = reader.bytes();
+                            break;
+                        }
+                    case 5: {
+                            message["in"] = reader.bytes();
+                            break;
+                        }
+                    case 6: {
+                            message.is = reader.bytes();
+                            break;
+                        }
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a SetVdfParamsOperation message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {apply.operations.SetVdfParamsOperation} SetVdfParamsOperation
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            SetVdfParamsOperation.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a SetVdfParamsOperation message.
+             * @function verify
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            SetVdfParamsOperation.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.tx != null && message.hasOwnProperty("tx"))
+                    if (!(message.tx && typeof message.tx.length === "number" || $util.isString(message.tx)))
+                        return "tx: buffer expected";
+                if (message.txv != null && message.hasOwnProperty("txv"))
+                    if (!(message.txv && typeof message.txv.length === "number" || $util.isString(message.txv)))
+                        return "txv: buffer expected";
+                if (message.df != null && message.hasOwnProperty("df"))
+                    if (!(message.df && typeof message.df.length === "number" || $util.isString(message.df)))
+                        return "df: buffer expected";
+                if (message.db != null && message.hasOwnProperty("db"))
+                    if (!(message.db && typeof message.db.length === "number" || $util.isString(message.db)))
+                        return "db: buffer expected";
+                if (message["in"] != null && message.hasOwnProperty("in"))
+                    if (!(message["in"] && typeof message["in"].length === "number" || $util.isString(message["in"])))
+                        return "in: buffer expected";
+                if (message.is != null && message.hasOwnProperty("is"))
+                    if (!(message.is && typeof message.is.length === "number" || $util.isString(message.is)))
+                        return "is: buffer expected";
+                return null;
+            };
+
+            /**
+             * Creates a SetVdfParamsOperation message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {apply.operations.SetVdfParamsOperation} SetVdfParamsOperation
+             */
+            SetVdfParamsOperation.fromObject = function fromObject(object) {
+                if (object instanceof $root.apply.operations.SetVdfParamsOperation)
+                    return object;
+                var message = new $root.apply.operations.SetVdfParamsOperation();
+                if (object.tx != null)
+                    if (typeof object.tx === "string")
+                        $util.base64.decode(object.tx, message.tx = $util.newBuffer($util.base64.length(object.tx)), 0);
+                    else if (object.tx.length >= 0)
+                        message.tx = object.tx;
+                if (object.txv != null)
+                    if (typeof object.txv === "string")
+                        $util.base64.decode(object.txv, message.txv = $util.newBuffer($util.base64.length(object.txv)), 0);
+                    else if (object.txv.length >= 0)
+                        message.txv = object.txv;
+                if (object.df != null)
+                    if (typeof object.df === "string")
+                        $util.base64.decode(object.df, message.df = $util.newBuffer($util.base64.length(object.df)), 0);
+                    else if (object.df.length >= 0)
+                        message.df = object.df;
+                if (object.db != null)
+                    if (typeof object.db === "string")
+                        $util.base64.decode(object.db, message.db = $util.newBuffer($util.base64.length(object.db)), 0);
+                    else if (object.db.length >= 0)
+                        message.db = object.db;
+                if (object["in"] != null)
+                    if (typeof object["in"] === "string")
+                        $util.base64.decode(object["in"], message["in"] = $util.newBuffer($util.base64.length(object["in"])), 0);
+                    else if (object["in"].length >= 0)
+                        message["in"] = object["in"];
+                if (object.is != null)
+                    if (typeof object.is === "string")
+                        $util.base64.decode(object.is, message.is = $util.newBuffer($util.base64.length(object.is)), 0);
+                    else if (object.is.length >= 0)
+                        message.is = object.is;
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a SetVdfParamsOperation message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @static
+             * @param {apply.operations.SetVdfParamsOperation} message SetVdfParamsOperation
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            SetVdfParamsOperation.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    if (options.bytes === String)
+                        object.tx = "";
+                    else {
+                        object.tx = [];
+                        if (options.bytes !== Array)
+                            object.tx = $util.newBuffer(object.tx);
+                    }
+                    if (options.bytes === String)
+                        object.txv = "";
+                    else {
+                        object.txv = [];
+                        if (options.bytes !== Array)
+                            object.txv = $util.newBuffer(object.txv);
+                    }
+                    if (options.bytes === String)
+                        object.df = "";
+                    else {
+                        object.df = [];
+                        if (options.bytes !== Array)
+                            object.df = $util.newBuffer(object.df);
+                    }
+                    if (options.bytes === String)
+                        object.db = "";
+                    else {
+                        object.db = [];
+                        if (options.bytes !== Array)
+                            object.db = $util.newBuffer(object.db);
+                    }
+                    if (options.bytes === String)
+                        object["in"] = "";
+                    else {
+                        object["in"] = [];
+                        if (options.bytes !== Array)
+                            object["in"] = $util.newBuffer(object["in"]);
+                    }
+                    if (options.bytes === String)
+                        object.is = "";
+                    else {
+                        object.is = [];
+                        if (options.bytes !== Array)
+                            object.is = $util.newBuffer(object.is);
+                    }
+                }
+                if (message.tx != null && message.hasOwnProperty("tx"))
+                    object.tx = options.bytes === String ? $util.base64.encode(message.tx, 0, message.tx.length) : options.bytes === Array ? Array.prototype.slice.call(message.tx) : message.tx;
+                if (message.txv != null && message.hasOwnProperty("txv"))
+                    object.txv = options.bytes === String ? $util.base64.encode(message.txv, 0, message.txv.length) : options.bytes === Array ? Array.prototype.slice.call(message.txv) : message.txv;
+                if (message.df != null && message.hasOwnProperty("df"))
+                    object.df = options.bytes === String ? $util.base64.encode(message.df, 0, message.df.length) : options.bytes === Array ? Array.prototype.slice.call(message.df) : message.df;
+                if (message.db != null && message.hasOwnProperty("db"))
+                    object.db = options.bytes === String ? $util.base64.encode(message.db, 0, message.db.length) : options.bytes === Array ? Array.prototype.slice.call(message.db) : message.db;
+                if (message["in"] != null && message.hasOwnProperty("in"))
+                    object["in"] = options.bytes === String ? $util.base64.encode(message["in"], 0, message["in"].length) : options.bytes === Array ? Array.prototype.slice.call(message["in"]) : message["in"];
+                if (message.is != null && message.hasOwnProperty("is"))
+                    object.is = options.bytes === String ? $util.base64.encode(message.is, 0, message.is.length) : options.bytes === Array ? Array.prototype.slice.call(message.is) : message.is;
+                return object;
+            };
+
+            /**
+             * Converts this SetVdfParamsOperation to JSON.
+             * @function toJSON
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            SetVdfParamsOperation.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            /**
+             * Gets the default type url for SetVdfParamsOperation
+             * @function getTypeUrl
+             * @memberof apply.operations.SetVdfParamsOperation
+             * @static
+             * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+             * @returns {string} The default type url
+             */
+            SetVdfParamsOperation.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+                if (typeUrlPrefix === undefined) {
+                    typeUrlPrefix = "type.googleapis.com";
+                }
+                return typeUrlPrefix + "/apply.operations.SetVdfParamsOperation";
+            };
+
+            return SetVdfParamsOperation;
         })();
 
         return operations;


### PR DESCRIPTION
Implemented the initial SET_VDF_PARAMS apply-operation schema.

This PR adds the new complete operation type to the apply protobuf enum, defines the SetVdfParamsOperation payload, wires it into the apply operation oneof as vpo, and regenerates the apply protobuf codec.