### PR TITLE
feat: Implement new command only for admin and handler to process set genesis epoch (#647)

### DIFF
--- a/cli/commandHandler.js
+++ b/cli/commandHandler.js
@@ -37,7 +37,8 @@ export const COMMANDS = {
     UNCONFIRMED_LENGTH: "/unconfirmed_length",
     GET_TXS_HASHES: "/get_txs_hashes",
     GET_TX_DETAILS: "/get_tx_details",
-    GET_EXTENDED_TX_DETAILS: "/get_extended_tx_details"
+    GET_EXTENDED_TX_DETAILS: "/get_extended_tx_details",
+    EPOCH_GENESIS_INITIALIZATION: "/init_genesis"
 };
 
 export class CommandHandler {
@@ -220,6 +221,10 @@ export class CommandHandler {
             {
                 evaluate: ({ input }) => input.startsWith(COMMANDS.GET_EXTENDED_TX_DETAILS),
                 process: async ({ parts }) => this.#handlers.handleExtendedTxDetails(parts[0], parts[1] === "true")
+            },
+            {
+                evaluate: ({ input }) => input.startsWith(COMMANDS.EPOCH_GENESIS_INITIALIZATION),
+                process: async () => this.#handlers.handleEpochGenesisInitialization()
             }
         ];
     }

--- a/cli/commandHandler.js
+++ b/cli/commandHandler.js
@@ -47,6 +47,7 @@ export class CommandHandler {
     #wallet;
     #handlers;
     #pendingConfirmation = null;
+    #pendingGenesisInitialization = null;
 
     constructor({ config, msb, handleClose, wallet }) {
         this.#msb = msb;
@@ -58,6 +59,10 @@ export class CommandHandler {
     async handle(input) {
         if (this.#pendingConfirmation !== null) {
             return this.#handlePendingConfirmation(input);
+        }
+
+        if (this.#pendingGenesisInitialization !== null) {
+            return this.#handlePendingGenesisInitialization(input);
         }
 
         const [command, ...parts] = input.split(" ");
@@ -224,7 +229,7 @@ export class CommandHandler {
             },
             {
                 evaluate: ({ input }) => input.startsWith(COMMANDS.EPOCH_GENESIS_INITIALIZATION),
-                process: async () => this.#handlers.handleEpochGenesisInitialization()
+                process: async () => this.#queueEpochGenesisInitialization()
             }
         ];
     }
@@ -242,7 +247,8 @@ export class CommandHandler {
                 const errorMessage = typeof error === "object" && error !== null && "message" in error
                     ? error.message
                     : `${error}`;
-                console.error(`Transaction submission failed: ${errorMessage}`);
+                const failureMessage = pendingConfirmation.failureMessage || "Transaction submission failed";
+                console.error(`${failureMessage}: ${errorMessage}`);
                 console.log("Try again or use /help.");
             }
 
@@ -254,7 +260,7 @@ export class CommandHandler {
             return pendingConfirmation.onDecline();
         }
 
-        console.log('Invalid input. Please answer "y" or "n".');
+        console.log(pendingConfirmation.invalidMessage || 'Invalid input. Please answer "y" or "n".');
         console.log(pendingConfirmation.prompt);
     }
 
@@ -278,5 +284,89 @@ export class CommandHandler {
         };
 
         console.log(this.#pendingConfirmation.prompt);
+    }
+
+    #queueEpochGenesisInitialization() {
+        this.#pendingGenesisInitialization = {
+            step: "difficulty"
+        };
+
+        console.log(this.#getGenesisDifficultyPrompt());
+    }
+
+    #handlePendingGenesisInitialization(input) {
+        const pendingGenesisInitialization = this.#pendingGenesisInitialization;
+
+        if (pendingGenesisInitialization.step === "difficulty") {
+            const difficulty = this.#parseGenesisEpochInteger(input);
+            if (!difficulty) {
+                console.log("Invalid difficulty. Please enter a positive integer (example 55_000_000).");
+                console.log(this.#getGenesisDifficultyPrompt());
+                return;
+            }
+
+            pendingGenesisInitialization.difficulty = difficulty;
+            pendingGenesisInitialization.step = "discriminantBitSize";
+            console.log(this.#getGenesisDiscriminantBitSizePrompt());
+            return;
+        }
+
+        const discriminantBitSize = this.#parseGenesisEpochInteger(input);
+        if (!discriminantBitSize) {
+            console.log("Invalid discriminant bit size. Please enter a positive integer (example 2048).");
+            console.log(this.#getGenesisDiscriminantBitSizePrompt());
+            return;
+        }
+
+        const difficulty = pendingGenesisInitialization.difficulty;
+        this.#pendingGenesisInitialization = null;
+
+        return this.#queueEpochGenesisConfirmation({
+            difficulty,
+            discriminantBitSize
+        });
+    }
+
+    #queueEpochGenesisConfirmation({ difficulty, discriminantBitSize }) {
+        const params = {
+            vdfDifficulty: difficulty.value,
+            vdfDiscriminantSize: discriminantBitSize.value
+        };
+
+        console.info("Genesis Epoch Initialization Parameters:");
+        console.info(`VDF difficulty: ${difficulty.display}`);
+        console.info(`VDF discriminant bit size: ${discriminantBitSize.display}`);
+
+        this.#pendingConfirmation = {
+            prompt: "Do you want to proceed? (yes/no)",
+            invalidMessage: 'Invalid input. Please answer "yes" or "no".',
+            failureMessage: "Genesis epoch initialization failed",
+            onConfirm: async () => this.#handlers.handleEpochGenesisInitialization(params),
+            onDecline: async () => console.log("Genesis epoch initialization cancelled.")
+        };
+
+        console.log(this.#pendingConfirmation.prompt);
+    }
+
+    #parseGenesisEpochInteger(input) {
+        const display = input.trim();
+        if (!/^[0-9]+(?:_[0-9]+)*$/.test(display)) {
+            return null;
+        }
+
+        const value = display.replaceAll("_", "");
+        if (BigInt(value) <= 0n) {
+            return null;
+        }
+
+        return { display, value };
+    }
+
+    #getGenesisDifficultyPrompt() {
+        return "Set VDF difficulty (example 55_000_000):";
+    }
+
+    #getGenesisDiscriminantBitSizePrompt() {
+        return "Set VDF discriminant bit size (example 2048):";
     }
 }

--- a/cli/handlers.js
+++ b/cli/handlers.js
@@ -207,4 +207,8 @@ export class Handlers {
 
         return txDetails;
     }
+
+    async handleEpochGenesisInitialization() {
+        return this.#msb.handleEpochGenesisInitialization();
+    }
 }

--- a/cli/handlers.js
+++ b/cli/handlers.js
@@ -208,7 +208,7 @@ export class Handlers {
         return txDetails;
     }
 
-    async handleEpochGenesisInitialization() {
-        return this.#msb.handleEpochGenesisInitialization();
+    async handleEpochGenesisInitialization(params) {
+        return this.#msb.handleEpochGenesisInitialization(params);
     }
 }

--- a/src/codecs/apply/applyOperationCodec.js
+++ b/src/codecs/apply/applyOperationCodec.js
@@ -24,7 +24,7 @@ const normalizeDecodedApplyOperation = operation => {
     return operation;
 }
 
-const encodeApplyOperation = (payload) => {
+export const encodeApplyOperation = (payload) => {
     const error = Operation.verify(payload);
     if (error) throw new Error(error);
     return b4a.from(Operation.encode(payload).finish());

--- a/src/core/consensus/v1/handlers/epochProposal/epochProofData.js
+++ b/src/core/consensus/v1/handlers/epochProposal/epochProofData.js
@@ -78,5 +78,6 @@ export const epochProofFromBuffer = (proofData) => {
 export const keys = {
     CURRENT_INDEX: '/epoch/current',
     EPOCH_HASH: n => `/epoch/${n}`,
-    EPOCH_DATA: n => `/epochHash/${n}`
+    EPOCH_DATA: n => `/epochHash/${n}`,
+    VDF_PARAMS: '/parameters/vdf'
 }

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -15,6 +15,8 @@ import {
     TRAC_NAMESPACE,
     EventType,
     CustomEventType,
+    VDF_DIFFICULTY_SIZE,
+    VDF_DISCRIMINANT_SIZE,
 } from '../../utils/constants.js';
 import { isHexString, sleep, isTransactionRecordPut } from '../../utils/helpers.js';
 import tracCryptoApi from 'trac-crypto-api';
@@ -515,6 +517,20 @@ class State extends ReadyResource {
             valueEncoding: HYPERBEE_VALUE_ENCODING,
         })
         return this.#bee;
+    }
+
+    async getSignedVDFParams() {
+        const vdfParamsBuffer = await this.getSigned(keys.VDF_PARAMS);
+        if (!vdfParamsBuffer) return null;
+
+        if (!b4a.isBuffer(vdfParamsBuffer) || vdfParamsBuffer.length !== VDF_DIFFICULTY_SIZE + VDF_DISCRIMINANT_SIZE) {
+            return null;
+        }
+
+        return {
+            vdfDifficulty: vdfParamsBuffer.readUInt32BE(0),
+            vdfDiscriminantSize: vdfParamsBuffer.readUInt16BE(VDF_DIFFICULTY_SIZE),
+        };
     }
 
     // ATTENTION: DO NOT USE METHODS ABOVE IN APPLY PART!

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -523,8 +523,12 @@ class State extends ReadyResource {
         const vdfParamsBuffer = await this.getSigned(keys.VDF_PARAMS);
         if (!vdfParamsBuffer) return null;
 
-        if (!b4a.isBuffer(vdfParamsBuffer) || vdfParamsBuffer.length !== VDF_DIFFICULTY_SIZE + VDF_DISCRIMINANT_SIZE) {
-            return null;
+        const expectedLength = VDF_DIFFICULTY_SIZE + VDF_DISCRIMINANT_SIZE;
+        if (!b4a.isBuffer(vdfParamsBuffer)) {
+            throw new Error("Invalid VDF params value: expected a buffer.");
+        }
+        if (vdfParamsBuffer.length !== expectedLength) {
+            throw new Error(`Invalid VDF params length: expected ${expectedLength}, got ${vdfParamsBuffer.length}.`);
         }
 
         return {

--- a/src/index.js
+++ b/src/index.js
@@ -1063,21 +1063,21 @@ export class MainSettlementBus extends ReadyResource {
 
     async handleEpochGenesisInitialization(params) {
         if (!this.#config.enableWallet) {
-            throw new Error("Can not initialize an admin - wallet is not enabled.");
+            throw new Error("Can not initialize genesis epoch - wallet is not enabled.");
         }
 
         const adminEntry = await this.#state.getAdminEntry();
 
         if (!adminEntry) {
             throw new Error(
-                "Can set epoch genesis operation - admin has been not initialized."
+                "Can not initialize genesis epoch - admin has not been initialized."
             );
         }
         if (!this.#wallet) {
-            throw new Error("Can not perform recovery - wallet is not initialized.");
+            throw new Error("Can not initialize genesis epoch - wallet is not initialized.");
         }
-        if (adminEntry.address !== this.#wallet.address) {
-            throw new Error("Can not perform recovery - you are not the admin.");
+        if (!this.isAdmin(adminEntry)) {
+            throw new Error("Can not initialize genesis epoch - you are not the admin.");
         }
 
         const existingVDFParams = await this.#state.getSignedVDFParams();
@@ -1086,8 +1086,18 @@ export class MainSettlementBus extends ReadyResource {
         }
 
         const { vdfDifficulty, vdfDiscriminantSize } = params;
-        const vdfDifficultyBuffer = uint32ToBuffer(Number(vdfDifficulty), "VDF difficulty");
-        const vdfDiscriminantSizeBuffer = uint16ToBuffer(Number(vdfDiscriminantSize), "VDF discriminant size");
+        const difficultyNumber = Number(vdfDifficulty);
+        const discriminantNumber = Number(vdfDiscriminantSize);
+
+        if (!Number.isInteger(difficultyNumber) || difficultyNumber <= 0) {
+            throw new Error("VDF difficulty must be a positive unsigned 32-bit integer.");
+        }
+        if (!Number.isInteger(discriminantNumber) || discriminantNumber <= 0) {
+            throw new Error("VDF discriminant size must be a positive unsigned 16-bit integer.");
+        }
+
+        const vdfDifficultyBuffer = uint32ToBuffer(difficultyNumber, "VDF difficulty");
+        const vdfDiscriminantSizeBuffer = uint16ToBuffer(discriminantNumber, "VDF discriminant size");
 
         const txValidity = await this.#state.getIndexerSequenceState();
         const payload = await applyStateMessageFactory(this.#wallet, this.#config)

--- a/src/index.js
+++ b/src/index.js
@@ -1056,7 +1056,7 @@ export class MainSettlementBus extends ReadyResource {
         await this.#state.append(encodedPayload);
     }
 
-    async handleEpochGenesisInitialization() {
+    async handleEpochGenesisInitialization(_params) {
         // TODO: Implement SET_GENESIS_EPOCH operation handling.
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,10 +22,15 @@ import {
 } from "./utils/normalizers.js";
 import fileUtils from './utils/fileUtils.js';
 import migrationUtils from './utils/migrationUtils.js';
-import {safeDecodeApplyOperation, safeEncodeApplyOperation} from "./codecs/apply/applyOperationCodec.js";
+import {
+    encodeApplyOperation,
+    safeDecodeApplyOperation,
+    safeEncodeApplyOperation
+} from "./codecs/apply/applyOperationCodec.js";
 import PartialTransactionValidator from "./core/network/protocols/shared/validators/PartialTransactionValidator.js";
 import PartialTransferValidator from "./core/network/protocols/shared/validators/PartialTransferValidator.js";
 import { BroadcastError, ValidationError } from "./utils/errors.js";
+import { uint16ToBuffer, uint32ToBuffer } from "./utils/buffer.js";
 
 export class MainSettlementBus extends ReadyResource {
     #store;
@@ -211,7 +216,7 @@ export class MainSettlementBus extends ReadyResource {
         return { payload, decoded }
     }
 
-    handleGetFee() {        
+    handleGetFee() {
         const fee = this.#state.getFee();
         return bufferToBigInt(fee);
     }
@@ -251,7 +256,7 @@ export class MainSettlementBus extends ReadyResource {
             let dagSystem = await this.#state.base.system.core.treeHash();
             let lengthdagSystem = this.#state.base.system.core.length;
             const wl = await this.#state.getWriterLength();
-            
+
             console.log("---------- node & network stats ----------");
             console.log("wallet.publicKey:", this.#wallet?.publicKey?.toString("hex") ?? "unset");
             console.log("wallet.address:", this.#wallet?.address ?? "unset");
@@ -1056,8 +1061,44 @@ export class MainSettlementBus extends ReadyResource {
         await this.#state.append(encodedPayload);
     }
 
-    async handleEpochGenesisInitialization(_params) {
-        // TODO: Implement SET_GENESIS_EPOCH operation handling.
+    async handleEpochGenesisInitialization(params) {
+        if (!this.#config.enableWallet) {
+            throw new Error("Can not initialize an admin - wallet is not enabled.");
+        }
+
+        const adminEntry = await this.#state.getAdminEntry();
+
+        if (!adminEntry) {
+            throw new Error(
+                "Can set epoch genesis operation - admin has been not initialized."
+            );
+        }
+        if (!this.#wallet) {
+            throw new Error("Can not perform recovery - wallet is not initialized.");
+        }
+        if (adminEntry.address !== this.#wallet.address) {
+            throw new Error("Can not perform recovery - you are not the admin.");
+        }
+
+        const existingVDFParams = await this.#state.getSignedVDFParams();
+        if (existingVDFParams) {
+            throw new Error("Can not initialize genesis epoch - VDF parameters already exist.");
+        }
+
+        const { vdfDifficulty, vdfDiscriminantSize } = params;
+        const vdfDifficultyBuffer = uint32ToBuffer(Number(vdfDifficulty), "VDF difficulty");
+        const vdfDiscriminantSizeBuffer = uint16ToBuffer(Number(vdfDiscriminantSize), "VDF discriminant size");
+
+        const txValidity = await this.#state.getIndexerSequenceState();
+        const payload = await applyStateMessageFactory(this.#wallet, this.#config)
+            .buildCompleteSetGenesisEpochMessage(
+                this.#wallet.address,
+                txValidity,
+                vdfDifficultyBuffer,
+                vdfDiscriminantSizeBuffer,
+            )
+        const encodedPayload = encodeApplyOperation(payload);
+        await this.#state.append(encodedPayload);
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -286,6 +286,7 @@ export class MainSettlementBus extends ReadyResource {
             console.log("- /add_indexer <address>: Change a role of the selected writer node to indexer role. Charges a fee.");
             console.log("- /remove_indexer <address>: Change a role of the selected indexer node to default role. Charges a fee.");
             console.log("- /ban_writer <address>: Demote a whitelisted writer to default role and remove it from the whitelist. Charges a fee.");
+            console.log("- /init_genesis: Initialize genesis epoch.");
         }
         console.log("Available commands:");
         console.log("- /add_writer: Add yourself as a validator to this MSB once whitelisted. Requires a fee + 10x the fee as a stake in $TNK.");
@@ -1053,6 +1054,10 @@ export class MainSettlementBus extends ReadyResource {
         console.log('Disabling initialization...');
         const encodedPayload = safeEncodeApplyOperation(payload);
         await this.#state.append(encodedPayload);
+    }
+
+    async handleEpochGenesisInitialization() {
+        // TODO: Implement SET_GENESIS_EPOCH operation handling.
     }
 }
 

--- a/tests/unit/cli/commandHandler.test.js
+++ b/tests/unit/cli/commandHandler.test.js
@@ -19,6 +19,7 @@ function createSubject(overrides = {}) {
     const msb = {
         prepareTransferOperation: sinon.stub().resolves(preparedTransfer),
         submitPreparedTransferOperation: sinon.stub().resolves("tx-hash"),
+        handleEpochGenesisInitialization: sinon.stub().resolves("genesis-tx-hash"),
         printHelp: sinon.stub(),
         close: sinon.stub(),
         ...overrides.msb
@@ -116,4 +117,56 @@ test("CommandHandler clears pending confirmation after submission failure", asyn
     await handler.handle("/transfer trac1recipient 11");
 
     t.is(msb.prepareTransferOperation.callCount, 2);
+});
+
+test("CommandHandler collects genesis epoch params before confirmation", async (t) => {
+    stubConsole(t);
+
+    const { handler, msb } = createSubject();
+
+    await handler.handle("/init_genesis");
+
+    t.ok(console.log.calledWith("Set VDF difficulty (example 55_000_000):"));
+
+    await handler.handle("55_000_000");
+
+    t.ok(console.log.calledWith("Set VDF discriminant bit size (example 2048):"));
+
+    await handler.handle("2048");
+
+    t.ok(console.info.calledWith("Genesis Epoch Initialization Parameters:"));
+    t.ok(console.info.calledWith("VDF difficulty: 55_000_000"));
+    t.ok(console.info.calledWith("VDF discriminant bit size: 2048"));
+    t.ok(console.log.calledWith("Do you want to proceed? (yes/no)"));
+    t.ok(msb.handleEpochGenesisInitialization.notCalled);
+
+    await handler.handle("yes");
+
+    t.ok(msb.handleEpochGenesisInitialization.calledOnceWithExactly({
+        vdfDifficulty: "55000000",
+        vdfDiscriminantSize: "2048"
+    }));
+});
+
+test("CommandHandler re-prompts invalid genesis epoch params and cancels on no", async (t) => {
+    stubConsole(t);
+
+    const { handler, msb } = createSubject();
+
+    await handler.handle("/init_genesis");
+    await handler.handle("abc");
+
+    t.ok(console.log.calledWith("Invalid difficulty. Please enter a positive integer (example 55_000_000)."));
+    t.ok(msb.handleEpochGenesisInitialization.notCalled);
+
+    await handler.handle("55_000_000");
+    await handler.handle("0");
+
+    t.ok(console.log.calledWith("Invalid discriminant bit size. Please enter a positive integer (example 2048)."));
+
+    await handler.handle("2048");
+    await handler.handle("no");
+
+    t.ok(console.log.calledWith("Genesis epoch initialization cancelled."));
+    t.ok(msb.handleEpochGenesisInitialization.notCalled);
 });

--- a/tests/unit/consensus/services/IndexerPendingRequestService.test.js
+++ b/tests/unit/consensus/services/IndexerPendingRequestService.test.js
@@ -249,13 +249,15 @@ test('rejectPendingRequestsForPeer rejects all requests for a peer', async t => 
     const pA1 = service.registerPendingRequest(validPeerA, msgA1);
     const pA2 = service.registerPendingRequest(validPeerA, msgA2);
     const pB = service.registerPendingRequest(validPeerB, msgB);
+    const pA1Rejected = t.exception(async () => pA1, /peer gone/);
+    const pA2Rejected = t.exception(async () => pA2, /peer gone/);
 
     const count = service.rejectPendingRequestsForPeer(validPeerA, new Error('peer gone'));
     t.is(count, 2, 'rejected 2 requests for peerA');
     t.ok(service.has(msgB.session_id), 'peerB request untouched');
 
-    await t.exception(async () => pA1, /peer gone/);
-    await t.exception(async () => pA2, /peer gone/);
+    await pA1Rejected;
+    await pA2Rejected;
 
     service.resolvePendingRequest(msgB.session_id);
     await pB;
@@ -297,11 +299,13 @@ test('close rejects all pending requests', async t => {
 
     const p1 = service.registerPendingRequest(validPeerA, msg1);
     const p2 = service.registerPendingRequest(validPeerB, msg2);
+    const p1Rejected = t.exception(async () => p1, /cancelled \(shutdown\)/);
+    const p2Rejected = t.exception(async () => p2, /cancelled \(shutdown\)/);
 
     service.close();
 
-    await t.exception(async () => p1, /cancelled \(shutdown\)/);
-    await t.exception(async () => p2, /cancelled \(shutdown\)/);
+    await p1Rejected;
+    await p2Rejected;
 
     t.absent(service.has(msg1.session_id), 'all entries cleared');
     t.absent(service.has(msg2.session_id), 'all entries cleared');

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -112,6 +112,14 @@ async function createWallet(config) {
     });
 }
 
+function adminEntryFor(wallet, state, overrides = {}) {
+    return {
+        address: wallet.address,
+        wk: state.writingKey,
+        ...overrides,
+    };
+}
+
 if (isBareRuntime) {
     test('MainSettlementBus startup role log coverage is Node-only', t => {
         t.pass('skipped in Bare because esmock depends on node:module');
@@ -144,7 +152,7 @@ if (isBareRuntime) {
 
         await msb.ready();
 
-        loaded.state.getAdminEntry.resolves({ address: wallet.address });
+        loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
         loaded.state.getSignedVDFParams.resolves(null);
         loaded.state.getIndexerSequenceState.resolves(txValidity);
 
@@ -203,7 +211,7 @@ if (isBareRuntime) {
                 vdfDifficulty: '55000000',
                 vdfDiscriminantSize: '2048',
             }),
-            errorMessageIncludes('admin has been not initialized')
+            errorMessageIncludes('admin has not been initialized')
         );
 
         t.ok(loaded.state.getSignedVDFParams.notCalled);
@@ -249,7 +257,9 @@ if (isBareRuntime) {
 
         await msb.ready();
 
-        loaded.state.getAdminEntry.resolves({ address: 'different-admin-address' });
+        loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state, {
+            address: 'different-admin-address',
+        }));
 
         await t.exception(
             () => msb.handleEpochGenesisInitialization({
@@ -260,6 +270,91 @@ if (isBareRuntime) {
         );
 
         t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.append.notCalled);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects genesis epoch initialization when admin writing key mismatches', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state, {
+            wk: b4a.alloc(32, 2),
+        }));
+
+        await t.exception(
+            () => msb.handleEpochGenesisInitialization({
+                vdfDifficulty: '55000000',
+                vdfDiscriminantSize: '2048',
+            }),
+            errorMessageIncludes('you are not the admin')
+        );
+
+        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.append.notCalled);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects genesis epoch initialization when VDF difficulty is not positive', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
+        loaded.state.getSignedVDFParams.resolves(null);
+
+        await t.exception(
+            () => msb.handleEpochGenesisInitialization({
+                vdfDifficulty: '0',
+                vdfDiscriminantSize: '2048',
+            }),
+            errorMessageIncludes('VDF difficulty must be a positive unsigned 32-bit integer.')
+        );
+
+        t.ok(loaded.state.getIndexerSequenceState.notCalled);
+        t.ok(loaded.state.append.notCalled);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects genesis epoch initialization when VDF discriminant size is not positive', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
+        loaded.state.getSignedVDFParams.resolves(null);
+
+        await t.exception(
+            () => msb.handleEpochGenesisInitialization({
+                vdfDifficulty: '55000000',
+                vdfDiscriminantSize: '0',
+            }),
+            errorMessageIncludes('VDF discriminant size must be a positive unsigned 16-bit integer.')
+        );
+
+        t.ok(loaded.state.getIndexerSequenceState.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -276,7 +371,7 @@ if (isBareRuntime) {
 
         await msb.ready();
 
-        loaded.state.getAdminEntry.resolves({ address: wallet.address });
+        loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
         loaded.state.getSignedVDFParams.resolves({
             vdfDifficulty: 55000000,
             vdfDiscriminantSize: 2048,

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -1,0 +1,311 @@
+import { test } from 'brittle';
+import sinon from 'sinon';
+import EventEmitter from 'bare-events';
+import b4a from 'b4a';
+import { WalletProvider } from 'trac-wallet';
+import { OperationType } from '../../src/utils/constants.js';
+import { safeDecodeApplyOperation } from '../../src/codecs/apply/applyOperationCodec.js';
+import { addressToBuffer } from '../../src/core/state/utils/address.js';
+import { overrideConfig } from '../helpers/config.js';
+import { testKeyPair1 } from '../fixtures/apply.fixtures.js';
+
+const isBareRuntime = typeof globalThis.Bare !== 'undefined';
+
+async function loadMainSettlementBus() {
+    const { default: esmock } = await import('esmock');
+    let stateInstance = null;
+    let networkInstance = null;
+    let storeInstance = null;
+
+    class CorestoreMock {
+        constructor(path) {
+            this.path = path;
+            this.close = sinon.stub().resolves();
+            storeInstance = this;
+        }
+    }
+
+    class StateMock extends EventEmitter {
+        constructor() {
+            super();
+            this.base = new EventEmitter();
+            this.writingKey = b4a.alloc(32, 1);
+            this.ready = sinon.stub().resolves();
+            this.close = sinon.stub().resolves();
+            this.getAdminEntry = sinon.stub().resolves(null);
+            this.getNodeEntry = sinon.stub().resolves(null);
+            this.getSignedVDFParams = sinon.stub().resolves(null);
+            this.getIndexerSequenceState = sinon.stub().resolves(b4a.from('11'.repeat(32), 'hex'));
+            this.append = sinon.stub().resolves();
+            this.isWritable = sinon.stub().returns(false);
+            this.isIndexer = sinon.stub().returns(false);
+            this.getUnsignedLength = sinon.stub().returns(0);
+            this.getSignedLength = sinon.stub().returns(0);
+            stateInstance = this;
+        }
+    }
+
+    class NetworkMock {
+        constructor() {
+            this.ready = sinon.stub().resolves();
+            this.replicate = sinon.stub().resolves();
+            this.close = sinon.stub().resolves();
+            this.disconnectValidatorPeer = sinon.stub().returns(true);
+            networkInstance = this;
+        }
+    }
+
+    const { MainSettlementBus } = await esmock('../../src/index.js', {
+        corestore: CorestoreMock,
+        '../../src/core/state/State.js': StateMock,
+        '../../src/core/network/Network.js': NetworkMock,
+        '../../src/utils/fileUtils.js': {
+            default: {
+                ensureKeyPathDir: sinon.stub().resolves(),
+            },
+            verifyWalletPath: sinon.stub().resolves(),
+        },
+        '../../src/utils/helpers.js': {
+            sleep: sinon.stub().resolves(),
+            isHexString: (value) => /^[0-9a-fA-F]+$/.test(value),
+        },
+    });
+
+    return {
+        MainSettlementBus,
+        get state() {
+            return stateInstance;
+        },
+        get network() {
+            return networkInstance;
+        },
+        get store() {
+            return storeInstance;
+        },
+    };
+}
+
+function buildConfig() {
+    return {
+        storesFullPath: '/tmp/msb-index-test',
+        enableInteractiveMode: false,
+        enableWallet: false,
+        enableRoleRequester: false,
+    };
+}
+
+function buildGenesisConfig(overrides = {}) {
+    return overrideConfig({
+        storesDirectory: '/tmp/msb-index-test',
+        enableInteractiveMode: false,
+        enableRoleRequester: false,
+        enableWallet: true,
+        ...overrides,
+    });
+}
+
+async function createWallet(config) {
+    return await new WalletProvider(config).fromMnemonic({
+        mnemonic: testKeyPair1.mnemonic,
+        derivationPath: config.derivationPath
+    });
+}
+
+async function assertRejectsMessageIncludes(t, fn, expectedMessage) {
+    try {
+        await fn();
+        t.fail(`Expected error including: ${expectedMessage}`);
+    } catch (error) {
+        t.ok(error?.message?.includes(expectedMessage));
+    }
+}
+
+if (isBareRuntime) {
+    test('MainSettlementBus startup role log coverage is Node-only', t => {
+        t.pass('skipped in Bare because esmock depends on node:module');
+    });
+} else {
+    test('MainSettlementBus logs local autobase role status', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const msb = new loaded.MainSettlementBus(buildConfig());
+
+        await msb.ready();
+
+        t.ok(consoleLog.calledWith("isIndexer: false"));
+        t.ok(consoleLog.calledWith("isWriter: false"));
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus appends genesis epoch initialization with encoded VDF params', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const txValidity = b4a.from('aa'.repeat(32), 'hex');
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves({ address: wallet.address });
+        loaded.state.getSignedVDFParams.resolves(null);
+        loaded.state.getIndexerSequenceState.resolves(txValidity);
+
+        await msb.handleEpochGenesisInitialization({
+            vdfDifficulty: '55000000',
+            vdfDiscriminantSize: '2048',
+        });
+
+        t.ok(loaded.state.getSignedVDFParams.calledOnce);
+        t.ok(loaded.state.getIndexerSequenceState.calledOnce);
+        t.ok(loaded.state.append.calledOnce);
+
+        const encodedPayload = loaded.state.append.firstCall.args[0];
+        const decoded = safeDecodeApplyOperation(encodedPayload);
+
+        t.is(decoded.type, OperationType.SET_GENESIS_EPOCH);
+        t.ok(b4a.equals(decoded.address, addressToBuffer(wallet.address, config.addressPrefix)));
+        t.ok(b4a.equals(decoded.sgo.txv, txValidity));
+        t.is(decoded.sgo.df.length, 4);
+        t.is(decoded.sgo.db.length, 2);
+        t.is(decoded.sgo.df.readUInt32BE(0), 55000000);
+        t.is(decoded.sgo.db.readUInt16BE(0), 2048);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects genesis epoch initialization when wallet is disabled', async t => {
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig({ enableWallet: false });
+        const msb = new loaded.MainSettlementBus(config);
+
+        await assertRejectsMessageIncludes(
+            t,
+            () => msb.handleEpochGenesisInitialization({
+                vdfDifficulty: '55000000',
+                vdfDiscriminantSize: '2048',
+            }),
+            'wallet is not enabled'
+        );
+    });
+
+    test('MainSettlementBus rejects genesis epoch initialization when admin is missing', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves(null);
+
+        await assertRejectsMessageIncludes(
+            t,
+            () => msb.handleEpochGenesisInitialization({
+                vdfDifficulty: '55000000',
+                vdfDiscriminantSize: '2048',
+            }),
+            'admin has been not initialized'
+        );
+
+        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.append.notCalled);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects genesis epoch initialization when wallet is missing', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const msb = new loaded.MainSettlementBus(config);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves({ address: 'admin-address' });
+
+        await assertRejectsMessageIncludes(
+            t,
+            () => msb.handleEpochGenesisInitialization({
+                vdfDifficulty: '55000000',
+                vdfDiscriminantSize: '2048',
+            }),
+            'wallet is not initialized'
+        );
+
+        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.append.notCalled);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects genesis epoch initialization for non-admin wallet', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves({ address: 'different-admin-address' });
+
+        await assertRejectsMessageIncludes(
+            t,
+            () => msb.handleEpochGenesisInitialization({
+                vdfDifficulty: '55000000',
+                vdfDiscriminantSize: '2048',
+            }),
+            'you are not the admin'
+        );
+
+        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.append.notCalled);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects genesis epoch initialization when VDF params already exist', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves({ address: wallet.address });
+        loaded.state.getSignedVDFParams.resolves({
+            vdfDifficulty: 55000000,
+            vdfDiscriminantSize: 2048,
+        });
+
+        await assertRejectsMessageIncludes(
+            t,
+            () => msb.handleEpochGenesisInitialization({
+                vdfDifficulty: '55000000',
+                vdfDiscriminantSize: '2048',
+            }),
+            'VDF parameters already exist'
+        );
+
+        t.ok(loaded.state.append.notCalled);
+        t.ok(loaded.state.getIndexerSequenceState.notCalled);
+
+        await msb.close();
+    });
+}

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -8,6 +8,7 @@ import { safeDecodeApplyOperation } from '../../src/codecs/apply/applyOperationC
 import { addressToBuffer } from '../../src/core/state/utils/address.js';
 import { overrideConfig } from '../helpers/config.js';
 import { testKeyPair1 } from '../fixtures/apply.fixtures.js';
+import { errorMessageIncludes } from '../helpers/regexHelper.js';
 
 const isBareRuntime = typeof globalThis.Bare !== 'undefined';
 
@@ -111,15 +112,6 @@ async function createWallet(config) {
     });
 }
 
-async function assertRejectsMessageIncludes(t, fn, expectedMessage) {
-    try {
-        await fn();
-        t.fail(`Expected error including: ${expectedMessage}`);
-    } catch (error) {
-        t.ok(error?.message?.includes(expectedMessage));
-    }
-}
-
 if (isBareRuntime) {
     test('MainSettlementBus startup role log coverage is Node-only', t => {
         t.pass('skipped in Bare because esmock depends on node:module');
@@ -184,13 +176,12 @@ if (isBareRuntime) {
         const config = buildGenesisConfig({ enableWallet: false });
         const msb = new loaded.MainSettlementBus(config);
 
-        await assertRejectsMessageIncludes(
-            t,
+        await t.exception(
             () => msb.handleEpochGenesisInitialization({
                 vdfDifficulty: '55000000',
                 vdfDiscriminantSize: '2048',
             }),
-            'wallet is not enabled'
+            errorMessageIncludes('wallet is not enabled')
         );
     });
 
@@ -207,13 +198,12 @@ if (isBareRuntime) {
 
         loaded.state.getAdminEntry.resolves(null);
 
-        await assertRejectsMessageIncludes(
-            t,
+        await t.exception(
             () => msb.handleEpochGenesisInitialization({
                 vdfDifficulty: '55000000',
                 vdfDiscriminantSize: '2048',
             }),
-            'admin has been not initialized'
+            errorMessageIncludes('admin has been not initialized')
         );
 
         t.ok(loaded.state.getSignedVDFParams.notCalled);
@@ -234,13 +224,12 @@ if (isBareRuntime) {
 
         loaded.state.getAdminEntry.resolves({ address: 'admin-address' });
 
-        await assertRejectsMessageIncludes(
-            t,
+        await t.exception(
             () => msb.handleEpochGenesisInitialization({
                 vdfDifficulty: '55000000',
                 vdfDiscriminantSize: '2048',
             }),
-            'wallet is not initialized'
+            errorMessageIncludes('wallet is not initialized')
         );
 
         t.ok(loaded.state.getSignedVDFParams.notCalled);
@@ -262,13 +251,12 @@ if (isBareRuntime) {
 
         loaded.state.getAdminEntry.resolves({ address: 'different-admin-address' });
 
-        await assertRejectsMessageIncludes(
-            t,
+        await t.exception(
             () => msb.handleEpochGenesisInitialization({
                 vdfDifficulty: '55000000',
                 vdfDiscriminantSize: '2048',
             }),
-            'you are not the admin'
+            errorMessageIncludes('you are not the admin')
         );
 
         t.ok(loaded.state.getSignedVDFParams.notCalled);
@@ -294,13 +282,12 @@ if (isBareRuntime) {
             vdfDiscriminantSize: 2048,
         });
 
-        await assertRejectsMessageIncludes(
-            t,
+        await t.exception(
             () => msb.handleEpochGenesisInitialization({
                 vdfDifficulty: '55000000',
                 vdfDiscriminantSize: '2048',
             }),
-            'VDF parameters already exist'
+            errorMessageIncludes('VDF parameters already exist')
         );
 
         t.ok(loaded.state.append.notCalled);

--- a/tests/unit/messages/state/applyStateMessageDirector.test.js
+++ b/tests/unit/messages/state/applyStateMessageDirector.test.js
@@ -62,6 +62,8 @@ test('ApplyStateMessageDirector builds complete set genesis epoch message', asyn
     t.ok(b4a.equals(payload.sgo.df, vdfDifficulty));
     t.ok(b4a.equals(payload.sgo.db, vdfDiscriminantSize));
     t.is(payload.sgo.tx.length, 32);
+    t.is(payload.sgo.df.length, VDF_DIFFICULTY_SIZE);
+    t.is(payload.sgo.db.length, VDF_DISCRIMINANT_SIZE);
     t.is(payload.sgo.in.length, 32);
     t.is(payload.sgo.is.length, 64);
 });

--- a/tests/unit/state/stateModule.test.js
+++ b/tests/unit/state/stateModule.test.js
@@ -15,6 +15,7 @@ async function runStateTests() {
     await import('./apply/state.apply.test.js');
     if (!isBare()) {
         await import('./stateAdminValidation.test.js');
+        await import('./vdfParams.test.js');
         await import('./State.test.js');
     }
     test.resume();

--- a/tests/unit/state/vdfParams.test.js
+++ b/tests/unit/state/vdfParams.test.js
@@ -1,0 +1,62 @@
+import { test } from 'brittle';
+import b4a from 'b4a';
+import esmock from 'esmock';
+import sinon from 'sinon';
+
+import { config } from '../../helpers/config.js';
+import { errorMessageIncludes } from '../../helpers/regexHelper.js';
+
+async function createStateWithSignedValue(value) {
+    const checkoutSession = {
+        get: sinon.stub().resolves(value === undefined ? null : { value }),
+        close: sinon.stub().resolves()
+    };
+    const checkout = sinon.stub().returns(checkoutSession);
+    const AutoBaseMock = sinon.stub().returns({
+        view: {
+            checkout,
+            core: { signedLength: 1 }
+        }
+    });
+    const State = await esmock('../../../src/core/state/State.js', {
+        autobase: AutoBaseMock
+    });
+
+    return new State(null, null, config);
+}
+
+test('State#getSignedVDFParams returns null when params are missing', async t => {
+    const state = await createStateWithSignedValue(undefined);
+
+    t.is(await state.getSignedVDFParams(), null);
+});
+
+test('State#getSignedVDFParams decodes stored VDF params', async t => {
+    const vdfParams = b4a.alloc(6);
+    vdfParams.writeUInt32BE(55_000_000, 0);
+    vdfParams.writeUInt16BE(2048, 4);
+    const state = await createStateWithSignedValue(vdfParams);
+
+    t.alike(await state.getSignedVDFParams(), {
+        vdfDifficulty: 55_000_000,
+        vdfDiscriminantSize: 2048,
+    });
+});
+
+test('State#getSignedVDFParams rejects non-buffer values', async t => {
+    const state = await createStateWithSignedValue('invalid');
+
+    await t.exception(
+        () => state.getSignedVDFParams(),
+        errorMessageIncludes('Invalid VDF params value: expected a buffer.')
+    );
+});
+
+test('State#getSignedVDFParams rejects values with invalid length', async t => {
+    const state = await createStateWithSignedValue(b4a.alloc(5));
+
+    await t.exception(
+        () => state.getSignedVDFParams(),
+        errorMessageIncludes('Invalid VDF params length: expected 6, got 5.')
+    );
+});


### PR DESCRIPTION
# Description
This PR adds a new interactive CLI handler for genesis epoch initialization. The user can provide VDF parameters, confirm the operation, and broadcast the genesis epoch initialization operation to the MSB.

# Implemented

- Added interactive CLI flow for /init_genesis.
- Added validation and conversion for VDF parameters:
    - difficulty as uint32, 4 bytes,
    - discriminant bit size as uint16, 2 bytes.

- Added guards to prevent re-initialization when VDF parameters already exist.
- Added a new state key:
    - /parameters/vdf

- VDF parameters are stored as byte concatenation:
    - first 4 bytes: VDF difficulty,
    - next 2 bytes: VDF discriminant bit size.

- Added unit tests for the happy path and error cases.

 # Why
Genesis epoch initialization needs deterministic VDF parameters stored in ledger state. This allows consensus components to read the same parameters from state instead of relying only on local configuration.