### PR TITLE
refactor: 274 refactor init to reuse encode logicor opposite in nodeentryjs

### DIFF
--- a/src/core/state/utils/nodeEntry.js
+++ b/src/core/state/utils/nodeEntry.js
@@ -9,9 +9,9 @@ export const ZERO_BALANCE = b4a.alloc(BALANCE_BYTE_LENGTH);
 export const ZERO_LICENSE = b4a.alloc(LICENSE_BYTE_LENGTH);
 
 
-const isWhitelisted = role => [NodeRole.INDEXER, NodeRole.WHITELISTED, NodeRole.WRITER].includes(role);
-const isWriter = role => [NodeRole.INDEXER, NodeRole.WRITER].includes(role);
-const isIndexer = role => [NodeRole.INDEXER].includes(role);
+const roleIsWhitelisted = role => [NodeRole.INDEXER, NodeRole.WHITELISTED, NodeRole.WRITER].includes(role);
+const roleIsWriter = role => [NodeRole.INDEXER, NodeRole.WRITER].includes(role);
+const roleIsIndexer = role => [NodeRole.INDEXER].includes(role);
 
 /**
  * Initializes a new node entry with given writing key and role and the balance is set to zero.
@@ -26,7 +26,12 @@ const isIndexer = role => [NodeRole.INDEXER].includes(role);
  */
 
 export function init(wk, role, balance = ZERO_BALANCE, license = ZERO_LICENSE, stakedBalance = ZERO_BALANCE) {
-    const node = { wk, isWhitelisted: isWhitelisted(role), isWriter: isWriter(role), isIndexer: isIndexer(role), balance, license, stakedBalance };
+    if (!isNodeRoleValid(role)) {
+        console.error('Invalid node role provided');
+        return b4a.alloc(0);
+    }
+    
+    const node = { wk, isWhitelisted: roleIsWhitelisted(role), isWriter: roleIsWriter(role), isIndexer: roleIsIndexer(role), balance, license, stakedBalance };
     return encode(node);
 }
 

--- a/src/core/state/utils/nodeEntry.js
+++ b/src/core/state/utils/nodeEntry.js
@@ -1,6 +1,6 @@
 import b4a from 'b4a';
 
-import { WRITER_MASK, INDEXER_MASK, WHITELISTED_MASK, calculateNodeRole, isNodeRoleValid } from './roles.js';
+import { WRITER_MASK, INDEXER_MASK, WHITELISTED_MASK, calculateNodeRole, isNodeRoleValid, NodeRole } from './roles.js';
 import { WRITER_BYTE_LENGTH, BALANCE_BYTE_LENGTH, LICENSE_BYTE_LENGTH } from '../../../utils/constants.js';
 import { isBufferValid } from '../../../utils/buffer.js';
 
@@ -8,6 +8,10 @@ export const NODE_ENTRY_SIZE = LICENSE_BYTE_LENGTH + WRITER_BYTE_LENGTH + 2 * BA
 export const ZERO_BALANCE = b4a.alloc(BALANCE_BYTE_LENGTH);
 export const ZERO_LICENSE = b4a.alloc(LICENSE_BYTE_LENGTH);
 
+
+const isWhitelisted = role => [NodeRole.INDEXER, NodeRole.WHITELISTED, NodeRole.WRITER].includes(role);
+const isWriter = role => [NodeRole.INDEXER, NodeRole.WRITER].includes(role);
+const isIndexer = role => [NodeRole.INDEXER].includes(role);
 
 /**
  * Initializes a new node entry with given writing key and role and the balance is set to zero.
@@ -20,37 +24,10 @@ export const ZERO_LICENSE = b4a.alloc(LICENSE_BYTE_LENGTH);
  * @param {Buffer} stakedBalance - Initial staked balance from node (must be 16 bytes)
  * @returns {Buffer} The initialized node entry buffer, or empty buffer if invalid input
  */
-export function init(writingKey, role, balance = ZERO_BALANCE, license = ZERO_LICENSE, stakedBalance = ZERO_BALANCE) {
-    if (!isBufferValid(writingKey, WRITER_BYTE_LENGTH) ||
-        !isBufferValid(balance, BALANCE_BYTE_LENGTH) ||
-        !isNodeRoleValid(role) ||
-        !isBufferValid(license, LICENSE_BYTE_LENGTH) ||
-        !isBufferValid(stakedBalance, BALANCE_BYTE_LENGTH)) {
-        console.error('Invalid input for node initialization');
-        return b4a.alloc(0);
-    }
 
-    try {
-        const nodeEntry = b4a.alloc(NODE_ENTRY_SIZE);
-        nodeEntry[0] = role;
-        let offset = 1;
-
-        b4a.copy(writingKey, nodeEntry, offset);
-        offset += WRITER_BYTE_LENGTH;
-
-        b4a.copy(balance, nodeEntry, offset);
-        offset += BALANCE_BYTE_LENGTH;
-
-        b4a.copy(license, nodeEntry, offset);
-        offset += LICENSE_BYTE_LENGTH;
-
-        b4a.copy(stakedBalance, nodeEntry, offset);
-
-        return nodeEntry;
-    } catch (error) {
-        console.error('Error initializing node entry:', error);
-        return b4a.alloc(0);
-    }
+export function init(wk, role, balance = ZERO_BALANCE, license = ZERO_LICENSE, stakedBalance = ZERO_BALANCE) {
+    const node = { wk, isWhitelisted: isWhitelisted(role), isWriter: isWriter(role), isIndexer: isIndexer(role), balance, license, stakedBalance };
+    return encode(node);
 }
 
 /**

--- a/src/core/state/utils/nodeEntry.js
+++ b/src/core/state/utils/nodeEntry.js
@@ -17,8 +17,8 @@ const roleIsIndexer = role => [NodeRole.INDEXER].includes(role);
  * Initializes a new node entry with given writing key and role and the balance is set to zero.
  * Creates a buffer in format: [NODE_ROLE_MASK(1)][WRITING_KEY(32)][BALANCE(16)][LICENSE(4)][STAKED_BALANCE(16)]
  *
- * @param {Buffer} writingKey - The writing key for the node (must be 32 bytes)
- * @param {number} role - Initial role from NodeRole enum 
+ * @param {Buffer} wk - The writing key for the node (must be 32 bytes)
+ * @param {number} role - Initial role from NodeRole enum
  * @param {Buffer} balance - Initial balance from node (must be 16 bytes)
  * @param {Buffer} license - Initial license from node (must be 4 bytes)
  * @param {Buffer} stakedBalance - Initial staked balance from node (must be 16 bytes)
@@ -29,8 +29,7 @@ export function init(wk, role, balance = ZERO_BALANCE, license = ZERO_LICENSE, s
     if (!isNodeRoleValid(role)) {
         console.error('Invalid node role provided');
         return b4a.alloc(0);
-    }
-    
+    }    
     const node = { wk, isWhitelisted: roleIsWhitelisted(role), isWriter: roleIsWriter(role), isIndexer: roleIsIndexer(role), balance, license, stakedBalance };
     return encode(node);
 }
@@ -178,15 +177,12 @@ export function isIndexer(nodeEntry) {
 }
 
 /**
- * Updates the role flags (writer/indexer) of an existing node entry buffer in-place.
- * Does not decode or reallocate memory; only updates the first byte (role mask).
- * If the buffer is not the expected size, the function does nothing.
+ * Sets the role mask of an existing node entry buffer, returning a new buffer.
+ * Does not decode the rest of the entry; only the first byte (role mask) changes.
  *
  * @param {Buffer} nodeEntry - The encoded node entry buffer to update.
- * @param {boolean} isWhitelisted - Whether the node should be marked as whitelisted.
- * @param {boolean} isWriter - Whether the node should be marked as a writer.
- * @param {boolean} isIndexer - Whether the node should be marked as an indexer.
- * @returns {Buffer | null} The updated node entry buffer or null if the input is invalid.
+ * @param {number} nodeRole - The new role bitmask (from NodeRole enum).
+ * @returns {Buffer | null} A new node entry buffer with the updated role, or null if the input is invalid.
  */
 export function setRole(nodeEntry, nodeRole) {
     if (!isNodeRoleValid(nodeRole)) {
@@ -244,7 +240,8 @@ export function setBalance(nodeEntry, balance) {
     }
 }
 
-/** Sets the license ID.
+/**
+ * Sets the license ID.
  * @param {Buffer} nodeEntry - The node entry buffer.
  * @param {Buffer} license - The buffer representation of the license ID
  * @returns {Buffer|null} The updated node entry buffer, or null if invalid.

--- a/tests/unit/state/utils/nodeEntry.test.js
+++ b/tests/unit/state/utils/nodeEntry.test.js
@@ -121,6 +121,38 @@ test('Node Entry - init - returns empty buffer on invalid role', t => {
     t.is(initialized.length, 0, 'invalid role produces empty buffer');
 });
 
+test('Node Entry - init - returns empty buffer on invalid wk', t => {
+    const invalidWk = randomBuffer(10) // invalid size
+    const initialized = initNodeEntry(invalidWk, NodeRole.WHITELISTED)
+
+    t.is(initialized.length, 0, 'invalid wk produces empty buffer');
+});
+
+test('Node Entry - init - returns empty buffer on invalid balance', t => {
+    const wk = randomBuffer(WRITER_BYTE_LENGTH)
+    const invalidBalance = randomBuffer(10) // invalid size
+    const initialized = initNodeEntry(wk, NodeRole.WHITELISTED, invalidBalance)
+
+    t.is(initialized.length, 0, 'invalid balance produces empty buffer');
+});
+
+test('Node Entry - init - returns empty buffer on invalid license', t => {
+    const wk = randomBuffer(WRITER_BYTE_LENGTH)
+    const invalidLicense = randomBuffer(10) // invalid size
+    const initialized = initNodeEntry(wk, NodeRole.WHITELISTED, TEN_THOUSAND_VALUE, invalidLicense)
+
+    t.is(initialized.length, 0, 'invalid license produces empty buffer');
+});
+
+test('Node Entry - init - returns empty buffer on invalid staked balance', t => {
+    const wk = randomBuffer(WRITER_BYTE_LENGTH)
+    const license = randomBuffer(LICENSE_BYTE_LENGTH)
+    const invalidStakedBalance = randomBuffer(10) // invalid size
+    const initialized = initNodeEntry(wk, NodeRole.WHITELISTED, TEN_THOUSAND_VALUE, license, invalidStakedBalance)
+
+    t.is(initialized.length, 0, 'invalid staked balance produces empty buffer');
+});
+
 // Test encode()
 test('Node Entry - encode and decode - Happy Path', t => {
     const node = {

--- a/tests/unit/state/utils/nodeEntry.test.js
+++ b/tests/unit/state/utils/nodeEntry.test.js
@@ -81,6 +81,46 @@ test('Node Entry - init - Happy Path with staked balance', t => {
 
 });
 
+test('Node Entry - init - READER role sets no role flags', t => {
+    const wk = randomBuffer(WRITER_BYTE_LENGTH)
+    const initialized = initNodeEntry(wk, NodeRole.READER)
+
+    const decoded = decodeNodeEntry(initialized);
+    t.ok(decoded, 'decoded should not be null');
+    t.is(decoded.isWhitelisted, false, 'isWhitelisted matches');
+    t.is(decoded.isWriter, false, 'isWriter matches');
+    t.is(decoded.isIndexer, false, 'isIndexer matches');
+});
+
+test('Node Entry - init - WRITER role sets isWhitelisted and isWriter only', t => {
+    const wk = randomBuffer(WRITER_BYTE_LENGTH)
+    const initialized = initNodeEntry(wk, NodeRole.WRITER)
+
+    const decoded = decodeNodeEntry(initialized);
+    t.ok(decoded, 'decoded should not be null');
+    t.is(decoded.isWhitelisted, true, 'isWhitelisted matches');
+    t.is(decoded.isWriter, true, 'isWriter matches');
+    t.is(decoded.isIndexer, false, 'isIndexer matches');
+});
+
+test('Node Entry - init - INDEXER role sets all role flags', t => {
+    const wk = randomBuffer(WRITER_BYTE_LENGTH)
+    const initialized = initNodeEntry(wk, NodeRole.INDEXER)
+
+    const decoded = decodeNodeEntry(initialized);
+    t.ok(decoded, 'decoded should not be null');
+    t.is(decoded.isWhitelisted, true, 'isWhitelisted matches');
+    t.is(decoded.isWriter, true, 'isWriter matches');
+    t.is(decoded.isIndexer, true, 'isIndexer matches');
+});
+
+test('Node Entry - init - returns empty buffer on invalid role', t => {
+    const wk = randomBuffer(WRITER_BYTE_LENGTH)
+    const initialized = initNodeEntry(wk, 0x2) // not a valid NodeRole value
+
+    t.is(initialized.length, 0, 'invalid role produces empty buffer');
+});
+
 // Test encode()
 test('Node Entry - encode and decode - Happy Path', t => {
     const node = {


### PR DESCRIPTION
 init() now delegates to encode() (removing the duplicated buffer-building logic), and re-validates the raw role via isNodeRoleValid before mapping it to isWhitelisted/isWriter/isIndexer flags.