### PR TITLE
feat: added command and handler for set vdf params

### DIFF
--- a/cli/commandHandler.js
+++ b/cli/commandHandler.js
@@ -38,7 +38,8 @@ export const COMMANDS = {
     GET_TXS_HASHES: "/get_txs_hashes",
     GET_TX_DETAILS: "/get_tx_details",
     GET_EXTENDED_TX_DETAILS: "/get_extended_tx_details",
-    EPOCH_GENESIS_INITIALIZATION: "/init_genesis"
+    EPOCH_GENESIS_INITIALIZATION: "/init_genesis",
+    SET_VDF_PARAMS: "/set_vdf_params"
 };
 
 export class CommandHandler {
@@ -48,6 +49,7 @@ export class CommandHandler {
     #handlers;
     #pendingConfirmation = null;
     #pendingGenesisInitialization = null;
+    #pendingSetVdfParams = null;
 
     constructor({ config, msb, handleClose, wallet }) {
         this.#msb = msb;
@@ -63,6 +65,10 @@ export class CommandHandler {
 
         if (this.#pendingGenesisInitialization !== null) {
             return this.#handlePendingGenesisInitialization(input);
+        }
+
+        if (this.#pendingSetVdfParams !== null) {
+            return this.#handlePendingSetVdfParams(input);
         }
 
         const [command, ...parts] = input.split(" ");
@@ -230,6 +236,10 @@ export class CommandHandler {
             {
                 evaluate: ({ input }) => input.startsWith(COMMANDS.EPOCH_GENESIS_INITIALIZATION),
                 process: async () => this.#queueEpochGenesisInitialization()
+            },
+            {
+                evaluate: ({ input }) => input.startsWith(COMMANDS.SET_VDF_PARAMS),
+                process: async () => this.#queueSetVdfParams()
             }
         ];
     }
@@ -349,6 +359,49 @@ export class CommandHandler {
     }
 
     #parseGenesisEpochInteger(input) {
+        return this.#parsePositiveInteger(input);
+    }
+
+    #queueSetVdfParams() {
+        this.#pendingSetVdfParams = {
+            step: "difficulty"
+        };
+
+        console.log(this.#getSetVdfParamsDifficultyPrompt());
+    }
+
+    #handlePendingSetVdfParams(input) {
+        const difficulty = this.#parsePositiveInteger(input);
+        if (!difficulty) {
+            console.log("Invalid difficulty. Please enter a positive integer (example 55_000_000).");
+            console.log(this.#getSetVdfParamsDifficultyPrompt());
+            return;
+        }
+
+        this.#pendingSetVdfParams = null;
+        return this.#queueSetVdfParamsConfirmation({ difficulty });
+    }
+
+    #queueSetVdfParamsConfirmation({ difficulty }) {
+        const params = {
+            vdfDifficulty: difficulty.value
+        };
+
+        console.info("VDF Params Update:");
+        console.info(`VDF difficulty: ${difficulty.display}`);
+
+        this.#pendingConfirmation = {
+            prompt: "Do you want to proceed? (yes/no)",
+            invalidMessage: 'Invalid input. Please answer "yes" or "no".',
+            failureMessage: "VDF params update failed",
+            onConfirm: async () => this.#handlers.handleSetVdfParams(params),
+            onDecline: async () => console.log("VDF params update cancelled.")
+        };
+
+        console.log(this.#pendingConfirmation.prompt);
+    }
+
+    #parsePositiveInteger(input) {
         const display = input.trim();
         if (!/^[0-9]+(?:_[0-9]+)*$/.test(display)) {
             return null;
@@ -368,5 +421,9 @@ export class CommandHandler {
 
     #getGenesisDiscriminantBitSizePrompt() {
         return "Set VDF discriminant bit size (example 2048):";
+    }
+
+    #getSetVdfParamsDifficultyPrompt() {
+        return "Set new VDF difficulty (example 55_000_000):";
     }
 }

--- a/cli/handlers.js
+++ b/cli/handlers.js
@@ -211,4 +211,8 @@ export class Handlers {
     async handleEpochGenesisInitialization(params) {
         return this.#msb.handleEpochGenesisInitialization(params);
     }
+
+    async handleSetVdfParams(params) {
+        return this.#msb.handleSetVdfParams(params);
+    }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -292,6 +292,7 @@ export class MainSettlementBus extends ReadyResource {
             console.log("- /remove_indexer <address>: Change a role of the selected indexer node to default role. Charges a fee.");
             console.log("- /ban_writer <address>: Demote a whitelisted writer to default role and remove it from the whitelist. Charges a fee.");
             console.log("- /init_genesis: Initialize genesis epoch.");
+            console.log("- /set_vdf_params: Update VDF difficulty.");
         }
         console.log("Available commands:");
         console.log("- /add_writer: Add yourself as a validator to this MSB once whitelisted. Requires a fee + 10x the fee as a stake in $TNK.");
@@ -1107,6 +1108,46 @@ export class MainSettlementBus extends ReadyResource {
                 vdfDifficultyBuffer,
                 vdfDiscriminantSizeBuffer,
             )
+        const encodedPayload = encodeApplyOperation(payload);
+        await this.#state.append(encodedPayload);
+    }
+
+    async handleSetVdfParams(params) {
+        if (!this.#config.enableWallet) {
+            throw new Error("Can not set VDF params - wallet is not enabled.");
+        }
+
+        const adminEntry = await this.#state.getAdminEntry();
+
+        if (!adminEntry) {
+            throw new Error("Can not set VDF params - admin has not been initialized.");
+        }
+        if (!this.#wallet) {
+            throw new Error("Can not set VDF params - wallet is not initialized.");
+        }
+        if (!this.isAdmin(adminEntry)) {
+            throw new Error("Can not set VDF params - you are not the admin.");
+        }
+
+        const existingVDFParams = await this.#state.getSignedVDFParams();
+        if (!existingVDFParams) {
+            throw new Error("Can not set VDF params - VDF parameters have not been initialized.");
+        }
+
+        const difficultyNumber = Number(params.vdfDifficulty);
+        if (!Number.isInteger(difficultyNumber) || difficultyNumber <= 0) {
+            throw new Error("VDF difficulty must be a positive unsigned 32-bit integer.");
+        }
+
+        const vdfDifficultyBuffer = uint32ToBuffer(difficultyNumber, "VDF difficulty");
+
+        const txValidity = await this.#state.getIndexerSequenceState();
+        const payload = await applyStateMessageFactory(this.#wallet, this.#config)
+            .buildCompleteSetVdfParamsMessage(
+                this.#wallet.address,
+                txValidity,
+                vdfDifficultyBuffer,
+            );
         const encodedPayload = encodeApplyOperation(payload);
         await this.#state.append(encodedPayload);
     }

--- a/tests/unit/cli/commandHandler.test.js
+++ b/tests/unit/cli/commandHandler.test.js
@@ -20,6 +20,7 @@ function createSubject(overrides = {}) {
         prepareTransferOperation: sinon.stub().resolves(preparedTransfer),
         submitPreparedTransferOperation: sinon.stub().resolves("tx-hash"),
         handleEpochGenesisInitialization: sinon.stub().resolves("genesis-tx-hash"),
+        handleSetVdfParams: sinon.stub().resolves("set-vdf-params-tx-hash"),
         printHelp: sinon.stub(),
         close: sinon.stub(),
         ...overrides.msb
@@ -169,4 +170,46 @@ test("CommandHandler re-prompts invalid genesis epoch params and cancels on no",
 
     t.ok(console.log.calledWith("Genesis epoch initialization cancelled."));
     t.ok(msb.handleEpochGenesisInitialization.notCalled);
+});
+
+test("CommandHandler collects VDF params update before confirmation", async (t) => {
+    stubConsole(t);
+
+    const { handler, msb } = createSubject();
+
+    await handler.handle("/set_vdf_params");
+
+    t.ok(console.log.calledWith("Set new VDF difficulty (example 55_000_000):"));
+
+    await handler.handle("60_000_000");
+
+    t.ok(console.info.calledWith("VDF Params Update:"));
+    t.ok(console.info.calledWith("VDF difficulty: 60_000_000"));
+    t.ok(console.log.calledWith("Do you want to proceed? (yes/no)"));
+    t.ok(msb.handleSetVdfParams.notCalled);
+
+    await handler.handle("yes");
+
+    t.ok(msb.handleSetVdfParams.calledOnceWithExactly({
+        vdfDifficulty: "60000000"
+    }));
+});
+
+test("CommandHandler re-prompts invalid VDF params update and cancels on no", async (t) => {
+    stubConsole(t);
+
+    const { handler, msb } = createSubject();
+
+    await handler.handle("/set_vdf_params");
+    await handler.handle("abc");
+
+    t.ok(console.log.calledWith("Invalid difficulty. Please enter a positive integer (example 55_000_000)."));
+    t.ok(console.log.calledWith("Set new VDF difficulty (example 55_000_000):"));
+    t.ok(msb.handleSetVdfParams.notCalled);
+
+    await handler.handle("60_000_000");
+    await handler.handle("no");
+
+    t.ok(console.log.calledWith("VDF params update cancelled."));
+    t.ok(msb.handleSetVdfParams.notCalled);
 });

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -390,4 +390,168 @@ if (isBareRuntime) {
 
         await msb.close();
     });
+
+    test('MainSettlementBus appends set VDF params with encoded difficulty', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const txValidity = b4a.from('bb'.repeat(32), 'hex');
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
+        loaded.state.getSignedVDFParams.resolves({
+            vdfDifficulty: 55000000,
+            vdfDiscriminantSize: 2048,
+        });
+        loaded.state.getIndexerSequenceState.resolves(txValidity);
+
+        await msb.handleSetVdfParams({
+            vdfDifficulty: '60000000',
+        });
+
+        t.ok(loaded.state.getSignedVDFParams.calledOnce);
+        t.ok(loaded.state.getIndexerSequenceState.calledOnce);
+        t.ok(loaded.state.append.calledOnce);
+
+        const encodedPayload = loaded.state.append.firstCall.args[0];
+        const decoded = safeDecodeApplyOperation(encodedPayload);
+
+        t.is(decoded.type, OperationType.SET_VDF_PARAMS);
+        t.ok(b4a.equals(decoded.address, addressToBuffer(wallet.address, config.addressPrefix)));
+        t.ok(b4a.equals(decoded.vpo.txv, txValidity));
+        t.is(decoded.vpo.df.length, 4);
+        t.is(decoded.vpo.df.readUInt32BE(0), 60000000);
+        t.absent(decoded.vpo.db);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects set VDF params when wallet is disabled', async t => {
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig({ enableWallet: false });
+        const msb = new loaded.MainSettlementBus(config);
+
+        await t.exception(
+            () => msb.handleSetVdfParams({
+                vdfDifficulty: '60000000',
+            }),
+            errorMessageIncludes('wallet is not enabled')
+        );
+    });
+
+    test('MainSettlementBus rejects set VDF params when admin is missing', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves(null);
+
+        await t.exception(
+            () => msb.handleSetVdfParams({
+                vdfDifficulty: '60000000',
+            }),
+            errorMessageIncludes('admin has not been initialized')
+        );
+
+        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.append.notCalled);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects set VDF params for non-admin wallet', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state, {
+            address: 'different-admin-address',
+        }));
+
+        await t.exception(
+            () => msb.handleSetVdfParams({
+                vdfDifficulty: '60000000',
+            }),
+            errorMessageIncludes('you are not the admin')
+        );
+
+        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.append.notCalled);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects set VDF params before VDF params are initialized', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
+        loaded.state.getSignedVDFParams.resolves(null);
+
+        await t.exception(
+            () => msb.handleSetVdfParams({
+                vdfDifficulty: '60000000',
+            }),
+            errorMessageIncludes('VDF parameters have not been initialized')
+        );
+
+        t.ok(loaded.state.getIndexerSequenceState.notCalled);
+        t.ok(loaded.state.append.notCalled);
+
+        await msb.close();
+    });
+
+    test('MainSettlementBus rejects set VDF params when VDF difficulty is not positive', async t => {
+        const consoleLog = sinon.stub(console, 'log');
+        t.teardown(() => consoleLog.restore());
+
+        const loaded = await loadMainSettlementBus();
+        const config = buildGenesisConfig();
+        const wallet = await createWallet(config);
+        const msb = new loaded.MainSettlementBus(config, wallet);
+
+        await msb.ready();
+
+        loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
+        loaded.state.getSignedVDFParams.resolves({
+            vdfDifficulty: 55000000,
+            vdfDiscriminantSize: 2048,
+        });
+
+        await t.exception(
+            () => msb.handleSetVdfParams({
+                vdfDifficulty: '0',
+            }),
+            errorMessageIncludes('VDF difficulty must be a positive unsigned 32-bit integer.')
+        );
+
+        t.ok(loaded.state.getIndexerSequenceState.notCalled);
+        t.ok(loaded.state.append.notCalled);
+
+        await msb.close();
+    });
 }


### PR DESCRIPTION
Adds the admin-only /set_vdf_params CLI flow for updating VDF difficulty after genesis VDF params already exist.

The command collects a new difficulty, asks for confirmation, validates admin/wallet/state requirements, builds a SET_VDF_PARAMS operation, encodes it, and appends it to state. It intentionally updates only difficulty and leaves discriminant unchanged.

Command and handler along with their tests are implemented.