### PR TITLE
feat: extend statevalidationschema.js with a new validation for set v…

### DIFF
--- a/proto/applyOperations/messages/set_vdf_params_operation.proto
+++ b/proto/applyOperations/messages/set_vdf_params_operation.proto
@@ -6,7 +6,6 @@ message SetVdfParamsOperation {
     bytes tx     = 1; // Transaction hash (unique identifier for the transaction)
     bytes txv    = 2; // Transaction expiration
     bytes df     = 3; // VDF difficulty factor
-    bytes db     = 4; // VDF discriminant size bits
-    bytes in     = 5; // Nonce of the invoker (admin)
-    bytes is     = 6; // Signature of the invoker (admin)
+    bytes in     = 4; // Nonce of the invoker (admin)
+    bytes is     = 5; // Signature of the invoker (admin)
 }

--- a/src/codecs/apply/applyOperations.generated.cjs
+++ b/src/codecs/apply/applyOperations.generated.cjs
@@ -4388,7 +4388,6 @@ $root.apply = (function() {
              * @property {Uint8Array|null} [tx] SetVdfParamsOperation tx
              * @property {Uint8Array|null} [txv] SetVdfParamsOperation txv
              * @property {Uint8Array|null} [df] SetVdfParamsOperation df
-             * @property {Uint8Array|null} [db] SetVdfParamsOperation db
              * @property {Uint8Array|null} ["in"] SetVdfParamsOperation in
              * @property {Uint8Array|null} [is] SetVdfParamsOperation is
              */
@@ -4431,14 +4430,6 @@ $root.apply = (function() {
              * @instance
              */
             SetVdfParamsOperation.prototype.df = $util.newBuffer([]);
-
-            /**
-             * SetVdfParamsOperation db.
-             * @member {Uint8Array} db
-             * @memberof apply.operations.SetVdfParamsOperation
-             * @instance
-             */
-            SetVdfParamsOperation.prototype.db = $util.newBuffer([]);
 
             /**
              * SetVdfParamsOperation in.
@@ -4486,12 +4477,10 @@ $root.apply = (function() {
                     writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.txv);
                 if (message.df != null && Object.hasOwnProperty.call(message, "df"))
                     writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.df);
-                if (message.db != null && Object.hasOwnProperty.call(message, "db"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.db);
                 if (message["in"] != null && Object.hasOwnProperty.call(message, "in"))
-                    writer.uint32(/* id 5, wireType 2 =*/42).bytes(message["in"]);
+                    writer.uint32(/* id 4, wireType 2 =*/34).bytes(message["in"]);
                 if (message.is != null && Object.hasOwnProperty.call(message, "is"))
-                    writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.is);
+                    writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.is);
                 return writer;
             };
 
@@ -4541,14 +4530,10 @@ $root.apply = (function() {
                             break;
                         }
                     case 4: {
-                            message.db = reader.bytes();
-                            break;
-                        }
-                    case 5: {
                             message["in"] = reader.bytes();
                             break;
                         }
-                    case 6: {
+                    case 5: {
                             message.is = reader.bytes();
                             break;
                         }
@@ -4596,9 +4581,6 @@ $root.apply = (function() {
                 if (message.df != null && message.hasOwnProperty("df"))
                     if (!(message.df && typeof message.df.length === "number" || $util.isString(message.df)))
                         return "df: buffer expected";
-                if (message.db != null && message.hasOwnProperty("db"))
-                    if (!(message.db && typeof message.db.length === "number" || $util.isString(message.db)))
-                        return "db: buffer expected";
                 if (message["in"] != null && message.hasOwnProperty("in"))
                     if (!(message["in"] && typeof message["in"].length === "number" || $util.isString(message["in"])))
                         return "in: buffer expected";
@@ -4635,11 +4617,6 @@ $root.apply = (function() {
                         $util.base64.decode(object.df, message.df = $util.newBuffer($util.base64.length(object.df)), 0);
                     else if (object.df.length >= 0)
                         message.df = object.df;
-                if (object.db != null)
-                    if (typeof object.db === "string")
-                        $util.base64.decode(object.db, message.db = $util.newBuffer($util.base64.length(object.db)), 0);
-                    else if (object.db.length >= 0)
-                        message.db = object.db;
                 if (object["in"] != null)
                     if (typeof object["in"] === "string")
                         $util.base64.decode(object["in"], message["in"] = $util.newBuffer($util.base64.length(object["in"])), 0);
@@ -4689,13 +4666,6 @@ $root.apply = (function() {
                             object.df = $util.newBuffer(object.df);
                     }
                     if (options.bytes === String)
-                        object.db = "";
-                    else {
-                        object.db = [];
-                        if (options.bytes !== Array)
-                            object.db = $util.newBuffer(object.db);
-                    }
-                    if (options.bytes === String)
                         object["in"] = "";
                     else {
                         object["in"] = [];
@@ -4716,8 +4686,6 @@ $root.apply = (function() {
                     object.txv = options.bytes === String ? $util.base64.encode(message.txv, 0, message.txv.length) : options.bytes === Array ? Array.prototype.slice.call(message.txv) : message.txv;
                 if (message.df != null && message.hasOwnProperty("df"))
                     object.df = options.bytes === String ? $util.base64.encode(message.df, 0, message.df.length) : options.bytes === Array ? Array.prototype.slice.call(message.df) : message.df;
-                if (message.db != null && message.hasOwnProperty("db"))
-                    object.db = options.bytes === String ? $util.base64.encode(message.db, 0, message.db.length) : options.bytes === Array ? Array.prototype.slice.call(message.db) : message.db;
                 if (message["in"] != null && message.hasOwnProperty("in"))
                     object["in"] = options.bytes === String ? $util.base64.encode(message["in"], 0, message["in"].length) : options.bytes === Array ? Array.prototype.slice.call(message["in"]) : message["in"];
                 if (message.is != null && message.hasOwnProperty("is"))

--- a/src/core/state/validators/StateValidationSchema.js
+++ b/src/core/state/validators/StateValidationSchema.js
@@ -35,6 +35,7 @@ class StateValidationSchema {
     #validateBalanceInitializationSchema;
     #validateSetEpochOperationSchema;
     #validateSetGenesisEpochOperationSchema;
+    #validateSetVdfParamsOperationSchema;
     #proofDataFields;
     #config;
 
@@ -272,6 +273,7 @@ class StateValidationSchema {
         this.#validateBalanceInitializationSchema = this.#compileBalanceInitializationSchema();
         this.#validateSetEpochOperationSchema = this.#compileSetEpochOperationSchema();
         this.#validateSetGenesisEpochOperationSchema = this.#compileSetGenesisEpochOperationSchema();
+        this.#validateSetVdfParamsOperationSchema = this.#compileSetVdfParamsOperationSchema();
 
     }
 
@@ -666,6 +668,31 @@ class StateValidationSchema {
 
     validateSetGenesisEpochOperation(op) {
         return this.#validateSetGenesisEpochOperationSchema(op) === true;
+    }
+
+    #compileSetVdfParamsOperationSchema() {
+        const schema = {
+            $$strict: true,
+            type: this.#operationTypeDomain(OperationType.SET_VDF_PARAMS),
+            address: {type: 'buffer', length: this.#config.addressLength, required: true},
+            vpo: {
+                strict: true,
+                type: 'object',
+                props: {
+                    tx: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true},
+                    txv: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true},
+                    df: {type: 'buffer', length: VDF_DIFFICULTY_SIZE, required: true},
+                    db: {type: 'buffer', length: VDF_DISCRIMINANT_SIZE, required: true},
+                    in: {type: 'buffer', length: NONCE_BYTE_LENGTH, required: true},
+                    is: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true},
+                }
+            }
+        };
+        return this.#validator.compile(schema);
+    }
+
+    validateSetVdfParamsOperation(op) {
+        return this.#validateSetVdfParamsOperationSchema(op) === true;
     }
 }
 

--- a/src/core/state/validators/StateValidationSchema.js
+++ b/src/core/state/validators/StateValidationSchema.js
@@ -682,7 +682,6 @@ class StateValidationSchema {
                     tx: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true},
                     txv: {type: 'buffer', length: HASH_BYTE_LENGTH, required: true},
                     df: {type: 'buffer', length: VDF_DIFFICULTY_SIZE, required: true},
-                    db: {type: 'buffer', length: VDF_DISCRIMINANT_SIZE, required: true},
                     in: {type: 'buffer', length: NONCE_BYTE_LENGTH, required: true},
                     is: {type: 'buffer', length: SIGNATURE_BYTE_LENGTH, required: true},
                 }

--- a/src/messages/state/ApplyStateMessageBuilder.js
+++ b/src/messages/state/ApplyStateMessageBuilder.js
@@ -584,14 +584,12 @@ class ApplyStateMessageBuilder {
             case OperationType.SET_VDF_PARAMS:
                 this.#requireFields([
                     [this.#txValidity, 'Transaction validity'],
-                    [this.#vdfDifficulty, 'Difficulty'],
-                    [this.#vdfDiscriminantSize, 'Discriminant size']
+                    [this.#vdfDifficulty, 'Difficulty']
                 ]);
                 msg = createMessage(
                     this.#config.networkId,
                     this.#txValidity,
                     this.#vdfDifficulty,
-                    this.#vdfDiscriminantSize,
                     nonce,
                     this.#operationType
                 );
@@ -700,7 +698,6 @@ class ApplyStateMessageBuilder {
                 tx,
                 txv: this.#txValidity,
                 df: this.#vdfDifficulty,
-                db: this.#vdfDiscriminantSize,
                 in: nonce,
                 is: signature
             };

--- a/src/messages/state/ApplyStateMessageDirector.js
+++ b/src/messages/state/ApplyStateMessageDirector.js
@@ -559,10 +559,9 @@ class ApplyStateMessageDirector {
      * @param {string|Buffer} invokerAddress
      * @param {string|Buffer} txValidity
      * @param {string|Buffer} vdfDifficulty
-     * @param {string|Buffer} vdfDiscriminantSize
      * @returns {Promise<object>}
      */
-    async buildCompleteSetVdfParamsMessage(invokerAddress, txValidity, vdfDifficulty, vdfDiscriminantSize) {
+    async buildCompleteSetVdfParamsMessage(invokerAddress, txValidity, vdfDifficulty) {
         if (!this.#builder) throw new Error('Builder has not been set.');
         await this.#builder
             .setPhase('complete')
@@ -571,7 +570,6 @@ class ApplyStateMessageDirector {
             .setAddress(invokerAddress)
             .setTxValidity(txValidity)
             .setVdfDifficulty(vdfDifficulty)
-            .setVdfDiscriminantSize(vdfDiscriminantSize)
             .build();
         return this.#builder.getPayload();
     }

--- a/tests/fixtures/check.fixtures.js
+++ b/tests/fixtures/check.fixtures.js
@@ -449,6 +449,32 @@ export const SGO = {
     }
 }
 
+export const VPO = {
+    valid_set_vdf_params_operation: {
+        type: OperationType.SET_VDF_PARAMS,
+        address: addressToBuffer(asAddress('3801ebd1f12462ad335b821807c9d87e4f20d57505222284b2634a7e8e5edac2'), config.addressPrefix),
+        vpo: {
+            tx: b4a.from('1bd4f96adeffba9c04943a82993c5b19660c3a5f572620d82a67464f381640e2', 'hex'),
+            txv: b4a.from('f24e61cf7941256b080be2133bccb520414c78021215edfcb781622da526c414', 'hex'),
+            df: b4a.from('000f4240', 'hex'),
+            db: b4a.from('0800', 'hex'),
+            in: b4a.from('0ad7fe36a35a27ea4df932b800200823a97d4db31bca247f43ad7523b0493645', 'hex'),
+            is: b4a.from('5b534be7a374148962c271d194c26cf5b1ad705ab218a87709a33fe74f9d1b811772447c939b17b2f803e3da7648f49b666b929fbb20e458ced952f147162c08', 'hex')
+        }
+    },
+
+    top_fields_set_vdf_params: ['type', 'address', 'vpo'],
+    set_vdf_params_value_fields: ['tx', 'txv', 'df', 'db', 'in', 'is'],
+    required_length_of_fields_for_set_vdf_params: {
+        tx: HASH_BYTE_LENGTH,
+        txv: HASH_BYTE_LENGTH,
+        df: VDF_DIFFICULTY_SIZE,
+        db: VDF_DISCRIMINANT_SIZE,
+        in: NONCE_BYTE_LENGTH,
+        is: SIGNATURE_BYTE_LENGTH
+    }
+}
+
 export const partial_operation_value_type = ['bdo', 'tto', 'txo', 'rao']
 
 export const not_allowed_data_types = [

--- a/tests/fixtures/check.fixtures.js
+++ b/tests/fixtures/check.fixtures.js
@@ -457,19 +457,17 @@ export const VPO = {
             tx: b4a.from('1bd4f96adeffba9c04943a82993c5b19660c3a5f572620d82a67464f381640e2', 'hex'),
             txv: b4a.from('f24e61cf7941256b080be2133bccb520414c78021215edfcb781622da526c414', 'hex'),
             df: b4a.from('000f4240', 'hex'),
-            db: b4a.from('0800', 'hex'),
             in: b4a.from('0ad7fe36a35a27ea4df932b800200823a97d4db31bca247f43ad7523b0493645', 'hex'),
             is: b4a.from('5b534be7a374148962c271d194c26cf5b1ad705ab218a87709a33fe74f9d1b811772447c939b17b2f803e3da7648f49b666b929fbb20e458ced952f147162c08', 'hex')
         }
     },
 
     top_fields_set_vdf_params: ['type', 'address', 'vpo'],
-    set_vdf_params_value_fields: ['tx', 'txv', 'df', 'db', 'in', 'is'],
+    set_vdf_params_value_fields: ['tx', 'txv', 'df', 'in', 'is'],
     required_length_of_fields_for_set_vdf_params: {
         tx: HASH_BYTE_LENGTH,
         txv: HASH_BYTE_LENGTH,
         df: VDF_DIFFICULTY_SIZE,
-        db: VDF_DISCRIMINANT_SIZE,
         in: NONCE_BYTE_LENGTH,
         is: SIGNATURE_BYTE_LENGTH
     }

--- a/tests/unit/messages/state/applyStateMessageBuilder.complete.test.js
+++ b/tests/unit/messages/state/applyStateMessageBuilder.complete.test.js
@@ -667,7 +667,6 @@ test('ApplyStateMessageBuilder complete set VDF params operation (vpo)', async t
     const wallet = await createWallet(testKeyPair1.mnemonic);
     const txValidity = toBuf(hex('77', 32));
     const vdfDifficulty = toBuf(hex('88', VDF_DIFFICULTY_SIZE));
-    const vdfDiscriminantSize = toBuf(hex('99', VDF_DISCRIMINANT_SIZE));
 
     const builder = new ApplyStateMessageBuilder(wallet, config);
     await builder
@@ -677,7 +676,6 @@ test('ApplyStateMessageBuilder complete set VDF params operation (vpo)', async t
         .setAddress(wallet.address)
         .setTxValidity(txValidity)
         .setVdfDifficulty(vdfDifficulty)
-        .setVdfDiscriminantSize(vdfDiscriminantSize)
         .build();
 
     const payload = builder.getPayload();
@@ -685,23 +683,20 @@ test('ApplyStateMessageBuilder complete set VDF params operation (vpo)', async t
     expectAddressBuffer(t, payload.address, 'address');
     t.ok(b4a.equals(payload.address, addressToBuffer(wallet.address, config.addressPrefix)));
     expectPayloadKeys(t, payload, 'vpo');
-    expectKeys(t, payload.vpo, ['tx', 'txv', 'df', 'db', 'in', 'is'], 'vpo');
+    expectKeys(t, payload.vpo, ['tx', 'txv', 'df', 'in', 'is'], 'vpo');
     expectBufferField(t, payload.vpo.tx, 32, 'vpo.tx');
     expectBufferField(t, payload.vpo.txv, 32, 'vpo.txv');
     expectBufferField(t, payload.vpo.df, VDF_DIFFICULTY_SIZE, 'vpo.df');
-    expectBufferField(t, payload.vpo.db, VDF_DISCRIMINANT_SIZE, 'vpo.db');
     expectBufferField(t, payload.vpo.in, 32, 'vpo.in');
     expectBufferField(t, payload.vpo.is, 64, 'vpo.is');
     t.ok(b4a.equals(payload.vpo.txv, txValidity));
     t.ok(b4a.equals(payload.vpo.df, vdfDifficulty));
-    t.ok(b4a.equals(payload.vpo.db, vdfDiscriminantSize));
 });
 
 test('ApplyStateMessageBuilder complete set VDF params operation codec roundtrip', async t => {
     const wallet = await createWallet(testKeyPair1.mnemonic);
     const txValidity = toBuf(hex('aa', 32));
     const vdfDifficulty = toBuf(hex('bb', VDF_DIFFICULTY_SIZE));
-    const vdfDiscriminantSize = toBuf(hex('cc', VDF_DISCRIMINANT_SIZE));
 
     const builder = new ApplyStateMessageBuilder(wallet, config);
     await builder
@@ -711,7 +706,6 @@ test('ApplyStateMessageBuilder complete set VDF params operation codec roundtrip
         .setAddress(wallet.address)
         .setTxValidity(txValidity)
         .setVdfDifficulty(vdfDifficulty)
-        .setVdfDiscriminantSize(vdfDiscriminantSize)
         .build();
 
     const payload = builder.getPayload();
@@ -723,11 +717,10 @@ test('ApplyStateMessageBuilder complete set VDF params operation codec roundtrip
     t.is(decoded.type, OperationType.SET_VDF_PARAMS);
     t.ok(b4a.equals(decoded.address, addressToBuffer(wallet.address, config.addressPrefix)));
     t.alike(Object.keys(decoded).sort(), ['address', 'type', 'vpo']);
-    t.alike(Object.keys(decoded.vpo).sort(), ['db', 'df', 'in', 'is', 'tx', 'txv']);
+    t.alike(Object.keys(decoded.vpo).sort(), ['df', 'in', 'is', 'tx', 'txv']);
     t.ok(b4a.equals(decoded.vpo.tx, payload.vpo.tx));
     t.ok(b4a.equals(decoded.vpo.txv, txValidity));
     t.ok(b4a.equals(decoded.vpo.df, vdfDifficulty));
-    t.ok(b4a.equals(decoded.vpo.db, vdfDiscriminantSize));
     t.ok(b4a.equals(decoded.vpo.in, payload.vpo.in));
     t.ok(b4a.equals(decoded.vpo.is, payload.vpo.is));
 });

--- a/tests/unit/messages/state/applyStateMessageDirector.test.js
+++ b/tests/unit/messages/state/applyStateMessageDirector.test.js
@@ -72,25 +72,21 @@ test('ApplyStateMessageDirector builds complete set VDF params message', async t
     const wallet = await createWallet(testKeyPair1.mnemonic);
     const txValidity = b4a.from('44'.repeat(32), 'hex');
     const vdfDifficulty = b4a.from('55'.repeat(VDF_DIFFICULTY_SIZE), 'hex');
-    const vdfDiscriminantSize = b4a.from('66'.repeat(VDF_DISCRIMINANT_SIZE), 'hex');
 
     const payload = await applyStateMessageFactory(wallet, config)
         .buildCompleteSetVdfParamsMessage(
             wallet.address,
             txValidity,
-            vdfDifficulty,
-            vdfDiscriminantSize
+            vdfDifficulty
         );
 
     t.is(payload.type, OperationType.SET_VDF_PARAMS);
     t.ok(b4a.equals(payload.address, addressToBuffer(wallet.address, config.addressPrefix)));
     t.alike(Object.keys(payload).sort(), ['address', 'type', 'vpo']);
-    t.alike(Object.keys(payload.vpo).sort(), ['db', 'df', 'in', 'is', 'tx', 'txv']);
+    t.alike(Object.keys(payload.vpo).sort(), ['df', 'in', 'is', 'tx', 'txv']);
     t.ok(b4a.equals(payload.vpo.txv, txValidity));
     t.ok(b4a.equals(payload.vpo.df, vdfDifficulty));
-    t.ok(b4a.equals(payload.vpo.db, vdfDiscriminantSize));
     t.is(payload.vpo.df.length, VDF_DIFFICULTY_SIZE);
-    t.is(payload.vpo.db.length, VDF_DISCRIMINANT_SIZE);
     t.is(payload.vpo.tx.length, 32);
     t.is(payload.vpo.in.length, 32);
     t.is(payload.vpo.is.length, 64);

--- a/tests/unit/utils/check/check.test.js
+++ b/tests/unit/utils/check/check.test.js
@@ -17,4 +17,4 @@ async function runCheckTests() {
     test.resume();
 }
 
-runCheckTests();
+await runCheckTests();

--- a/tests/unit/utils/check/check.test.js
+++ b/tests/unit/utils/check/check.test.js
@@ -12,6 +12,7 @@ async function runCheckTests() {
     await import('./balanceInitializationOperation.test.js')
     await import('./setEpochOperation.test.js')
     await import('./setGenesisEpochOperation.test.js')
+    await import('./setVdfParamsOperation.test.js')
 
     test.resume();
 }

--- a/tests/unit/utils/check/setVdfParamsOperation.test.js
+++ b/tests/unit/utils/check/setVdfParamsOperation.test.js
@@ -1,0 +1,55 @@
+import test from 'brittle';
+
+import StateValidationSchema from '../../../../src/core/state/validators/StateValidationSchema.js';
+import { VPO, not_allowed_data_types } from '../../../fixtures/check.fixtures.js';
+import { topLevelValidationTests, valueLevelValidationTest, addressBufferLengthTest, fieldsBufferLengthTest } from './common.test.js';
+import { config } from '../../../helpers/config.js';
+
+const stateValidationSchema = new StateValidationSchema(config);
+
+test('validateSetVdfParamsOperation - happy path', t => {
+    t.ok(
+        stateValidationSchema.validateSetVdfParamsOperation(VPO.valid_set_vdf_params_operation),
+        'Valid data for set VDF params operation should pass the validation'
+    );
+});
+
+test('validateSetVdfParamsOperation - type level validation (vpo)', t => {
+    topLevelValidationTests(
+        t,
+        stateValidationSchema.validateSetVdfParamsOperation.bind(stateValidationSchema),
+        VPO.valid_set_vdf_params_operation,
+        'vpo',
+        not_allowed_data_types,
+        VPO.top_fields_set_vdf_params
+    );
+});
+
+test('validateSetVdfParamsOperation - value level validation (vpo)', t => {
+    valueLevelValidationTest(
+        t,
+        stateValidationSchema.validateSetVdfParamsOperation.bind(stateValidationSchema),
+        VPO.valid_set_vdf_params_operation,
+        'vpo',
+        VPO.set_vdf_params_value_fields,
+        not_allowed_data_types
+    );
+});
+
+test('validateSetVdfParamsOperation - address buffer length validation - TOP LEVEL', t => {
+    addressBufferLengthTest(
+        t,
+        stateValidationSchema.validateSetVdfParamsOperation.bind(stateValidationSchema),
+        VPO.valid_set_vdf_params_operation,
+    );
+});
+
+test('validateSetVdfParamsOperation - fields buffer length validation - VALUE LEVEL (vpo)', t => {
+    fieldsBufferLengthTest(
+        t,
+        stateValidationSchema.validateSetVdfParamsOperation.bind(stateValidationSchema),
+        VPO.valid_set_vdf_params_operation,
+        'vpo',
+        VPO.required_length_of_fields_for_set_vdf_params
+    );
+});


### PR DESCRIPTION
Implemented schema validation for the SET_VDF_PARAMS apply operation.

This adds validation for the vpo payload, enforcing the expected field structure and byte sizes for tx, txv, df, db, in, and is. 

It also adds fixtures and unit tests covering happy path, strict schema behavior, required fields, invalid types, address length, and field buffer lengths.

NOTE: Due to the latest development, we figured that setting the discriminant is a destructive operation to perform outside of a hard-fork so that field is completely omitted in the proto, builder and schema validation with this PR.

