### PR TITLE
feat: extend builder class for apply operations to build set vdf para…

### DIFF
--- a/src/messages/state/ApplyStateMessageBuilder.js
+++ b/src/messages/state/ApplyStateMessageBuilder.js
@@ -2,7 +2,11 @@ import b4a from 'b4a';
 import tracCryptoApi from 'trac-crypto-api';
 
 import { createMessage, toHex } from '../../utils/buffer.js';
-import { OperationType } from '../../utils/constants.js';
+import {
+    OperationType,
+    VDF_DIFFICULTY_SIZE,
+    VDF_DISCRIMINANT_SIZE
+} from '../../utils/constants.js';
 import { addressToBuffer, bufferToAddress } from '../../core/state/utils/address.js';
 import { isAddressValid } from "../../core/state/utils/address.js";
 import {
@@ -13,6 +17,7 @@ import {
     isRoleAccess,
     isSetEpoch,
     isSetGenesisEpoch,
+    isSetVdfParams,
     isTransaction,
     isTransfer,
     operationToPayload
@@ -182,12 +187,12 @@ class ApplyStateMessageBuilder {
     }
 
     setVdfDifficulty(vdfDifficulty) {
-        this.#vdfDifficulty = this.#normalizeHexBuffer(vdfDifficulty, 32, 'VDF difficulty');
+        this.#vdfDifficulty = this.#normalizeHexBuffer(vdfDifficulty, VDF_DIFFICULTY_SIZE, 'VDF difficulty');
         return this;
     }
 
     setVdfDiscriminantSize(vdfDiscriminantSize) {
-        this.#vdfDiscriminantSize = this.#normalizeHexBuffer(vdfDiscriminantSize, 32, 'VDF discriminant size');
+        this.#vdfDiscriminantSize = this.#normalizeHexBuffer(vdfDiscriminantSize, VDF_DISCRIMINANT_SIZE, 'VDF discriminant size');
         return this;
     }
 
@@ -576,6 +581,21 @@ class ApplyStateMessageBuilder {
                     this.#operationType
                 );
                 break;
+            case OperationType.SET_VDF_PARAMS:
+                this.#requireFields([
+                    [this.#txValidity, 'Transaction validity'],
+                    [this.#vdfDifficulty, 'Difficulty'],
+                    [this.#vdfDiscriminantSize, 'Discriminant size']
+                ]);
+                msg = createMessage(
+                    this.#config.networkId,
+                    this.#txValidity,
+                    this.#vdfDifficulty,
+                    this.#vdfDiscriminantSize,
+                    nonce,
+                    this.#operationType
+                );
+                break;
             default:
                 throw new Error(`Unsupported operation type: ${this.#operationType}`);
         }
@@ -666,6 +686,16 @@ class ApplyStateMessageBuilder {
             };
         }
         if (isSetGenesisEpoch(this.#operationType)) {
+            return {
+                tx,
+                txv: this.#txValidity,
+                df: this.#vdfDifficulty,
+                db: this.#vdfDiscriminantSize,
+                in: nonce,
+                is: signature
+            };
+        }
+        if (isSetVdfParams(this.#operationType)) {
             return {
                 tx,
                 txv: this.#txValidity,

--- a/src/messages/state/ApplyStateMessageDirector.js
+++ b/src/messages/state/ApplyStateMessageDirector.js
@@ -553,6 +553,28 @@ class ApplyStateMessageDirector {
             .build();
         return this.#builder.getPayload();
     }
+
+    /**
+     * Build a complete set VDF params payload.
+     * @param {string|Buffer} invokerAddress
+     * @param {string|Buffer} txValidity
+     * @param {string|Buffer} vdfDifficulty
+     * @param {string|Buffer} vdfDiscriminantSize
+     * @returns {Promise<object>}
+     */
+    async buildCompleteSetVdfParamsMessage(invokerAddress, txValidity, vdfDifficulty, vdfDiscriminantSize) {
+        if (!this.#builder) throw new Error('Builder has not been set.');
+        await this.#builder
+            .setPhase('complete')
+            .setOutput('buffer')
+            .setOperationType(OperationType.SET_VDF_PARAMS)
+            .setAddress(invokerAddress)
+            .setTxValidity(txValidity)
+            .setVdfDifficulty(vdfDifficulty)
+            .setVdfDiscriminantSize(vdfDiscriminantSize)
+            .build();
+        return this.#builder.getPayload();
+    }
 }
 
 export default ApplyStateMessageDirector;

--- a/src/utils/applyOperations.js
+++ b/src/utils/applyOperations.js
@@ -60,6 +60,12 @@ const isSetGenesisEpoch = type => {
     ].includes(type);
 }
 
+const isSetVdfParams = type => {
+    return [
+        OperationType.SET_VDF_PARAMS
+    ].includes(type);
+}
+
 const operationToPayload = type => {
     const fromTo = [
         {
@@ -97,6 +103,10 @@ const operationToPayload = type => {
         {
             condition: isSetGenesisEpoch,
             jsonPath: 'sgo'
+        },
+        {
+            condition: isSetVdfParams,
+            jsonPath: 'vpo'
         }
     ]
     const match = fromTo.find(entry => !!entry.condition(type))
@@ -113,5 +123,6 @@ export {
     isTransfer,
     isBalanceInitialization,
     isSetEpoch,
-    isSetGenesisEpoch
+    isSetGenesisEpoch,
+    isSetVdfParams
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -37,6 +37,7 @@ export const OperationType = Object.freeze({
     TRANSFER: ApplyOperationType.TRANSFER,
     SET_EPOCH: ApplyOperationType.SET_EPOCH,
     SET_GENESIS_EPOCH: ApplyOperationType.SET_GENESIS_EPOCH,
+    SET_VDF_PARAMS: ApplyOperationType.SET_VDF_PARAMS,
 });
 
 export const NetworkOperationType = Object.freeze({

--- a/tests/unit/messages/state/applyStateMessageBuilder.complete.test.js
+++ b/tests/unit/messages/state/applyStateMessageBuilder.complete.test.js
@@ -6,7 +6,11 @@ import {
     safeDecodeApplyOperation,
     safeEncodeApplyOperation,
 } from '../../../../src/codecs/apply/applyOperationCodec.js';
-import { OperationType } from '../../../../src/utils/constants.js';
+import {
+    OperationType,
+    VDF_DIFFICULTY_SIZE,
+    VDF_DISCRIMINANT_SIZE
+} from '../../../../src/utils/constants.js';
 import { config } from '../../../helpers/config.js';
 import { testKeyPair1, testKeyPair2 } from '../../../fixtures/apply.fixtures.js';
 import { addressToBuffer } from '../../../../src/core/state/utils/address.js';
@@ -593,8 +597,8 @@ test('ApplyStateMessageBuilder complete set epoch operation codec roundtrip', as
 test('ApplyStateMessageBuilder complete set genesis epoch operation (sgo)', async t => {
     const wallet = await createWallet(testKeyPair1.mnemonic);
     const txValidity = toBuf(hex('11', 32));
-    const vdfDifficulty = toBuf(hex('22', 32));
-    const vdfDiscriminantSize = toBuf(hex('33', 32));
+    const vdfDifficulty = toBuf(hex('22', VDF_DIFFICULTY_SIZE));
+    const vdfDiscriminantSize = toBuf(hex('33', VDF_DISCRIMINANT_SIZE));
 
     const builder = new ApplyStateMessageBuilder(wallet, config);
     await builder
@@ -615,8 +619,8 @@ test('ApplyStateMessageBuilder complete set genesis epoch operation (sgo)', asyn
     expectKeys(t, payload.sgo, ['tx', 'txv', 'df', 'db', 'in', 'is'], 'sgo');
     expectBufferField(t, payload.sgo.tx, 32, 'sgo.tx');
     expectBufferField(t, payload.sgo.txv, 32, 'sgo.txv');
-    expectBufferField(t, payload.sgo.df, 32, 'sgo.df');
-    expectBufferField(t, payload.sgo.db, 32, 'sgo.db');
+    expectBufferField(t, payload.sgo.df, VDF_DIFFICULTY_SIZE, 'sgo.df');
+    expectBufferField(t, payload.sgo.db, VDF_DISCRIMINANT_SIZE, 'sgo.db');
     expectBufferField(t, payload.sgo.in, 32, 'sgo.in');
     expectBufferField(t, payload.sgo.is, 64, 'sgo.is');
     t.ok(b4a.equals(payload.sgo.txv, txValidity));
@@ -627,8 +631,8 @@ test('ApplyStateMessageBuilder complete set genesis epoch operation (sgo)', asyn
 test('ApplyStateMessageBuilder complete set genesis epoch operation codec roundtrip', async t => {
     const wallet = await createWallet(testKeyPair1.mnemonic);
     const txValidity = toBuf(hex('44', 32));
-    const vdfDifficulty = toBuf(hex('55', 32));
-    const vdfDiscriminantSize = toBuf(hex('66', 32));
+    const vdfDifficulty = toBuf(hex('55', VDF_DIFFICULTY_SIZE));
+    const vdfDiscriminantSize = toBuf(hex('66', VDF_DISCRIMINANT_SIZE));
 
     const builder = new ApplyStateMessageBuilder(wallet, config);
     await builder
@@ -657,4 +661,73 @@ test('ApplyStateMessageBuilder complete set genesis epoch operation codec roundt
     t.ok(b4a.equals(decoded.sgo.db, vdfDiscriminantSize));
     t.ok(b4a.equals(decoded.sgo.in, payload.sgo.in));
     t.ok(b4a.equals(decoded.sgo.is, payload.sgo.is));
+});
+
+test('ApplyStateMessageBuilder complete set VDF params operation (vpo)', async t => {
+    const wallet = await createWallet(testKeyPair1.mnemonic);
+    const txValidity = toBuf(hex('77', 32));
+    const vdfDifficulty = toBuf(hex('88', VDF_DIFFICULTY_SIZE));
+    const vdfDiscriminantSize = toBuf(hex('99', VDF_DISCRIMINANT_SIZE));
+
+    const builder = new ApplyStateMessageBuilder(wallet, config);
+    await builder
+        .setPhase('complete')
+        .setOutput('buffer')
+        .setOperationType(OperationType.SET_VDF_PARAMS)
+        .setAddress(wallet.address)
+        .setTxValidity(txValidity)
+        .setVdfDifficulty(vdfDifficulty)
+        .setVdfDiscriminantSize(vdfDiscriminantSize)
+        .build();
+
+    const payload = builder.getPayload();
+    t.is(payload.type, OperationType.SET_VDF_PARAMS);
+    expectAddressBuffer(t, payload.address, 'address');
+    t.ok(b4a.equals(payload.address, addressToBuffer(wallet.address, config.addressPrefix)));
+    expectPayloadKeys(t, payload, 'vpo');
+    expectKeys(t, payload.vpo, ['tx', 'txv', 'df', 'db', 'in', 'is'], 'vpo');
+    expectBufferField(t, payload.vpo.tx, 32, 'vpo.tx');
+    expectBufferField(t, payload.vpo.txv, 32, 'vpo.txv');
+    expectBufferField(t, payload.vpo.df, VDF_DIFFICULTY_SIZE, 'vpo.df');
+    expectBufferField(t, payload.vpo.db, VDF_DISCRIMINANT_SIZE, 'vpo.db');
+    expectBufferField(t, payload.vpo.in, 32, 'vpo.in');
+    expectBufferField(t, payload.vpo.is, 64, 'vpo.is');
+    t.ok(b4a.equals(payload.vpo.txv, txValidity));
+    t.ok(b4a.equals(payload.vpo.df, vdfDifficulty));
+    t.ok(b4a.equals(payload.vpo.db, vdfDiscriminantSize));
+});
+
+test('ApplyStateMessageBuilder complete set VDF params operation codec roundtrip', async t => {
+    const wallet = await createWallet(testKeyPair1.mnemonic);
+    const txValidity = toBuf(hex('aa', 32));
+    const vdfDifficulty = toBuf(hex('bb', VDF_DIFFICULTY_SIZE));
+    const vdfDiscriminantSize = toBuf(hex('cc', VDF_DISCRIMINANT_SIZE));
+
+    const builder = new ApplyStateMessageBuilder(wallet, config);
+    await builder
+        .setPhase('complete')
+        .setOutput('buffer')
+        .setOperationType(OperationType.SET_VDF_PARAMS)
+        .setAddress(wallet.address)
+        .setTxValidity(txValidity)
+        .setVdfDifficulty(vdfDifficulty)
+        .setVdfDiscriminantSize(vdfDiscriminantSize)
+        .build();
+
+    const payload = builder.getPayload();
+    const encoded = safeEncodeApplyOperation(payload);
+    const decoded = safeDecodeApplyOperation(encoded);
+
+    t.ok(b4a.isBuffer(encoded));
+    t.ok(encoded.length > 0);
+    t.is(decoded.type, OperationType.SET_VDF_PARAMS);
+    t.ok(b4a.equals(decoded.address, addressToBuffer(wallet.address, config.addressPrefix)));
+    t.alike(Object.keys(decoded).sort(), ['address', 'type', 'vpo']);
+    t.alike(Object.keys(decoded.vpo).sort(), ['db', 'df', 'in', 'is', 'tx', 'txv']);
+    t.ok(b4a.equals(decoded.vpo.tx, payload.vpo.tx));
+    t.ok(b4a.equals(decoded.vpo.txv, txValidity));
+    t.ok(b4a.equals(decoded.vpo.df, vdfDifficulty));
+    t.ok(b4a.equals(decoded.vpo.db, vdfDiscriminantSize));
+    t.ok(b4a.equals(decoded.vpo.in, payload.vpo.in));
+    t.ok(b4a.equals(decoded.vpo.is, payload.vpo.is));
 });

--- a/tests/unit/messages/state/applyStateMessageDirector.test.js
+++ b/tests/unit/messages/state/applyStateMessageDirector.test.js
@@ -4,7 +4,11 @@ import { WalletProvider } from 'trac-wallet';
 
 import { applyStateMessageFactory } from '../../../../src/messages/state/applyStateMessageFactory.js';
 import { addressToBuffer } from '../../../../src/core/state/utils/address.js';
-import { OperationType } from '../../../../src/utils/constants.js';
+import {
+    OperationType,
+    VDF_DIFFICULTY_SIZE,
+    VDF_DISCRIMINANT_SIZE
+} from '../../../../src/utils/constants.js';
 import { config } from '../../../helpers/config.js';
 import { testKeyPair1 } from '../../../fixtures/apply.fixtures.js';
 import {
@@ -39,8 +43,8 @@ test('ApplyStateMessageDirector builds complete set epoch message', async t => {
 test('ApplyStateMessageDirector builds complete set genesis epoch message', async t => {
     const wallet = await createWallet(testKeyPair1.mnemonic);
     const txValidity = b4a.from('11'.repeat(32), 'hex');
-    const vdfDifficulty = b4a.from('22'.repeat(32), 'hex');
-    const vdfDiscriminantSize = b4a.from('33'.repeat(32), 'hex');
+    const vdfDifficulty = b4a.from('22'.repeat(VDF_DIFFICULTY_SIZE), 'hex');
+    const vdfDiscriminantSize = b4a.from('33'.repeat(VDF_DISCRIMINANT_SIZE), 'hex');
 
     const payload = await applyStateMessageFactory(wallet, config)
         .buildCompleteSetGenesisEpochMessage(
@@ -60,4 +64,32 @@ test('ApplyStateMessageDirector builds complete set genesis epoch message', asyn
     t.is(payload.sgo.tx.length, 32);
     t.is(payload.sgo.in.length, 32);
     t.is(payload.sgo.is.length, 64);
+});
+
+test('ApplyStateMessageDirector builds complete set VDF params message', async t => {
+    const wallet = await createWallet(testKeyPair1.mnemonic);
+    const txValidity = b4a.from('44'.repeat(32), 'hex');
+    const vdfDifficulty = b4a.from('55'.repeat(VDF_DIFFICULTY_SIZE), 'hex');
+    const vdfDiscriminantSize = b4a.from('66'.repeat(VDF_DISCRIMINANT_SIZE), 'hex');
+
+    const payload = await applyStateMessageFactory(wallet, config)
+        .buildCompleteSetVdfParamsMessage(
+            wallet.address,
+            txValidity,
+            vdfDifficulty,
+            vdfDiscriminantSize
+        );
+
+    t.is(payload.type, OperationType.SET_VDF_PARAMS);
+    t.ok(b4a.equals(payload.address, addressToBuffer(wallet.address, config.addressPrefix)));
+    t.alike(Object.keys(payload).sort(), ['address', 'type', 'vpo']);
+    t.alike(Object.keys(payload.vpo).sort(), ['db', 'df', 'in', 'is', 'tx', 'txv']);
+    t.ok(b4a.equals(payload.vpo.txv, txValidity));
+    t.ok(b4a.equals(payload.vpo.df, vdfDifficulty));
+    t.ok(b4a.equals(payload.vpo.db, vdfDiscriminantSize));
+    t.is(payload.vpo.df.length, VDF_DIFFICULTY_SIZE);
+    t.is(payload.vpo.db.length, VDF_DISCRIMINANT_SIZE);
+    t.is(payload.vpo.tx.length, 32);
+    t.is(payload.vpo.in.length, 32);
+    t.is(payload.vpo.is.length, 64);
 });


### PR DESCRIPTION
Implemented builder support for the SET_VDF_PARAMS apply operation.

This PR wires SET_VDF_PARAMS into the apply message builder flow by:
  - exposing OperationType.SET_VDF_PARAMS
  - mapping the operation to the vpo payload key
  - adding complete-message builder support
  - adding buildCompleteSetVdfParamsMessage() to the message director
  - adding builder/director tests for the new operation

The VDF parameter setters now use the protocol-defined byte sizes:
  - df: 4 bytes
  - db: 2 bytes
