### PR TITLE
feat: implement missing checks in validation module for internal consensus messages

### DIFF
--- a/proto/consensus/v1/messages/proof_proposal.proto
+++ b/proto/consensus/v1/messages/proof_proposal.proto
@@ -8,9 +8,9 @@ message ProofProposal {
   bytes protocol_version = 1; // 0x01
   bytes network_id = 2;
   bytes epoch = 3; // epoch number (for what epoch the proof is for current_epoch + 1)
-  bytes previous_epoch_record_hash = 4; // this must be a blob of previous epoch operation - TODO we need agree for the spec of the serialization
+  bytes previous_epoch_record_hash = 4; // BLAKE3 hash of the encoded previous epoch record
   bytes proposer = 5; // TRAC address of the proposer
-  bytes vdf_parameters_hash = 6; // H(difficulty || iterations)
+  bytes vdf_parameters_hash = 6; // BLAKE3(uint32_be difficulty || uint16_be discriminant_bit_size)
   bytes vdf_proof = 7; // bytes blob  that is actually y || pi
   bytes signature = 8; // SIG(challenge_data + vdf_proof)
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -277,14 +277,6 @@ export class Config {
         return this.#config.validatorConnectionAttemptDelay
     }
 
-    get vdfDifficulty() {
-        return this.#config.vdfDifficulty
-    }
-
-    get vdfDiscriminantSizeBits() {
-        return this.#config.vdfDiscriminantSizeBits
-    }
-
     #isOverriden(prop) {
         return this.#options.hasOwnProperty(prop) && isDefined(this.#options[prop])
     }

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -63,8 +63,6 @@ const configData = {
         epochThreshold: 2, // Minimum number of validator confirmations required to append a new epoch
         storesDirectory: 'stores/',
         storeName: 'testnet',
-        vdfDifficulty: 1000000, // number of iterations
-        vdfDiscriminantSizeBits: 2048, // discriminant size
     },
     [ENV.MAINNET]: {
         debug: false,
@@ -119,8 +117,6 @@ const configData = {
         epochThreshold: 2, // Minimum number of validator confirmations required to append a new epoch
         storesDirectory: 'stores/',
         storeName: 'mainnet',
-        vdfDifficulty: 1000000, // number of iterations
-        vdfDiscriminantSizeBits: 2048, // discriminant size
     },
     [ENV.DEVELOPMENT]: {
         debug: false,
@@ -175,8 +171,6 @@ const configData = {
         epochThreshold: 2, // Minimum number of validator confirmations required to append a new epoch
         storesDirectory: 'stores/',
         storeName: 'development',
-        vdfDifficulty: 1000000, // number of iterations
-        vdfDiscriminantSizeBits: 2048, // discriminant size
     }
 }
 

--- a/src/core/consensus/v1/handlers/ConsesusEpochProofProposalOperationHandler.js
+++ b/src/core/consensus/v1/handlers/ConsesusEpochProofProposalOperationHandler.js
@@ -17,8 +17,8 @@ class ConsensusEpochProofProposalOperationHandler extends ConnectionOperationHan
         super(config)
         this.#state = state;
         this.#wallet = wallet;
-        this.#proofProposalRequestValidator = new V1EpochProofProposalRequest(config);
-        this.#proofProposalApprovalValidator = new V1EpochProofProposalApproval(config);
+        this.#proofProposalRequestValidator = new V1EpochProofProposalRequest(config, state);
+        this.#proofProposalApprovalValidator = new V1EpochProofProposalApproval(config, state);
     }
 
     /**

--- a/src/core/consensus/v1/validators/V1BaseConsensusOperation.js
+++ b/src/core/consensus/v1/validators/V1BaseConsensusOperation.js
@@ -52,14 +52,17 @@ class V1BaseConsensusOperation {
                 throw error;
             }
 
-            const reason = error instanceof Error
-                ? error.message
-                : typeof error === 'string' ? error : String(error);
+            let validationError = error;
+            if (!(validationError instanceof Error)) {
+                validationError = new TypeError('Validation threw a non-Error value.');
+                validationError.cause = error;
+            }
+
             const protocolError = new V1ConsensusProtocolError(
                 ConsensusResultCode.UNEXPECTED_ERROR,
-                reason
+                validationError.message
             );
-            protocolError.cause = error;
+            protocolError.cause = validationError;
             throw protocolError;
         }
     }

--- a/src/core/consensus/v1/validators/V1BaseConsensusOperation.js
+++ b/src/core/consensus/v1/validators/V1BaseConsensusOperation.js
@@ -39,6 +39,7 @@ class V1BaseConsensusOperation {
      * Expected protocol errors keep their result code and identity. Unexpected
      * errors from state, codecs, crypto APIs, or malformed runtime values are
      * exposed as a stable protocol error while remaining available as `cause`.
+     * Validation operations are expected to throw `Error` instances.
      *
      * @param {function(): (Promise<*>|*)} validation Validation operation to execute.
      * @returns {Promise<*>} Result returned by the validation operation.
@@ -52,17 +53,11 @@ class V1BaseConsensusOperation {
                 throw error;
             }
 
-            let validationError = error;
-            if (!(validationError instanceof Error)) {
-                validationError = new TypeError('Validation threw a non-Error value.');
-                validationError.cause = error;
-            }
-
             const protocolError = new V1ConsensusProtocolError(
                 ConsensusResultCode.UNEXPECTED_ERROR,
-                validationError.message
+                error.message
             );
-            protocolError.cause = validationError;
+            protocolError.cause = error;
             throw protocolError;
         }
     }

--- a/src/core/consensus/v1/validators/V1BaseConsensusOperation.js
+++ b/src/core/consensus/v1/validators/V1BaseConsensusOperation.js
@@ -13,17 +13,66 @@ import b4a from "b4a";
 
 class V1BaseConsensusOperation {
     #consensusValidationSchema;
-    #config;
+    _config;
+    _state;
     /**
-     * Creates the base consensus validator with schema validation support.
+     * Creates the base validator shared by consensus v1 operations.
+     *
+     * Initializes operation schemas and stores the shared dependencies used by
+     * address, signature, and state-backed validation.
+     *
+     * @param {Config} config Application configuration. The base validator uses
+     * `addressLength` for schemas and `addressPrefix` for address conversion.
+     * @param {State} state Ledger state. It must expose `isIndexerAddress(address)`
+     * for indexer membership validation.
+     * @throws {Error} When consensus schemas cannot be initialized from the configuration.
      */
-    constructor(config) {
+    constructor(config, state) {
         this.#consensusValidationSchema = new ConsensusValidationSchema(config);
-        this.#config = config;
+        this._config = config;
+        this._state = state;
     }
 
     /**
-     * Validates the consensus payload shape for its declared operation type.
+     * Runs a validator behind the consensus protocol error boundary.
+     *
+     * Expected protocol errors keep their result code and identity. Unexpected
+     * errors from state, codecs, crypto APIs, or malformed runtime values are
+     * exposed as a stable protocol error while remaining available as `cause`.
+     *
+     * @param {function(): (Promise<*>|*)} validation Validation operation to execute.
+     * @returns {Promise<*>} Result returned by the validation operation.
+     * @throws {V1ConsensusProtocolError} Re-throws protocol errors or wraps unexpected failures.
+     */
+    async validateAsProtocolError(validation) {
+        try {
+            return await validation();
+        } catch (error) {
+            if (error instanceof V1ConsensusProtocolError) {
+                throw error;
+            }
+
+            const reason = error instanceof Error
+                ? error.message
+                : typeof error === 'string' ? error : '';
+            const protocolError = new V1ConsensusProtocolError(
+                ConsensusResultCode.UNEXPECTED_ERROR,
+                reason
+            );
+            protocolError.cause = error;
+            throw protocolError;
+        }
+    }
+
+    /**
+     * Validates the payload against the schema selected by its operation type.
+     *
+     * Checks that the operation type is present, supported, and that all fields
+     * required by the corresponding request or approval schema are valid.
+     *
+     * @param {object} payload Decoded consensus operation payload.
+     * @returns {void}
+     * @throws {V1ConsensusProtocolError} When the type or payload schema is invalid.
      */
     isPayloadSchemaValid(payload) {
         if (_.isNil(payload?.type)) {
@@ -44,7 +93,13 @@ class V1BaseConsensusOperation {
     }
 
     /**
-     * Builds proof proposal challenge data from fields 1 through 6.
+     * Builds canonical VDF challenge data from proof proposal fields 1 through 6.
+     *
+     * The message contains protocol version, network id, epoch, previous epoch
+     * record hash, proposer address, and VDF parameters hash in protocol order.
+     *
+     * @param {object} proofProposal Decoded proof proposal.
+     * @returns {Buffer} Canonically encoded challenge data.
      */
     buildProofProposalChallengeData(proofProposal) {
         return createMessage(
@@ -59,6 +114,10 @@ class V1BaseConsensusOperation {
 
     /**
      * Selects the schema validator for the consensus operation type.
+     *
+     * @param {number} type Consensus operation type.
+     * @returns {function(object): boolean} Bound schema validation function.
+     * @throws {V1ConsensusProtocolError} When the operation type is not an integer or is unsupported.
      */
     #selectCheckSchemaValidator(type) {
         if (!Number.isInteger(type)) {
@@ -87,7 +146,16 @@ class V1BaseConsensusOperation {
     }
 
     /**
-     * Builds and verifies the operation signature against the remote public key.
+     * Verifies the operation signature against the remote peer public key.
+     *
+     * Builds the canonical request or approval signature message, hashes it with
+     * BLAKE3, and verifies the signature using the supplied public key.
+     *
+     * @param {object} payload Decoded proof proposal request or approval payload.
+     * @param {Buffer} remotePublicKey Public key received from the peer connection.
+     * @param {object} [proofProposal] Original proof proposal required for approval verification.
+     * @returns {Promise<void>}
+     * @throws {V1ConsensusProtocolError} When message construction, hashing, or signature verification fails.
      */
     async validateSignature(payload, remotePublicKey, proofProposal) {
         let signature;
@@ -139,6 +207,14 @@ class V1BaseConsensusOperation {
 
     /**
      * Builds the canonical signature message for the internal consensus operation.
+     *
+     * A proposal message covers the VDF challenge and proof. An approval message
+     * additionally covers the approver and the original proposal signature.
+     *
+     * @param {object} payload Decoded consensus operation payload.
+     * @param {object} [proofProposalContext] Original proposal used for an approval message.
+     * @returns {{signature: Buffer, message: Buffer}} Signature and canonical message to verify.
+     * @throws {V1ConsensusProtocolError} When the operation type is invalid or unsupported.
      */
     #buildSignatureMessage(payload, proofProposalContext) {
         if (!Number.isInteger(payload.type)) {
@@ -184,10 +260,18 @@ class V1BaseConsensusOperation {
     }
 
     /**
-     * Validates that the payload address resolves to the remote public key.
+     * Validates that a binary protocol address belongs to the connected peer.
+     *
+     * Converts the binary address to its configured textual representation,
+     * decodes its public key, and compares it with the remote connection key.
+     *
+     * @param {Buffer} binaryAddress Binary proposer or approver address from the payload.
+     * @param {Buffer} remotePublicKey Public key received from the peer connection.
+     * @returns {void}
+     * @throws {V1ConsensusProtocolError} When the address is invalid or belongs to another key.
      */
     assertAddressWithRemotePublicKey(binaryAddress, remotePublicKey) {
-        const address = bufferToAddress(binaryAddress, this.#config.addressPrefix);
+        const address = bufferToAddress(binaryAddress, this._config.addressPrefix);
         if (!address) {
             throw new V1ConsensusProtocolError(
                 ConsensusResultCode.UNEXPECTED_ERROR,
@@ -203,15 +287,29 @@ class V1BaseConsensusOperation {
         }
     }
 
-    validateAddressIsIndexer() {
-        // TODO: Placeholder - payload address should have the indexer role in state.
-        // Completion depends on genesis being initialized in the ledger. This is not implemented yet.
-        //
+    /**
+     * Validates that the connected peer is registered as an indexer in state.
+     *
+     * Encodes the remote public key as a configured network address and checks
+     * that address against the current indexer set.
+     *
+     * @param {Buffer} remotePublicKey Public key received from the peer connection.
+     * @returns {Promise<void>}
+     * @throws {V1ConsensusProtocolError} When the remote address is not an indexer.
+     */
+    async validateAddressIsIndexer(remotePublicKey) {
         // TODO: When we replace UNEXPECTED_ERROR with INVALID_ADDRESS_ASSERTION,
         // we should handle this specific error to not only drop the connection but also blacklist the specific node.
         // Such an error would mean that someone is trying to impersonate an indexer.
+        const address = tracCryptoApi.address.encode(this._config.addressPrefix, remotePublicKey);
+        const isIndexer  =  await this._state.isIndexerAddress(address);
+        if (!isIndexer) {
+            throw new V1ConsensusProtocolError(
+                ConsensusResultCode.UNEXPECTED_ERROR,
+                'Incoming address is not an indexer.'
+            )
+        }
     }
-
 }
 
 

--- a/src/core/consensus/v1/validators/V1BaseConsensusOperation.js
+++ b/src/core/consensus/v1/validators/V1BaseConsensusOperation.js
@@ -54,7 +54,7 @@ class V1BaseConsensusOperation {
 
             const reason = error instanceof Error
                 ? error.message
-                : typeof error === 'string' ? error : '';
+                : typeof error === 'string' ? error : String(error);
             const protocolError = new V1ConsensusProtocolError(
                 ConsensusResultCode.UNEXPECTED_ERROR,
                 reason

--- a/src/core/consensus/v1/validators/V1BaseConsensusOperation.js
+++ b/src/core/consensus/v1/validators/V1BaseConsensusOperation.js
@@ -302,7 +302,7 @@ class V1BaseConsensusOperation {
         // we should handle this specific error to not only drop the connection but also blacklist the specific node.
         // Such an error would mean that someone is trying to impersonate an indexer.
         const address = tracCryptoApi.address.encode(this._config.addressPrefix, remotePublicKey);
-        const isIndexer  =  await this._state.isIndexerAddress(address);
+        const isIndexer = await this._state.isIndexerAddress(address);
         if (!isIndexer) {
             throw new V1ConsensusProtocolError(
                 ConsensusResultCode.UNEXPECTED_ERROR,

--- a/src/core/consensus/v1/validators/V1EpochProofProposalApproval.js
+++ b/src/core/consensus/v1/validators/V1EpochProofProposalApproval.js
@@ -8,33 +8,59 @@ import {V1ConsensusProtocolError} from "../V1ConsensusProtocolError.js";
 class V1EpochProofProposalApproval extends V1BaseConsensusOperation {
     /**
      * Creates the proof proposal approval validator.
+     *
+     * @param {Config} config Application configuration. Approval validation uses
+     * `addressLength` for schemas and `addressPrefix` for approver addresses.
+     * @param {State} state Ledger state. It must expose
+     * `isIndexerAddress(address)` for approver membership validation.
+     * @throws {Error} When consensus schemas cannot be initialized from the configuration.
      */
-    constructor(config) {
-        super(config);
+    constructor(config, state) {
+        super(config, state);
     }
 
     /**
-     * Validates proof proposal response schema and required response signatures.
+     * Validates a complete incoming proof proposal approval.
+     *
+     * Checks the response schema and signature, requires an OK result, verifies
+     * that the approver belongs to the remote public key, verifies the approval
+     * signature against the original proposal, and checks indexer membership.
+     *
+     * @param {object} payload Decoded proof proposal approval payload.
+     * @param {object} connection Peer connection containing `remotePublicKey`.
+     * @param {object} proofProposal Original proof proposal being approved.
+     * @returns {Promise<boolean>} Resolves to `true` when every check succeeds.
+     * @throws {V1ConsensusProtocolError} When any approval validation check fails.
      */
     async validate(payload, connection, proofProposal) {
-        this.isPayloadSchemaValid(payload);
+        return await this.validateAsProtocolError(async () => {
+            this.isPayloadSchemaValid(payload);
 
-        await this.#validateResponseSignature(payload, connection.remotePublicKey);
-        const resultCode = payload.proof_proposal_response.result;
-        this.#validateIfResultCodeIsOk(resultCode);
-        const approval = payload.proof_proposal_response.approval;
-        this.assertAddressWithRemotePublicKey(
-            approval.approver,
-            connection.remotePublicKey
-        );
-        await this.validateSignature(payload, connection.remotePublicKey, proofProposal);
-        this.validateAddressIsIndexer();
-        await this.#validateResponseSignature(payload, connection.remotePublicKey);
-        return true;
+            await this.#validateResponseSignature(payload, connection.remotePublicKey);
+            const resultCode = payload.proof_proposal_response.result;
+            this.#validateIfResultCodeIsOk(resultCode);
+            const approval = payload.proof_proposal_response.approval;
+            this.assertAddressWithRemotePublicKey(
+                approval.approver,
+                connection.remotePublicKey
+            );
+            await this.validateSignature(payload, connection.remotePublicKey, proofProposal);
+            await this.validateAddressIsIndexer(connection.remotePublicKey);
+            await this.#validateResponseSignature(payload, connection.remotePublicKey);
+            return true;
+        });
     }
 
     /**
      * Verifies the response signature over result code and optional encoded approval.
+     *
+     * For an OK response the signed message covers both result code and encoded
+     * approval. For a rejection it covers only the result code.
+     *
+     * @param {object} payload Decoded proof proposal response payload.
+     * @param {Buffer} remotePublicKey Public key received from the peer connection.
+     * @returns {Promise<void>}
+     * @throws {V1ConsensusProtocolError} When hashing or response signature verification fails.
      */
     async #validateResponseSignature(payload, remotePublicKey) {
         const proofProposalResponse = payload.proof_proposal_response;
@@ -71,6 +97,13 @@ class V1EpochProofProposalApproval extends V1BaseConsensusOperation {
         }
     }
 
+    /**
+     * Validates that the proof proposal response accepts the proposal.
+     *
+     * @param {number} resultCode Consensus result code from the response.
+     * @returns {void}
+     * @throws {V1ConsensusProtocolError} When the response result is not `ConsensusResultCode.OK`.
+     */
     #validateIfResultCodeIsOk(resultCode) {
         if (resultCode !== ConsensusResultCode.OK) {
             throw new V1ConsensusProtocolError(resultCode, `Proof proposal response result code is not OK: ${resultCode}`);

--- a/src/core/consensus/v1/validators/V1EpochProofProposalApproval.js
+++ b/src/core/consensus/v1/validators/V1EpochProofProposalApproval.js
@@ -46,7 +46,6 @@ class V1EpochProofProposalApproval extends V1BaseConsensusOperation {
             );
             await this.validateSignature(payload, connection.remotePublicKey, proofProposal);
             await this.validateAddressIsIndexer(connection.remotePublicKey);
-            await this.#validateResponseSignature(payload, connection.remotePublicKey);
             return true;
         });
     }

--- a/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
+++ b/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
@@ -7,72 +7,119 @@ import b4a from "b4a";
 import {verifyWesolowski} from '@tracsystems/trac-vdf';
 
 class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
-    #config;
 
     /**
      * Creates the proof proposal request validator.
+     *
+     * @param {Config} config Application configuration. In addition to base
+     * fields, request validation uses `networkId`, `vdfDifficulty`, and
+     * `vdfDiscriminantSizeBits`.
+     * @param {State} state Ledger state. It must expose `getCurrentEpoch()`,
+     * `getEpoch(epoch)`, and `isIndexerAddress(address)`.
+     * @throws {Error} When consensus schemas cannot be initialized from the configuration.
      */
-    constructor(config) {
-        super(config);
-        this.#config = config;
+    constructor(config, state) {
+        super(config, state);
     }
 
     /**
-     * Validates proof proposal request schema and proposer signature.
+     * Validates a complete incoming epoch proof proposal request.
+     *
+     * Checks the payload schema, protocol version, network id, proposer identity,
+     * VDF parameters hash, proposal signature, VDF proof, next epoch number,
+     * previous epoch record hash, and proposer indexer membership.
+     *
+     * @param {object} payload Decoded proof proposal request payload.
+     * @param {object} connection Peer connection containing `remotePublicKey`.
+     * @returns {Promise<boolean>} Resolves to `true` when every check succeeds.
+     * @throws {V1ConsensusProtocolError} When any proposal validation check fails.
      */
     async validate(payload, connection) {
-        this.isPayloadSchemaValid(payload);
-        this.validateProofProposalProtocolVersion(payload.proof_proposal);
-        this.validateProofProposalNetworkId(payload.proof_proposal);
-        this.assertAddressWithRemotePublicKey(
-            payload.proof_proposal.proposer,
-            connection.remotePublicKey
-        );
-        await this.validateProofProposalVdfParametersHash(payload.proof_proposal);
-        await this.validateSignature(payload, connection.remotePublicKey);
-        await this.validateProofProposalVdfProof(payload.proof_proposal);
-        this.validateIncomingEpoch()
-        this.validatePreviousEpochRecordHash()
-        this.validateAddressIsIndexer()
-        return true;
+        return await this.validateAsProtocolError(async () => {
+            this.isPayloadSchemaValid(payload);
+            this.validateProofProposalProtocolVersion(payload.proof_proposal);
+            this.validateProofProposalNetworkId(payload.proof_proposal);
+            this.assertAddressWithRemotePublicKey(
+                payload.proof_proposal.proposer,
+                connection.remotePublicKey
+            );
+            await this.validateAddressIsIndexer(connection.remotePublicKey);
+            await this.validateProofProposalVdfParametersHash(payload.proof_proposal);
+            await this.validateSignature(payload, connection.remotePublicKey);
+            await this.validateProofProposalVdfProof(payload.proof_proposal);
+            const currentEpoch = await this._state.getCurrentEpoch();
+            this.validateIncomingEpoch(payload.proof_proposal, currentEpoch);
+            await this.validatePreviousEpochRecordHash(payload.proof_proposal, currentEpoch);
+            return true;
+        });
     }
 
     /**
      * Validates that the proof proposal uses the supported consensus protocol version.
+     *
+     * @param {object} proofProposal Decoded proof proposal.
+     * @returns {void}
+     * @throws {V1ConsensusProtocolError} When the version is missing or is not consensus v1.
      */
     validateProofProposalProtocolVersion(proofProposal) {
         if (!proofProposal?.protocol_version) {
-            throw new V1ConsensusProtocolError(ConsensusResultCode.UNEXPECTED_ERROR, 'Proof proposal protocol version is missing.');
+            throw new V1ConsensusProtocolError(
+                ConsensusResultCode.UNEXPECTED_ERROR,
+                'Proof proposal protocol version is missing.'
+            );
         }
 
         if (proofProposal.protocol_version[0] !== ConsensusProtocolVersion.V1) {
-            throw new V1ConsensusProtocolError(ConsensusResultCode.UNEXPECTED_ERROR, 'Unsupported proof proposal protocol version.');
+            throw new V1ConsensusProtocolError(
+                ConsensusResultCode.UNEXPECTED_ERROR,
+                'Unsupported proof proposal protocol version.'
+            );
         }
     }
 
     /**
      * Validates that the proof proposal VDF parameters hash matches local config.
+     *
+     * Reconstructs the configured difficulty and discriminant-size message,
+     * hashes it with BLAKE3, and compares it with `vdf_parameters_hash`.
+     *
+     * @param {object} proofProposal Decoded proof proposal.
+     * @returns {Promise<void>}
+     * @throws {V1ConsensusProtocolError} When hashing fails or the hash does not match.
      */
     async validateProofProposalVdfParametersHash(proofProposal) {
         const message = createMessage(
-            uint32ToBuffer(this.#config.vdfDifficulty),
-            uint32ToBuffer(this.#config.vdfDiscriminantSizeBits)
+            uint32ToBuffer(this._config.vdfDifficulty),
+            uint16ToBuffer(this._config.vdfDiscriminantSizeBits)
         );
 
         let expectedHash;
         try {
             expectedHash = await tracCryptoApi.hash.blake3(message);
         } catch {
-            throw new V1ConsensusProtocolError(ConsensusResultCode.UNEXPECTED_ERROR, 'Failed to hash VDF parameters.');
+            throw new V1ConsensusProtocolError(
+                ConsensusResultCode.UNEXPECTED_ERROR,
+                'Failed to hash VDF parameters.'
+            );
         }
 
         if (!b4a.equals(proofProposal.vdf_parameters_hash, expectedHash)) {
-            throw new V1ConsensusProtocolError(ConsensusResultCode.UNEXPECTED_ERROR, 'VDF parameters hash is invalid.');
+            throw new V1ConsensusProtocolError(
+                ConsensusResultCode.UNEXPECTED_ERROR,
+                'VDF parameters hash is invalid.'
+            );
         }
     }
 
     /**
      * Verifies the proof proposal VDF proof against its challenge data.
+     *
+     * Uses the canonical challenge fields and locally configured VDF difficulty
+     * and discriminant size for Wesolowski proof verification.
+     *
+     * @param {object} proofProposal Decoded proof proposal.
+     * @returns {Promise<void>}
+     * @throws {V1ConsensusProtocolError} When VDF verification fails or returns false.
      */
     async validateProofProposalVdfProof(proofProposal) {
         const challengeData = this.buildProofProposalChallengeData(proofProposal);
@@ -81,9 +128,9 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
         try {
             verified = await verifyWesolowski(
                 challengeData,
-                this.#config.vdfDifficulty,
+                this._config.vdfDifficulty,
                 proofProposal.vdf_proof,
-                this.#config.vdfDiscriminantSizeBits
+                this._config.vdfDiscriminantSizeBits
             );
         } catch {
             verified = false;
@@ -99,20 +146,60 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
 
     /**
      * Validates that the proof proposal targets the configured network.
+     *
+     * @param {object} proofProposal Decoded proof proposal.
+     * @returns {void}
+     * @throws {V1ConsensusProtocolError} When `network_id` differs from the local network id.
      */
     validateProofProposalNetworkId(proofProposal) {
-        const expectedNetworkId = uint16ToBuffer(this.#config.networkId);
+        const expectedNetworkId = uint16ToBuffer(this._config.networkId);
         if (!b4a.equals(proofProposal.network_id, expectedNetworkId)) {
-            throw new V1ConsensusProtocolError(ConsensusResultCode.UNEXPECTED_ERROR, 'Invalid proof proposal network id.');
+            throw new V1ConsensusProtocolError(
+                ConsensusResultCode.UNEXPECTED_ERROR,
+                'Invalid proof proposal network id.'
+            );
         }
     }
 
-    validateIncomingEpoch() {
-        //TODO: Placeholder - epoch defined in the payload should be current_epoch + 1. Completion depends on genesis being initialized in the ledger. this is not implemented yet.
+    /**
+     * Validates that the proposal advances the current epoch by exactly one.
+     *
+     * @param {object} proofProposal Decoded proof proposal containing an uint64 epoch buffer.
+     * @param {bigint} currentEpoch Current epoch snapshot used by all epoch-related checks.
+     * @returns {void}
+     * @throws {V1ConsensusProtocolError} When the proposed epoch is not `currentEpoch + 1`.
+     */
+    validateIncomingEpoch(proofProposal, currentEpoch) {
+        const proofProposalEpoch = proofProposal.epoch.readBigUInt64BE(0);
+        if (proofProposalEpoch !== currentEpoch + 1n) {
+            throw new V1ConsensusProtocolError(
+                ConsensusResultCode.UNEXPECTED_ERROR,
+                `Unexpected epoch. Proof proposal must be ${currentEpoch + 1n} but got ${proofProposalEpoch}`
+            );
+        }
     }
 
-    validatePreviousEpochRecordHash() {
-        //TODO: Placeholder - previous_epoch_record_hash should match the latest epoch record hash. Completion depends on genesis being initialized in the ledger. this is not implemented yet.
+    /**
+     * Validates that the proposal references the current epoch record hash.
+     *
+     * Reads the current epoch id and its stored hash, then compares that hash
+     * with `previous_epoch_record_hash` from the proposal.
+     *
+     * @param {object} proofProposal Decoded proof proposal.
+     * @param {bigint} currentEpoch Current epoch snapshot used by all epoch-related checks.
+     * @returns {Promise<void>}
+     * @throws {V1ConsensusProtocolError} When the previous epoch record hash does not match state.
+     */
+    async validatePreviousEpochRecordHash(proofProposal, currentEpoch) {
+        const currentEpochHash = await this._state.getEpoch(currentEpoch);
+        const epochHashInProofProposal = proofProposal.previous_epoch_record_hash;
+        if (!b4a.equals(currentEpochHash, epochHashInProofProposal)) {
+            throw new V1ConsensusProtocolError(
+                ConsensusResultCode.UNEXPECTED_ERROR,
+                `Previous epoch record hash mismatch for epoch ${currentEpoch}: expected ${currentEpochHash.toString('hex')}, got ${epochHashInProofProposal.toString('hex')}`
+            )
+        }
+
     }
 }
 

--- a/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
+++ b/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
@@ -14,7 +14,7 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
      * @param {Config} config Application configuration used by base validation
      * and network identity checks.
      * @param {State} state Ledger state. It must expose `getCurrentEpoch()`,
-     * `getEpoch(epoch)`, `getSignedVDFParams()`, and `isIndexerAddress(address)`.
+     * `getEpoch(epoch)`, `requireSignedVDFParams()`, and `isIndexerAddress(address)`.
      * @throws {Error} When consensus schemas cannot be initialized from the configuration.
      */
     constructor(config, state) {
@@ -47,7 +47,7 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
             const currentEpoch = await this._state.getCurrentEpoch();
             this.validateIncomingEpoch(payload.proof_proposal, currentEpoch);
             await this.validatePreviousEpochRecordHash(payload.proof_proposal, currentEpoch);
-            const vdfParams = await this._state.getSignedVDFParams();
+            const vdfParams = await this._state.requireSignedVDFParams();
             await this.validateProofProposalVdfParametersHash(payload.proof_proposal, vdfParams);
             await this.validateProofProposalVdfProof(payload.proof_proposal, vdfParams);
             return true;

--- a/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
+++ b/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
@@ -25,8 +25,8 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
      * Validates a complete incoming epoch proof proposal request.
      *
      * Checks the payload schema, protocol version, network id, proposer identity,
-     * VDF parameters hash, proposal signature, VDF proof, next epoch number,
-     * previous epoch record hash, and proposer indexer membership.
+     * proposal signature, proposer indexer membership, next epoch number,
+     * previous epoch record hash, VDF parameters hash, and VDF proof.
      *
      * @param {object} payload Decoded proof proposal request payload.
      * @param {object} connection Peer connection containing `remotePublicKey`.
@@ -42,14 +42,14 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
                 payload.proof_proposal.proposer,
                 connection.remotePublicKey
             );
-            await this.validateAddressIsIndexer(connection.remotePublicKey);
-            const vdfParams = await this._state.getSignedVDFParams();
-            await this.validateProofProposalVdfParametersHash(payload.proof_proposal, vdfParams);
             await this.validateSignature(payload, connection.remotePublicKey);
-            await this.validateProofProposalVdfProof(payload.proof_proposal, vdfParams);
+            await this.validateAddressIsIndexer(connection.remotePublicKey);
             const currentEpoch = await this._state.getCurrentEpoch();
             this.validateIncomingEpoch(payload.proof_proposal, currentEpoch);
             await this.validatePreviousEpochRecordHash(payload.proof_proposal, currentEpoch);
+            const vdfParams = await this._state.getSignedVDFParams();
+            await this.validateProofProposalVdfParametersHash(payload.proof_proposal, vdfParams);
+            await this.validateProofProposalVdfProof(payload.proof_proposal, vdfParams);
             return true;
         });
     }
@@ -199,7 +199,7 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
             throw new V1ConsensusProtocolError(
                 ConsensusResultCode.UNEXPECTED_ERROR,
                 `Previous epoch record hash mismatch for epoch ${currentEpoch}: expected ${currentEpochHash.toString('hex')}, got ${epochHashInProofProposal.toString('hex')}`
-            )
+            );
         }
 
     }

--- a/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
+++ b/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
@@ -44,9 +44,10 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
                 connection.remotePublicKey
             );
             await this.validateAddressIsIndexer(connection.remotePublicKey);
-            await this.validateProofProposalVdfParametersHash(payload.proof_proposal);
+            const vdfParams = await this._state.getSignedVDFParams();
+            await this.validateProofProposalVdfParametersHash(payload.proof_proposal, vdfParams);
             await this.validateSignature(payload, connection.remotePublicKey);
-            await this.validateProofProposalVdfProof(payload.proof_proposal);
+            await this.validateProofProposalVdfProof(payload.proof_proposal, vdfParams);
             const currentEpoch = await this._state.getCurrentEpoch();
             this.validateIncomingEpoch(payload.proof_proposal, currentEpoch);
             await this.validatePreviousEpochRecordHash(payload.proof_proposal, currentEpoch);
@@ -84,13 +85,14 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
      * hashes it with BLAKE3, and compares it with `vdf_parameters_hash`.
      *
      * @param {object} proofProposal Decoded proof proposal.
+     * @param {object} vdfParams Signed VDF parameters read from ledger state.
      * @returns {Promise<void>}
      * @throws {V1ConsensusProtocolError} When hashing fails or the hash does not match.
      */
-    async validateProofProposalVdfParametersHash(proofProposal) {
+    async validateProofProposalVdfParametersHash(proofProposal, vdfParams) {
         const message = createMessage(
-            uint32ToBuffer(this._config.vdfDifficulty),
-            uint16ToBuffer(this._config.vdfDiscriminantSizeBits)
+            uint32ToBuffer(vdfParams.vdfDifficulty),
+            uint16ToBuffer(vdfParams.vdfDiscriminantSize)
         );
 
         let expectedHash;
@@ -114,23 +116,24 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
     /**
      * Verifies the proof proposal VDF proof against its challenge data.
      *
-     * Uses the canonical challenge fields and locally configured VDF difficulty
-     * and discriminant size for Wesolowski proof verification.
+     * Uses the canonical challenge fields and signed-state VDF difficulty and
+     * discriminant size for Wesolowski proof verification.
      *
      * @param {object} proofProposal Decoded proof proposal.
+     * @param {object} vdfParams Signed VDF parameters read from ledger state.
      * @returns {Promise<void>}
      * @throws {V1ConsensusProtocolError} When VDF verification fails or returns false.
      */
-    async validateProofProposalVdfProof(proofProposal) {
+    async validateProofProposalVdfProof(proofProposal, vdfParams) {
         const challengeData = this.buildProofProposalChallengeData(proofProposal);
 
         let verified = false;
         try {
             verified = await verifyWesolowski(
                 challengeData,
-                this._config.vdfDifficulty,
+                vdfParams.vdfDifficulty,
                 proofProposal.vdf_proof,
-                this._config.vdfDiscriminantSizeBits
+                vdfParams.vdfDiscriminantSize
             );
         } catch {
             verified = false;

--- a/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
+++ b/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
@@ -13,8 +13,8 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
      *
      * @param {Config} config Application configuration used by base validation
      * and network identity checks.
-     * @param {State} state Ledger state. It must expose `getCurrentEpoch()`,
-     * `getEpoch(epoch)`, `requireSignedVDFParams()`, and `isIndexerAddress(address)`.
+     * @param {State} state Ledger state. It must expose `requireCurrentEpoch()`,
+     * `requireEpoch(epoch)`, `requireSignedVDFParams()`, and `isIndexerAddress(address)`.
      * @throws {Error} When consensus schemas cannot be initialized from the configuration.
      */
     constructor(config, state) {
@@ -44,7 +44,7 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
             );
             await this.validateSignature(payload, connection.remotePublicKey);
             await this.validateAddressIsIndexer(connection.remotePublicKey);
-            const currentEpoch = await this._state.getCurrentEpoch();
+            const currentEpoch = await this._state.requireCurrentEpoch();
             this.validateIncomingEpoch(payload.proof_proposal, currentEpoch);
             await this.validatePreviousEpochRecordHash(payload.proof_proposal, currentEpoch);
             const vdfParams = await this._state.requireSignedVDFParams();
@@ -193,7 +193,7 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
      * @throws {V1ConsensusProtocolError} When the previous epoch record hash does not match state.
      */
     async validatePreviousEpochRecordHash(proofProposal, currentEpoch) {
-        const currentEpochHash = await this._state.getEpoch(currentEpoch);
+        const currentEpochHash = await this._state.requireEpoch(currentEpoch);
         const epochHashInProofProposal = proofProposal.previous_epoch_record_hash;
         if (!b4a.equals(currentEpochHash, epochHashInProofProposal)) {
             throw new V1ConsensusProtocolError(

--- a/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
+++ b/src/core/consensus/v1/validators/V1EpochProofProposalRequest.js
@@ -11,11 +11,10 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
     /**
      * Creates the proof proposal request validator.
      *
-     * @param {Config} config Application configuration. In addition to base
-     * fields, request validation uses `networkId`, `vdfDifficulty`, and
-     * `vdfDiscriminantSizeBits`.
+     * @param {Config} config Application configuration used by base validation
+     * and network identity checks.
      * @param {State} state Ledger state. It must expose `getCurrentEpoch()`,
-     * `getEpoch(epoch)`, and `isIndexerAddress(address)`.
+     * `getEpoch(epoch)`, `getSignedVDFParams()`, and `isIndexerAddress(address)`.
      * @throws {Error} When consensus schemas cannot be initialized from the configuration.
      */
     constructor(config, state) {
@@ -79,9 +78,9 @@ class V1EpochProofProposalRequest extends V1BaseConsensusOperation {
     }
 
     /**
-     * Validates that the proof proposal VDF parameters hash matches local config.
+     * Validates that the proof proposal VDF parameters hash matches signed state.
      *
-     * Reconstructs the configured difficulty and discriminant-size message,
+     * Reconstructs the signed difficulty and discriminant-size message,
      * hashes it with BLAKE3, and compares it with `vdf_parameters_hash`.
      *
      * @param {object} proofProposal Decoded proof proposal.

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -46,6 +46,7 @@ import { Status } from './utils/transaction.js';
 import remote from 'hypercore/lib/fully-remote-proof.js'
 import PQueue from 'p-queue';
 import {decodeVdfParameters, encodeVdfParameters, createGenesisEpochProof} from './utils/epochProof.js';
+import _ from 'lodash';
 
 const OVERSIZED_BATCH_PENALTY_MULTIPLIER = BATCH_SIZE;
 
@@ -177,11 +178,16 @@ class State extends ReadyResource {
     /**
      * Reads the current epoch id from signed state.
      *
-     * @returns {Promise<bigint|null>} Current epoch id, or null when epoch state is not initialized.
+     * @returns {Promise<bigint>} Current epoch id.
+     * @throws {Error} When genesis epoch state has not been initialized.
      */
     async getCurrentEpoch() {
         const currentEpoch = await this.getSigned(EntryType.EPOCH_CURRENT);
-        if (currentEpoch === null) return null;
+        if (_.isNil(currentEpoch)) {
+            throw new Error(
+                'Current epoch is not initialized. Genesis epoch has not been set.'
+            );
+        }
         return currentEpoch.readBigUInt64BE(0);
     }
 
@@ -189,26 +195,48 @@ class State extends ReadyResource {
      * Reads the epoch hash stored under `/epoch/<epoch>`.
      *
      * @param {bigint|number|string} count Epoch id.
-     * @returns {Promise<Buffer|null>} Epoch hash, or null when the epoch is not stored.
+     * @returns {Promise<Buffer>} Epoch hash.
+     * @throws {Error} When epoch id is missing or the epoch is not stored.
      */
     async getEpoch(count) {
-        if (count === null || count === undefined) return null;
+        if (_.isNil(count)) {
+            throw new Error(
+                'Cannot read epoch: epoch id is required.'
+            );
+        }
 
         const epochId = typeof count === 'bigint' ? count : BigInt(count);
-        return await this.getSigned(EntryType.EPOCH + epochId.toString());
+        const epochHash = await this.getSigned(EntryType.EPOCH + epochId.toString());
+        if (_.isNil(epochHash)) {
+            throw new Error(
+                `Cannot read epoch ${epochId}: epoch is not initialized or does not exist.`
+            );
+        }
+
+        return epochHash;
     }
 
     /**
      * Reads the encoded epoch proof stored under `/epochHash/<epochHash>`.
      *
      * @param {Buffer|string} epochHash Epoch hash as a buffer or hex string.
-     * @returns {Promise<Buffer|null>} Encoded epoch proof, or null when the proof is not stored.
+     * @returns {Promise<Buffer>} Encoded epoch proof.
+     * @throws {Error} When epoch hash is missing or the epoch proof is not stored.
      */
     async getEpochProof(epochHash) {
-        if (epochHash === null || epochHash === undefined) return null;
+        if (_.isNil(epochHash)) {
+            throw new Error('Cannot read epoch proof: epoch hash is required.');
+        }
 
         const epochHashString = b4a.isBuffer(epochHash) ? epochHash.toString('hex') : epochHash.toString();
-        return await this.getSigned(EntryType.EPOCH_HASH + epochHashString);
+        const epochProof = await this.getSigned(EntryType.EPOCH_HASH + epochHashString);
+        if (_.isNil(epochProof)) {
+            throw new Error(
+                `Cannot read epoch proof ${epochHashString}: epoch proof is not initialized or does not exist.`
+            );
+        }
+
+        return epochProof;
     }
 
     getFee() {

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -574,7 +574,9 @@ class State extends ReadyResource {
 
     async getSignedVDFParams() {
         const vdfParamsBuffer = await this.getSigned(EntryType.VDF_PARAMS);
-        if (!vdfParamsBuffer) return null;
+        if (!vdfParamsBuffer) {
+            throw new Error("VDF parameters are not initialized.");
+        }
 
         const expectedLength = VDF_DIFFICULTY_SIZE + VDF_DISCRIMINANT_SIZE;
         if (!b4a.isBuffer(vdfParamsBuffer)) {

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -574,9 +574,7 @@ class State extends ReadyResource {
 
     async getSignedVDFParams() {
         const vdfParamsBuffer = await this.getSigned(EntryType.VDF_PARAMS);
-        if (!vdfParamsBuffer) {
-            throw new Error("VDF parameters are not initialized.");
-        }
+        if (_.isNil(vdfParamsBuffer)) return null;
 
         const expectedLength = VDF_DIFFICULTY_SIZE + VDF_DISCRIMINANT_SIZE;
         if (!b4a.isBuffer(vdfParamsBuffer)) {
@@ -594,6 +592,14 @@ class State extends ReadyResource {
             vdfDifficulty: decodedVdfParams.difficulty.readUInt32BE(0),
             vdfDiscriminantSize: decodedVdfParams.discriminantBitSize.readUInt16BE(0),
         };
+    }
+
+    async requireSignedVDFParams() {
+        const params = await this.getSignedVDFParams();
+        if (_.isNil(params)) {
+            throw new Error("VDF parameters are not initialized.");
+        }
+        return params;
     }
 
     // ATTENTION: DO NOT USE METHODS ABOVE IN APPLY PART!

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -178,25 +178,36 @@ class State extends ReadyResource {
     /**
      * Reads the current epoch id from signed state.
      *
-     * @returns {Promise<bigint>} Current epoch id.
-     * @throws {Error} When genesis epoch state has not been initialized.
+     * @returns {Promise<bigint|null>} Current epoch id, or `null` when genesis
+     * epoch state has not been initialized.
      */
     async getCurrentEpoch() {
         const currentEpoch = await this.getSigned(EntryType.EPOCH_CURRENT);
+        return _.isNil(currentEpoch) ? null : currentEpoch.readBigUInt64BE(0);
+    }
+
+    /**
+     * Reads the required current epoch id from signed state.
+     *
+     * @returns {Promise<bigint>} Current epoch id.
+     * @throws {Error} When genesis epoch state has not been initialized.
+     */
+    async requireCurrentEpoch() {
+        const currentEpoch = await this.getCurrentEpoch();
         if (_.isNil(currentEpoch)) {
             throw new Error(
                 'Current epoch is not initialized. Genesis epoch has not been set.'
             );
         }
-        return currentEpoch.readBigUInt64BE(0);
+        return currentEpoch;
     }
 
     /**
      * Reads the epoch hash stored under `/epoch/<epoch>`.
      *
      * @param {bigint|number|string} count Epoch id.
-     * @returns {Promise<Buffer>} Epoch hash.
-     * @throws {Error} When epoch id is missing or the epoch is not stored.
+     * @returns {Promise<Buffer|null>} Epoch hash, or `null` when the epoch is not stored.
+     * @throws {Error} When epoch id is missing or invalid.
      */
     async getEpoch(count) {
         if (_.isNil(count)) {
@@ -206,13 +217,24 @@ class State extends ReadyResource {
         }
 
         const epochId = typeof count === 'bigint' ? count : BigInt(count);
-        const epochHash = await this.getSigned(EntryType.EPOCH + epochId.toString());
+        return await this.getSigned(EntryType.EPOCH + epochId.toString());
+    }
+
+    /**
+     * Reads the required epoch hash stored under `/epoch/<epoch>`.
+     *
+     * @param {bigint|number|string} count Epoch id.
+     * @returns {Promise<Buffer>} Epoch hash.
+     * @throws {Error} When epch id is missing or invalid, or the epoch is not stored.
+     */
+    async requireEpoch(count) {
+        const epochHash = await this.getEpoch(count);
         if (_.isNil(epochHash)) {
+            const epochId = typeof count === 'bigint' ? count : BigInt(count);
             throw new Error(
                 `Cannot read epoch ${epochId}: epoch is not initialized or does not exist.`
             );
         }
-
         return epochHash;
     }
 
@@ -220,8 +242,8 @@ class State extends ReadyResource {
      * Reads the encoded epoch proof stored under `/epochHash/<epochHash>`.
      *
      * @param {Buffer|string} epochHash Epoch hash as a buffer or hex string.
-     * @returns {Promise<Buffer>} Encoded epoch proof.
-     * @throws {Error} When epoch hash is missing or the epoch proof is not stored.
+     * @returns {Promise<Buffer|null>} Encoded epoch proof, or `null` when it is not stored.
+     * @throws {Error} When epoch hash is missing.
      */
     async getEpochProof(epochHash) {
         if (_.isNil(epochHash)) {
@@ -229,13 +251,24 @@ class State extends ReadyResource {
         }
 
         const epochHashString = b4a.isBuffer(epochHash) ? epochHash.toString('hex') : epochHash.toString();
-        const epochProof = await this.getSigned(EntryType.EPOCH_HASH + epochHashString);
+        return await this.getSigned(EntryType.EPOCH_HASH + epochHashString);
+    }
+
+    /**
+     * Reads the required encoded epoch proof stored under `/epochHash/<epochHash>`.
+     *
+     * @param {Buffer|string} epochHash Epoch hash as a buffer or hex string.
+     * @returns {Promise<Buffer>} Encoded epoch proof.
+     * @throws {Error} When epoch hash is missing or the epoch proof is not stored.
+     */
+    async requireEpochProof(epochHash) {
+        const epochProof = await this.getEpochProof(epochHash);
         if (_.isNil(epochProof)) {
+            const epochHashString = b4a.isBuffer(epochHash) ? epochHash.toString('hex') : epochHash.toString();
             throw new Error(
                 `Cannot read epoch proof ${epochHashString}: epoch proof is not initialized or does not exist.`
             );
         }
-
         return epochProof;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,8 @@ import {
     BOOTSTRAP_HEXSTRING_LENGTH,
     BALANCE_MIGRATION_SLEEP_INTERVAL,
     WHITELIST_MIGRATION_DIR,
-    OperationType
+    OperationType,
+    EntryType
 } from "./utils/constants.js";
 import { decimalStringToBigInt, bigIntTo16ByteBuffer, bufferToBigInt, bigIntToDecimalString } from "./utils/amountSerialization.js"
 import {
@@ -1081,7 +1082,9 @@ export class MainSettlementBus extends ReadyResource {
             throw new Error("Can not initialize genesis epoch - you are not the admin.");
         }
 
-        const existingVDFParams = await this.#state.getSignedVDFParams();
+        // Read the raw entry because missing VDF params are expected before genesis,
+        // while getSignedVDFParams() intentionally throws when they are not initialized.
+        const existingVDFParams = await this.#state.getSigned(EntryType.VDF_PARAMS);
         if (existingVDFParams) {
             throw new Error("Can not initialize genesis epoch - VDF parameters already exist.");
         }

--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,7 @@ import {
     BOOTSTRAP_HEXSTRING_LENGTH,
     BALANCE_MIGRATION_SLEEP_INTERVAL,
     WHITELIST_MIGRATION_DIR,
-    OperationType,
-    EntryType
+    OperationType
 } from "./utils/constants.js";
 import { decimalStringToBigInt, bigIntTo16ByteBuffer, bufferToBigInt, bigIntToDecimalString } from "./utils/amountSerialization.js"
 import {
@@ -1082,9 +1081,7 @@ export class MainSettlementBus extends ReadyResource {
             throw new Error("Can not initialize genesis epoch - you are not the admin.");
         }
 
-        // Read the raw entry because missing VDF params are expected before genesis,
-        // while getSignedVDFParams() intentionally throws when they are not initialized.
-        const existingVDFParams = await this.#state.getSigned(EntryType.VDF_PARAMS);
+        const existingVDFParams = await this.#state.getSignedVDFParams();
         if (existingVDFParams) {
             throw new Error("Can not initialize genesis epoch - VDF parameters already exist.");
         }
@@ -1132,7 +1129,7 @@ export class MainSettlementBus extends ReadyResource {
             throw new Error("Can not set VDF params - you are not the admin.");
         }
 
-        await this.#state.getSignedVDFParams();
+        await this.#state.requireSignedVDFParams();
 
         const difficultyNumber = Number(params.vdfDifficulty);
         if (!Number.isInteger(difficultyNumber) || difficultyNumber <= 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -1129,17 +1129,14 @@ export class MainSettlementBus extends ReadyResource {
             throw new Error("Can not set VDF params - you are not the admin.");
         }
 
-        const existingVDFParams = await this.#state.getSignedVDFParams();
-        if (!existingVDFParams) {
-            throw new Error("Can not set VDF params - VDF parameters have not been initialized.");
-        }
+        await this.#state.getSignedVDFParams();
 
         const difficultyNumber = Number(params.vdfDifficulty);
         if (!Number.isInteger(difficultyNumber) || difficultyNumber <= 0) {
             throw new Error("VDF difficulty must be a positive unsigned 32-bit integer.");
         }
 
-        const vdfDifficultyBuffer = uint32ToBuffer(difficultyNumber, "VDF difficulty");
+        const vdfDifficultyBuffer = uint32ToBuffer(difficultyNumber);
 
         const txValidity = await this.#state.getIndexerSequenceState();
         const payload = await applyStateMessageFactory(this.#wallet, this.#config)

--- a/tests/unit/consensus/V1EpochProofProposalApproval.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalApproval.test.js
@@ -5,6 +5,7 @@ import {WalletProvider} from 'trac-wallet';
 
 import ConsensusMessageBuilder from '../../../src/messages/consensus/v1/ConsensusMessageBuilder.js';
 import V1EpochProofProposalApproval from '../../../src/core/consensus/v1/validators/V1EpochProofProposalApproval.js';
+import {V1ConsensusProtocolError} from '../../../src/core/consensus/v1/V1ConsensusProtocolError.js';
 import {bufferToAddress} from '../../../src/core/state/utils/address.js';
 import {
     ConsensusOperationType,
@@ -20,6 +21,9 @@ import {createMessage, uint32ToBuffer} from '../../../src/utils/buffer.js';
 const previousEpochRecordHash = b4a.alloc(32, 1);
 const vdfParametersHash = b4a.alloc(32, 2);
 const vdfProof = b4a.alloc(VDF_BLOB_PROOF_SIZE, 3);
+const state = {
+    isIndexerAddress: async () => true
+};
 
 async function createWallet(keyPair) {
     return await new WalletProvider(config).fromSecretKey(keyPair.secretKey);
@@ -84,7 +88,7 @@ async function buildProofProposalRejectionPayload(approverWallet, proofProposalP
 test('V1EpochProofProposalApproval validates approval signature against original proof proposal', async t => {
     const proposerWallet = await createWallet(testKeyPair1);
     const approverWallet = await createWallet(testKeyPair2);
-    const validator = new V1EpochProofProposalApproval(config);
+    const validator = new V1EpochProofProposalApproval(config, state);
     const proofProposalPayload = await buildProofProposalPayload(proposerWallet);
     const approvalPayload = await buildProofProposalApprovalPayload(approverWallet, proofProposalPayload);
 
@@ -100,7 +104,7 @@ test('V1EpochProofProposalApproval validates approval signature against original
 test('V1EpochProofProposalApproval rejects non-OK response without approval', async t => {
     const proposerWallet = await createWallet(testKeyPair1);
     const approverWallet = await createWallet(testKeyPair2);
-    const validator = new V1EpochProofProposalApproval(config);
+    const validator = new V1EpochProofProposalApproval(config, state);
     const proofProposalPayload = await buildProofProposalPayload(proposerWallet);
     const approvalPayload = await buildProofProposalRejectionPayload(approverWallet, proofProposalPayload);
 
@@ -117,7 +121,7 @@ test('V1EpochProofProposalApproval rejects non-OK response without approval', as
 test('V1EpochProofProposalApproval rejects fake non-OK response signature before result code handling', async t => {
     const proposerWallet = await createWallet(testKeyPair1);
     const approverWallet = await createWallet(testKeyPair2);
-    const validator = new V1EpochProofProposalApproval(config);
+    const validator = new V1EpochProofProposalApproval(config, state);
     const proofProposalPayload = await buildProofProposalPayload(proposerWallet);
     const approvalPayload = await buildProofProposalRejectionPayload(approverWallet, proofProposalPayload);
     const fakeApprovalPayload = {
@@ -142,7 +146,7 @@ test('V1EpochProofProposalApproval validateSignature does not validate approver 
     const proposerWallet = await createWallet(testKeyPair1);
     const approverWallet = await createWallet(testKeyPair2);
     const otherWallet = await createWallet(testKeyPair3);
-    const validator = new V1EpochProofProposalApproval(config);
+    const validator = new V1EpochProofProposalApproval(config, state);
     const proofProposalPayload = await buildProofProposalPayload(proposerWallet);
     const approvalPayload = await buildProofProposalApprovalPayload(
         approverWallet,
@@ -163,7 +167,7 @@ test('V1EpochProofProposalApproval rejects approver address mismatched with remo
     const proposerWallet = await createWallet(testKeyPair1);
     const approverWallet = await createWallet(testKeyPair2);
     const otherWallet = await createWallet(testKeyPair3);
-    const validator = new V1EpochProofProposalApproval(config);
+    const validator = new V1EpochProofProposalApproval(config, state);
     const proofProposalPayload = await buildProofProposalPayload(proposerWallet);
     const approvalPayload = await buildProofProposalApprovalPayload(
         approverWallet,
@@ -184,7 +188,7 @@ test('V1EpochProofProposalApproval rejects approver address mismatched with remo
 test('V1EpochProofProposalApproval rejects fake approval signature message', async t => {
     const proposerWallet = await createWallet(testKeyPair1);
     const approverWallet = await createWallet(testKeyPair2);
-    const validator = new V1EpochProofProposalApproval(config);
+    const validator = new V1EpochProofProposalApproval(config, state);
     const proofProposalPayload = await buildProofProposalPayload(proposerWallet);
     const approvalPayload = await buildProofProposalApprovalPayload(approverWallet, proofProposalPayload);
     const fakeApprover = b4a.from(approvalPayload.proof_proposal_response.approval.approver);
@@ -214,7 +218,7 @@ test('V1EpochProofProposalApproval rejects fake approval signature message', asy
 test('V1EpochProofProposalApproval rejects fake response signature', async t => {
     const proposerWallet = await createWallet(testKeyPair1);
     const approverWallet = await createWallet(testKeyPair2);
-    const validator = new V1EpochProofProposalApproval(config);
+    const validator = new V1EpochProofProposalApproval(config, state);
     const proofProposalPayload = await buildProofProposalPayload(proposerWallet);
     const approvalPayload = await buildProofProposalApprovalPayload(approverWallet, proofProposalPayload);
     const fakeApprovalPayload = {
@@ -233,4 +237,31 @@ test('V1EpochProofProposalApproval rejects fake response signature', async t => 
         ),
         errorMessageIncludes('response signature verification failed')
     );
+});
+
+test('V1EpochProofProposalApproval wraps state failures as protocol errors', async t => {
+    const proposerWallet = await createWallet(testKeyPair1);
+    const approverWallet = await createWallet(testKeyPair2);
+    const stateError = new Error('Indexer state is unavailable.');
+    const validator = new V1EpochProofProposalApproval(config, {
+        isIndexerAddress: async () => {
+            throw stateError;
+        }
+    });
+    const proofProposalPayload = await buildProofProposalPayload(proposerWallet);
+    const approvalPayload = await buildProofProposalApprovalPayload(approverWallet, proofProposalPayload);
+
+    try {
+        await validator.validate(
+            approvalPayload,
+            {remotePublicKey: approverWallet.publicKey},
+            proofProposalPayload.proof_proposal
+        );
+        t.fail('should reject');
+    } catch (error) {
+        t.ok(error instanceof V1ConsensusProtocolError);
+        t.is(error.resultCode, ConsensusResultCode.UNEXPECTED_ERROR);
+        t.is(error.message, 'Indexer state is unavailable.');
+        t.is(error.cause, stateError);
+    }
 });

--- a/tests/unit/consensus/V1EpochProofProposalApproval.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalApproval.test.js
@@ -101,6 +101,25 @@ test('V1EpochProofProposalApproval validates approval signature against original
     t.pass();
 });
 
+test('V1EpochProofProposalApproval rejects approver that is not an indexer', async t => {
+    const proposerWallet = await createWallet(testKeyPair1);
+    const approverWallet = await createWallet(testKeyPair2);
+    const validator = new V1EpochProofProposalApproval(config, {
+        isIndexerAddress: async () => false
+    });
+    const proofProposalPayload = await buildProofProposalPayload(proposerWallet);
+    const approvalPayload = await buildProofProposalApprovalPayload(approverWallet, proofProposalPayload);
+
+    await t.exception(
+        async () => validator.validate(
+            approvalPayload,
+            {remotePublicKey: approverWallet.publicKey},
+            proofProposalPayload.proof_proposal
+        ),
+        errorMessageIncludes('Incoming address is not an indexer.')
+    );
+});
+
 test('V1EpochProofProposalApproval rejects non-OK response without approval', async t => {
     const proposerWallet = await createWallet(testKeyPair1);
     const approverWallet = await createWallet(testKeyPair2);

--- a/tests/unit/consensus/V1EpochProofProposalRequest.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalRequest.test.js
@@ -5,6 +5,7 @@ import tracCryptoApi from 'trac-crypto-api';
 import {solveWesolowski} from '@tracsystems/trac-vdf';
 
 import ConsensusMessageBuilder from '../../../src/messages/consensus/v1/ConsensusMessageBuilder.js';
+import V1BaseConsensusOperation from '../../../src/core/consensus/v1/validators/V1BaseConsensusOperation.js';
 import V1EpochProofProposalRequest from '../../../src/core/consensus/v1/validators/V1EpochProofProposalRequest.js';
 import {V1ConsensusProtocolError} from '../../../src/core/consensus/v1/V1ConsensusProtocolError.js';
 import {addressToBuffer} from '../../../src/core/state/utils/address.js';
@@ -35,6 +36,23 @@ const TEST_VDF_PARAMS = Object.freeze({
 });
 const vdfProofCache = new Map();
 const defaultPreviousEpochRecordHash = b4a.alloc(32, 1);
+
+test('V1BaseConsensusOperation stringifies non-Error failures', async t => {
+    const thrownValue = {reason: 'state unavailable'};
+    const validator = new V1BaseConsensusOperation(config, {});
+
+    try {
+        await validator.validateAsProtocolError(() => {
+            throw thrownValue;
+        });
+        t.fail('should reject');
+    } catch (error) {
+        t.ok(error instanceof V1ConsensusProtocolError);
+        t.is(error.resultCode, ConsensusResultCode.UNEXPECTED_ERROR);
+        t.is(error.message, String(thrownValue));
+        t.is(error.cause, thrownValue);
+    }
+});
 
 function createState({
     currentEpoch = 0n,

--- a/tests/unit/consensus/V1EpochProofProposalRequest.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalRequest.test.js
@@ -58,7 +58,8 @@ function createState({
     currentEpoch = 0n,
     currentEpochHash = defaultPreviousEpochRecordHash,
     vdfDifficulty = TEST_VDF_PARAMS.vdfDifficulty,
-    vdfDiscriminantSize = TEST_VDF_PARAMS.vdfDiscriminantSize
+    vdfDiscriminantSize = TEST_VDF_PARAMS.vdfDiscriminantSize,
+    isIndexer = true
 } = {}) {
     return {
         requireCurrentEpoch: async () => currentEpoch,
@@ -67,7 +68,7 @@ function createState({
             vdfDifficulty,
             vdfDiscriminantSize
         }),
-        isIndexerAddress: async () => true
+        isIndexerAddress: async () => isIndexer
     };
 }
 
@@ -180,6 +181,17 @@ test('V1EpochProofProposalRequest validates proof proposal signature', async t =
     t.is(currentEpochReads, 1);
     t.is(vdfParamsReads, 1);
     t.pass();
+});
+
+test('V1EpochProofProposalRequest rejects proposer that is not an indexer', async t => {
+    const wallet = await createWallet();
+    const validator = new V1EpochProofProposalRequest(config, createState({isIndexer: false}));
+    const payload = await buildProofProposalPayload(wallet);
+
+    await t.exception(
+        async () => validator.validate(payload, {remotePublicKey: wallet.publicKey}),
+        errorMessageIncludes('Incoming address is not an indexer.')
+    );
 });
 
 test('V1EpochProofProposalRequest rejects unsupported proof proposal protocol version', async t => {

--- a/tests/unit/consensus/V1EpochProofProposalRequest.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalRequest.test.js
@@ -63,7 +63,7 @@ function createState({
     return {
         getCurrentEpoch: async () => currentEpoch,
         getEpoch: async () => currentEpochHash,
-        getSignedVDFParams: async () => ({
+        requireSignedVDFParams: async () => ({
             vdfDifficulty,
             vdfDiscriminantSize
         }),
@@ -157,16 +157,16 @@ test('V1EpochProofProposalRequest validates proof proposal signature', async t =
         currentEpochHash: genesisEpochHash
     });
     const getCurrentEpoch = state.getCurrentEpoch;
-    const getSignedVDFParams = state.getSignedVDFParams;
+    const requireSignedVDFParams = state.requireSignedVDFParams;
     let currentEpochReads = 0;
     let vdfParamsReads = 0;
     state.getCurrentEpoch = async () => {
         currentEpochReads++;
         return await getCurrentEpoch();
     };
-    state.getSignedVDFParams = async () => {
+    state.requireSignedVDFParams = async () => {
         vdfParamsReads++;
-        return await getSignedVDFParams();
+        return await requireSignedVDFParams();
     };
     const validator = new V1EpochProofProposalRequest(config, state);
     const payload = await buildProofProposalPayload(wallet, {

--- a/tests/unit/consensus/V1EpochProofProposalRequest.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalRequest.test.js
@@ -61,8 +61,8 @@ function createState({
     vdfDiscriminantSize = TEST_VDF_PARAMS.vdfDiscriminantSize
 } = {}) {
     return {
-        getCurrentEpoch: async () => currentEpoch,
-        getEpoch: async () => currentEpochHash,
+        requireCurrentEpoch: async () => currentEpoch,
+        requireEpoch: async () => currentEpochHash,
         requireSignedVDFParams: async () => ({
             vdfDifficulty,
             vdfDiscriminantSize
@@ -156,13 +156,13 @@ test('V1EpochProofProposalRequest validates proof proposal signature', async t =
         currentEpoch: 0n,
         currentEpochHash: genesisEpochHash
     });
-    const getCurrentEpoch = state.getCurrentEpoch;
+    const requireCurrentEpoch = state.requireCurrentEpoch;
     const requireSignedVDFParams = state.requireSignedVDFParams;
     let currentEpochReads = 0;
     let vdfParamsReads = 0;
-    state.getCurrentEpoch = async () => {
+    state.requireCurrentEpoch = async () => {
         currentEpochReads++;
-        return await getCurrentEpoch();
+        return await requireCurrentEpoch();
     };
     state.requireSignedVDFParams = async () => {
         vdfParamsReads++;
@@ -384,7 +384,7 @@ test('V1EpochProofProposalRequest wraps state failures as protocol errors', asyn
     const stateError = new Error('State storage is unavailable.');
     const validator = new V1EpochProofProposalRequest(config, {
         ...createState(),
-        getCurrentEpoch: async () => {
+        requireCurrentEpoch: async () => {
             throw stateError;
         }
     });

--- a/tests/unit/consensus/V1EpochProofProposalRequest.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalRequest.test.js
@@ -9,6 +9,10 @@ import V1EpochProofProposalRequest from '../../../src/core/consensus/v1/validato
 import {V1ConsensusProtocolError} from '../../../src/core/consensus/v1/V1ConsensusProtocolError.js';
 import {addressToBuffer} from '../../../src/core/state/utils/address.js';
 import {
+    createGenesisEpochProof,
+    encodeVdfParameters
+} from '../../../src/core/state/utils/epochProof.js';
+import {
     createMessage,
     uint8ToBuffer,
     uint16ToBuffer,
@@ -33,15 +37,37 @@ const vdfTestConfig = new Proxy(config, {
     }
 });
 const vdfProofCache = new Map();
+const defaultPreviousEpochRecordHash = b4a.alloc(32, 1);
+
+function createState({
+    currentEpoch = 0n,
+    currentEpochHash = defaultPreviousEpochRecordHash
+} = {}) {
+    return {
+        getCurrentEpoch: async () => currentEpoch,
+        getEpoch: async () => currentEpochHash,
+        isIndexerAddress: async () => true
+    };
+}
 
 async function createWallet(keyPair = testKeyPair1) {
     return await new WalletProvider(config).fromSecretKey(keyPair.secretKey);
 }
 
+async function buildGenesisEpochHash(wallet, vdfConfig = vdfTestConfig) {
+    const vdfParamsEntry = encodeVdfParameters(
+        uint32ToBuffer(vdfConfig.vdfDifficulty),
+        uint16ToBuffer(vdfConfig.vdfDiscriminantSizeBits)
+    );
+    const genesisEpoch = await createGenesisEpochProof(vdfConfig, wallet.address, vdfParamsEntry);
+
+    return await tracCryptoApi.hash.blake3(genesisEpoch);
+}
+
 async function buildVdfParametersHash(vdfConfig = vdfTestConfig) {
     const message = createMessage(
         uint32ToBuffer(vdfConfig.vdfDifficulty),
-        uint32ToBuffer(vdfConfig.vdfDiscriminantSizeBits)
+        uint16ToBuffer(vdfConfig.vdfDiscriminantSizeBits)
     );
 
     return await tracCryptoApi.hash.blake3(message);
@@ -65,18 +91,20 @@ async function buildVdfProof(challengeData, vdfConfig = vdfTestConfig) {
     return b4a.from(vdfProofCache.get(cacheKey));
 }
 
-async function buildProofProposalPayload(wallet, vdfConfig = vdfTestConfig) {
+async function buildProofProposalPayload(wallet, vdfConfig = vdfTestConfig, {
+    epoch = 1,
+    previousEpochRecordHash = defaultPreviousEpochRecordHash
+} = {}) {
     const builder = new ConsensusMessageBuilder(wallet, vdfConfig);
     const protocolVersion = uint8ToBuffer(ConsensusProtocolVersion.V1);
     const networkId = uint16ToBuffer(vdfConfig.networkId);
-    const epoch = uint64ToBuffer(1);
-    const previousEpochRecordHash = b4a.alloc(32, 1);
+    const epochBuffer = uint64ToBuffer(epoch);
     const proposer = addressToBuffer(wallet.address, vdfConfig.addressPrefix);
     const vdfParametersHash = await buildVdfParametersHash(vdfConfig);
     const challengeData = createMessage(
         protocolVersion,
         networkId,
-        epoch,
+        epochBuffer,
         previousEpochRecordHash,
         proposer,
         vdfParametersHash
@@ -89,7 +117,7 @@ async function buildProofProposalPayload(wallet, vdfConfig = vdfTestConfig) {
         .setTimestamp()
         .setProtocolVersion(ConsensusProtocolVersion.V1)
         .setNetworkId(vdfConfig.networkId)
-        .setEpoch(1)
+        .setEpoch(epoch)
         .setPreviousEpochRecordHash(previousEpochRecordHash)
         .setProposer(wallet.address)
         .setVdfParametersHash(vdfParametersHash)
@@ -101,18 +129,33 @@ async function buildProofProposalPayload(wallet, vdfConfig = vdfTestConfig) {
 
 test('V1EpochProofProposalRequest validates proof proposal signature', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig);
-    const payload = await buildProofProposalPayload(wallet);
+    const genesisEpochHash = await buildGenesisEpochHash(wallet);
+    const state = createState({
+        currentEpoch: 0n,
+        currentEpochHash: genesisEpochHash
+    });
+    const getCurrentEpoch = state.getCurrentEpoch;
+    let currentEpochReads = 0;
+    state.getCurrentEpoch = async () => {
+        currentEpochReads++;
+        return await getCurrentEpoch();
+    };
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, state);
+    const payload = await buildProofProposalPayload(wallet, vdfTestConfig, {
+        epoch: 1,
+        previousEpochRecordHash: genesisEpochHash
+    });
 
     t.is(payload.proof_proposal.vdf_proof.length, VDF_BLOB_PROOF_SIZE);
     await validator.validate(payload, {remotePublicKey: wallet.publicKey});
 
+    t.is(currentEpochReads, 1);
     t.pass();
 });
 
 test('V1EpochProofProposalRequest rejects unsupported proof proposal protocol version', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig);
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
     const payload = await buildProofProposalPayload(wallet);
     const fakePayload = {
         ...payload,
@@ -130,7 +173,7 @@ test('V1EpochProofProposalRequest rejects unsupported proof proposal protocol ve
 
 test('V1EpochProofProposalRequest rejects invalid VDF parameters hash', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig);
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
     const payload = await buildProofProposalPayload(wallet);
     const fakePayload = {
         ...payload,
@@ -148,7 +191,7 @@ test('V1EpochProofProposalRequest rejects invalid VDF parameters hash', async t 
 
 test('V1EpochProofProposalRequest builds proof proposal challenge data from fields one through six', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig);
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
     const payload = await buildProofProposalPayload(wallet);
     const proofProposal = payload.proof_proposal;
     const challengeData = validator.buildProofProposalChallengeData(proofProposal);
@@ -168,7 +211,7 @@ test('V1EpochProofProposalRequest builds proof proposal challenge data from fiel
 
 test('V1EpochProofProposalRequest rejects invalid proof proposal signature', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig);
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
     const payload = await buildProofProposalPayload(wallet);
     const fakePayload = {
         ...payload,
@@ -186,7 +229,7 @@ test('V1EpochProofProposalRequest rejects invalid proof proposal signature', asy
 
 test('V1EpochProofProposalRequest rejects invalid VDF proof', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig);
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
     const payload = await buildProofProposalPayload(wallet);
     const fakeProofProposal = {
         ...payload.proof_proposal,
@@ -210,7 +253,7 @@ test('V1EpochProofProposalRequest rejects invalid VDF proof', async t => {
 
 test('V1EpochProofProposalRequest accepts proposer address matching remote public key', async t => {
     const wallet = await createWallet(testKeyPair1);
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig);
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
     const proposer = addressToBuffer(wallet.address, vdfTestConfig.addressPrefix);
 
     validator.assertAddressWithRemotePublicKey(proposer, wallet.publicKey);
@@ -221,7 +264,7 @@ test('V1EpochProofProposalRequest accepts proposer address matching remote publi
 test('V1EpochProofProposalRequest rejects proposer address mismatched with remote public key', async t => {
     const wallet = await createWallet(testKeyPair1);
     const otherWallet = await createWallet(testKeyPair2);
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig);
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
     const proposer = addressToBuffer(wallet.address, vdfTestConfig.addressPrefix);
 
     t.exception(
@@ -232,7 +275,7 @@ test('V1EpochProofProposalRequest rejects proposer address mismatched with remot
 
 test('V1EpochProofProposalRequest rejects invalid proposer address as protocol error', async t => {
     const wallet = await createWallet(testKeyPair1);
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig);
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
     const invalidProposer = b4a.alloc(vdfTestConfig.addressLength, 1);
 
     try {
@@ -247,7 +290,7 @@ test('V1EpochProofProposalRequest rejects invalid proposer address as protocol e
 
 test('V1EpochProofProposalRequest rejects invalid proof proposal network id', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig);
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
     const payload = await buildProofProposalPayload(wallet);
     const fakeNetworkId = vdfTestConfig.networkId === 1 ? 2 : 1;
     const fakePayload = {
@@ -262,4 +305,64 @@ test('V1EpochProofProposalRequest rejects invalid proof proposal network id', as
         async () => validator.validate(fakePayload, {remotePublicKey: wallet.publicKey}),
         errorMessageIncludes('Invalid proof proposal network id')
     );
+});
+
+test('V1EpochProofProposalRequest rejects proof proposal epoch that is not next epoch', async t => {
+    const wallet = await createWallet();
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState({currentEpoch: 0n}));
+    const payload = await buildProofProposalPayload(wallet, vdfTestConfig, {epoch: 2});
+
+    try {
+        await validator.validate(payload, {remotePublicKey: wallet.publicKey});
+        t.fail('should reject');
+    } catch (error) {
+        t.ok(error instanceof V1ConsensusProtocolError);
+        t.is(error.resultCode, ConsensusResultCode.UNEXPECTED_ERROR);
+        t.is(error.message, 'Unexpected epoch. Proof proposal must be 1 but got 2');
+    }
+});
+
+test('V1EpochProofProposalRequest rejects previous epoch record hash mismatch', async t => {
+    const wallet = await createWallet();
+    const expectedHash = await buildGenesisEpochHash(wallet);
+    const payloadHash = b4a.alloc(32, 2);
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState({
+        currentEpoch: 0n,
+        currentEpochHash: expectedHash
+    }));
+    const payload = await buildProofProposalPayload(wallet, vdfTestConfig, {
+        previousEpochRecordHash: payloadHash
+    });
+    const expectedMessage = `Previous epoch record hash mismatch for epoch 0: expected ${expectedHash.toString('hex')}, got ${payloadHash.toString('hex')}`;
+
+    try {
+        await validator.validate(payload, {remotePublicKey: wallet.publicKey});
+        t.fail('should reject');
+    } catch (error) {
+        t.ok(error instanceof V1ConsensusProtocolError);
+        t.is(error.resultCode, ConsensusResultCode.UNEXPECTED_ERROR);
+        t.is(error.message, expectedMessage);
+    }
+});
+
+test('V1EpochProofProposalRequest wraps state failures as protocol errors', async t => {
+    const wallet = await createWallet();
+    const stateError = new Error('State storage is unavailable.');
+    const validator = new V1EpochProofProposalRequest(vdfTestConfig, {
+        ...createState(),
+        getCurrentEpoch: async () => {
+            throw stateError;
+        }
+    });
+    const payload = await buildProofProposalPayload(wallet);
+
+    try {
+        await validator.validate(payload, {remotePublicKey: wallet.publicKey});
+        t.fail('should reject');
+    } catch (error) {
+        t.ok(error instanceof V1ConsensusProtocolError);
+        t.is(error.resultCode, ConsensusResultCode.UNEXPECTED_ERROR);
+        t.is(error.message, 'State storage is unavailable.');
+        t.is(error.cause, stateError);
+    }
 });

--- a/tests/unit/consensus/V1EpochProofProposalRequest.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalRequest.test.js
@@ -29,12 +29,9 @@ import {config} from '../../helpers/config.js';
 import {testKeyPair1, testKeyPair2} from '../../fixtures/apply.fixtures.js';
 import {errorMessageIncludes} from '../../helpers/regexHelper.js';
 
-const vdfTestConfig = new Proxy(config, {
-    get(target, property) {
-        if (property === 'vdfDifficulty') return 1;
-        if (property === 'vdfDiscriminantSizeBits') return 2048;
-        return target[property];
-    }
+const TEST_VDF_PARAMS = Object.freeze({
+    vdfDifficulty: 1,
+    vdfDiscriminantSize: 2048
 });
 const vdfProofCache = new Map();
 const defaultPreviousEpochRecordHash = b4a.alloc(32, 1);
@@ -42,8 +39,8 @@ const defaultPreviousEpochRecordHash = b4a.alloc(32, 1);
 function createState({
     currentEpoch = 0n,
     currentEpochHash = defaultPreviousEpochRecordHash,
-    vdfDifficulty = vdfTestConfig.vdfDifficulty,
-    vdfDiscriminantSize = vdfTestConfig.vdfDiscriminantSizeBits
+    vdfDifficulty = TEST_VDF_PARAMS.vdfDifficulty,
+    vdfDiscriminantSize = TEST_VDF_PARAMS.vdfDiscriminantSize
 } = {}) {
     return {
         getCurrentEpoch: async () => currentEpoch,
@@ -60,53 +57,54 @@ async function createWallet(keyPair = testKeyPair1) {
     return await new WalletProvider(config).fromSecretKey(keyPair.secretKey);
 }
 
-async function buildGenesisEpochHash(wallet, vdfConfig = vdfTestConfig) {
+async function buildGenesisEpochHash(wallet, vdfParams = TEST_VDF_PARAMS) {
     const vdfParamsEntry = encodeVdfParameters(
-        uint32ToBuffer(vdfConfig.vdfDifficulty),
-        uint16ToBuffer(vdfConfig.vdfDiscriminantSizeBits)
+        uint32ToBuffer(vdfParams.vdfDifficulty),
+        uint16ToBuffer(vdfParams.vdfDiscriminantSize)
     );
-    const genesisEpoch = await createGenesisEpochProof(vdfConfig, wallet.address, vdfParamsEntry);
+    const genesisEpoch = await createGenesisEpochProof(config, wallet.address, vdfParamsEntry);
 
     return await tracCryptoApi.hash.blake3(genesisEpoch);
 }
 
-async function buildVdfParametersHash(vdfConfig = vdfTestConfig) {
+async function buildVdfParametersHash(vdfParams = TEST_VDF_PARAMS) {
     const message = createMessage(
-        uint32ToBuffer(vdfConfig.vdfDifficulty),
-        uint16ToBuffer(vdfConfig.vdfDiscriminantSizeBits)
+        uint32ToBuffer(vdfParams.vdfDifficulty),
+        uint16ToBuffer(vdfParams.vdfDiscriminantSize)
     );
 
     return await tracCryptoApi.hash.blake3(message);
 }
 
-async function buildVdfProof(challengeData, vdfConfig = vdfTestConfig) {
+async function buildVdfProof(challengeData, vdfParams = TEST_VDF_PARAMS) {
     const cacheKey = [
-        vdfConfig.vdfDifficulty,
-        vdfConfig.vdfDiscriminantSizeBits,
+        vdfParams.vdfDifficulty,
+        vdfParams.vdfDiscriminantSize,
         b4a.toString(challengeData, 'hex')
     ].join(':');
 
     if (!vdfProofCache.has(cacheKey)) {
         vdfProofCache.set(cacheKey, await solveWesolowski(
             challengeData,
-            vdfConfig.vdfDifficulty,
-            vdfConfig.vdfDiscriminantSizeBits
+            vdfParams.vdfDifficulty,
+            vdfParams.vdfDiscriminantSize
         ));
     }
 
     return b4a.from(vdfProofCache.get(cacheKey));
 }
 
-async function buildProofProposalPayload(wallet, vdfConfig = vdfTestConfig, {
+async function buildProofProposalPayload(wallet, {
     epoch = 1,
-    previousEpochRecordHash = defaultPreviousEpochRecordHash
+    previousEpochRecordHash = defaultPreviousEpochRecordHash,
+    vdfParams = TEST_VDF_PARAMS
 } = {}) {
-    const builder = new ConsensusMessageBuilder(wallet, vdfConfig);
+    const builder = new ConsensusMessageBuilder(wallet, config);
     const protocolVersion = uint8ToBuffer(ConsensusProtocolVersion.V1);
-    const networkId = uint16ToBuffer(vdfConfig.networkId);
+    const networkId = uint16ToBuffer(config.networkId);
     const epochBuffer = uint64ToBuffer(epoch);
-    const proposer = addressToBuffer(wallet.address, vdfConfig.addressPrefix);
-    const vdfParametersHash = await buildVdfParametersHash(vdfConfig);
+    const proposer = addressToBuffer(wallet.address, config.addressPrefix);
+    const vdfParametersHash = await buildVdfParametersHash(vdfParams);
     const challengeData = createMessage(
         protocolVersion,
         networkId,
@@ -115,14 +113,14 @@ async function buildProofProposalPayload(wallet, vdfConfig = vdfTestConfig, {
         proposer,
         vdfParametersHash
     );
-    const vdfProof = await buildVdfProof(challengeData, vdfConfig);
+    const vdfProof = await buildVdfProof(challengeData, vdfParams);
 
     await builder
         .setType(ConsensusOperationType.PROOF_PROPOSAL)
         .setSessionId('session')
         .setTimestamp()
         .setProtocolVersion(ConsensusProtocolVersion.V1)
-        .setNetworkId(vdfConfig.networkId)
+        .setNetworkId(config.networkId)
         .setEpoch(epoch)
         .setPreviousEpochRecordHash(previousEpochRecordHash)
         .setProposer(wallet.address)
@@ -152,8 +150,8 @@ test('V1EpochProofProposalRequest validates proof proposal signature', async t =
         vdfParamsReads++;
         return await getSignedVDFParams();
     };
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, state);
-    const payload = await buildProofProposalPayload(wallet, vdfTestConfig, {
+    const validator = new V1EpochProofProposalRequest(config, state);
+    const payload = await buildProofProposalPayload(wallet, {
         epoch: 1,
         previousEpochRecordHash: genesisEpochHash
     });
@@ -168,7 +166,7 @@ test('V1EpochProofProposalRequest validates proof proposal signature', async t =
 
 test('V1EpochProofProposalRequest rejects unsupported proof proposal protocol version', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
+    const validator = new V1EpochProofProposalRequest(config, createState());
     const payload = await buildProofProposalPayload(wallet);
     const fakePayload = {
         ...payload,
@@ -186,7 +184,7 @@ test('V1EpochProofProposalRequest rejects unsupported proof proposal protocol ve
 
 test('V1EpochProofProposalRequest rejects invalid VDF parameters hash', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
+    const validator = new V1EpochProofProposalRequest(config, createState());
     const payload = await buildProofProposalPayload(wallet);
     const fakePayload = {
         ...payload,
@@ -204,7 +202,7 @@ test('V1EpochProofProposalRequest rejects invalid VDF parameters hash', async t 
 
 test('V1EpochProofProposalRequest builds proof proposal challenge data from fields one through six', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
+    const validator = new V1EpochProofProposalRequest(config, createState());
     const payload = await buildProofProposalPayload(wallet);
     const proofProposal = payload.proof_proposal;
     const challengeData = validator.buildProofProposalChallengeData(proofProposal);
@@ -224,7 +222,7 @@ test('V1EpochProofProposalRequest builds proof proposal challenge data from fiel
 
 test('V1EpochProofProposalRequest rejects invalid proof proposal signature', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
+    const validator = new V1EpochProofProposalRequest(config, createState());
     const payload = await buildProofProposalPayload(wallet);
     const fakePayload = {
         ...payload,
@@ -242,7 +240,7 @@ test('V1EpochProofProposalRequest rejects invalid proof proposal signature', asy
 
 test('V1EpochProofProposalRequest rejects invalid VDF proof', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
+    const validator = new V1EpochProofProposalRequest(config, createState());
     const payload = await buildProofProposalPayload(wallet);
     const fakeProofProposal = {
         ...payload.proof_proposal,
@@ -266,8 +264,8 @@ test('V1EpochProofProposalRequest rejects invalid VDF proof', async t => {
 
 test('V1EpochProofProposalRequest accepts proposer address matching remote public key', async t => {
     const wallet = await createWallet(testKeyPair1);
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
-    const proposer = addressToBuffer(wallet.address, vdfTestConfig.addressPrefix);
+    const validator = new V1EpochProofProposalRequest(config, createState());
+    const proposer = addressToBuffer(wallet.address, config.addressPrefix);
 
     validator.assertAddressWithRemotePublicKey(proposer, wallet.publicKey);
 
@@ -277,8 +275,8 @@ test('V1EpochProofProposalRequest accepts proposer address matching remote publi
 test('V1EpochProofProposalRequest rejects proposer address mismatched with remote public key', async t => {
     const wallet = await createWallet(testKeyPair1);
     const otherWallet = await createWallet(testKeyPair2);
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
-    const proposer = addressToBuffer(wallet.address, vdfTestConfig.addressPrefix);
+    const validator = new V1EpochProofProposalRequest(config, createState());
+    const proposer = addressToBuffer(wallet.address, config.addressPrefix);
 
     t.exception(
         () => validator.assertAddressWithRemotePublicKey(proposer, otherWallet.publicKey),
@@ -288,8 +286,8 @@ test('V1EpochProofProposalRequest rejects proposer address mismatched with remot
 
 test('V1EpochProofProposalRequest rejects invalid proposer address as protocol error', async t => {
     const wallet = await createWallet(testKeyPair1);
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
-    const invalidProposer = b4a.alloc(vdfTestConfig.addressLength, 1);
+    const validator = new V1EpochProofProposalRequest(config, createState());
+    const invalidProposer = b4a.alloc(config.addressLength, 1);
 
     try {
         validator.assertAddressWithRemotePublicKey(invalidProposer, wallet.publicKey);
@@ -303,9 +301,9 @@ test('V1EpochProofProposalRequest rejects invalid proposer address as protocol e
 
 test('V1EpochProofProposalRequest rejects invalid proof proposal network id', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState());
+    const validator = new V1EpochProofProposalRequest(config, createState());
     const payload = await buildProofProposalPayload(wallet);
-    const fakeNetworkId = vdfTestConfig.networkId === 1 ? 2 : 1;
+    const fakeNetworkId = config.networkId === 1 ? 2 : 1;
     const fakePayload = {
         ...payload,
         proof_proposal: {
@@ -322,8 +320,8 @@ test('V1EpochProofProposalRequest rejects invalid proof proposal network id', as
 
 test('V1EpochProofProposalRequest rejects proof proposal epoch that is not next epoch', async t => {
     const wallet = await createWallet();
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState({currentEpoch: 0n}));
-    const payload = await buildProofProposalPayload(wallet, vdfTestConfig, {epoch: 2});
+    const validator = new V1EpochProofProposalRequest(config, createState({currentEpoch: 0n}));
+    const payload = await buildProofProposalPayload(wallet, {epoch: 2});
 
     try {
         await validator.validate(payload, {remotePublicKey: wallet.publicKey});
@@ -339,11 +337,11 @@ test('V1EpochProofProposalRequest rejects previous epoch record hash mismatch', 
     const wallet = await createWallet();
     const expectedHash = await buildGenesisEpochHash(wallet);
     const payloadHash = b4a.alloc(32, 2);
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, createState({
+    const validator = new V1EpochProofProposalRequest(config, createState({
         currentEpoch: 0n,
         currentEpochHash: expectedHash
     }));
-    const payload = await buildProofProposalPayload(wallet, vdfTestConfig, {
+    const payload = await buildProofProposalPayload(wallet, {
         previousEpochRecordHash: payloadHash
     });
     const expectedMessage = `Previous epoch record hash mismatch for epoch 0: expected ${expectedHash.toString('hex')}, got ${payloadHash.toString('hex')}`;
@@ -361,7 +359,7 @@ test('V1EpochProofProposalRequest rejects previous epoch record hash mismatch', 
 test('V1EpochProofProposalRequest wraps state failures as protocol errors', async t => {
     const wallet = await createWallet();
     const stateError = new Error('State storage is unavailable.');
-    const validator = new V1EpochProofProposalRequest(vdfTestConfig, {
+    const validator = new V1EpochProofProposalRequest(config, {
         ...createState(),
         getCurrentEpoch: async () => {
             throw stateError;

--- a/tests/unit/consensus/V1EpochProofProposalRequest.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalRequest.test.js
@@ -37,7 +37,7 @@ const TEST_VDF_PARAMS = Object.freeze({
 const vdfProofCache = new Map();
 const defaultPreviousEpochRecordHash = b4a.alloc(32, 1);
 
-test('V1BaseConsensusOperation stringifies non-Error failures', async t => {
+test('V1BaseConsensusOperation normalizes non-Error failures', async t => {
     const thrownValue = {reason: 'state unavailable'};
     const validator = new V1BaseConsensusOperation(config, {});
 
@@ -49,8 +49,9 @@ test('V1BaseConsensusOperation stringifies non-Error failures', async t => {
     } catch (error) {
         t.ok(error instanceof V1ConsensusProtocolError);
         t.is(error.resultCode, ConsensusResultCode.UNEXPECTED_ERROR);
-        t.is(error.message, String(thrownValue));
-        t.is(error.cause, thrownValue);
+        t.is(error.message, 'Validation threw a non-Error value.');
+        t.ok(error.cause instanceof TypeError);
+        t.is(error.cause.cause, thrownValue);
     }
 });
 

--- a/tests/unit/consensus/V1EpochProofProposalRequest.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalRequest.test.js
@@ -204,12 +204,17 @@ test('V1EpochProofProposalRequest rejects invalid VDF parameters hash', async t 
     const wallet = await createWallet();
     const validator = new V1EpochProofProposalRequest(config, createState());
     const payload = await buildProofProposalPayload(wallet);
+    const fakeProofProposal = {
+        ...payload.proof_proposal,
+        vdf_parameters_hash: b4a.alloc(32, 9)
+    };
+    const challengeData = validator.buildProofProposalChallengeData(fakeProofProposal);
+    const signatureMessage = createMessage(challengeData, fakeProofProposal.vdf_proof);
+    const signatureHash = await tracCryptoApi.hash.blake3(signatureMessage);
+    fakeProofProposal.signature = wallet.sign(signatureHash);
     const fakePayload = {
         ...payload,
-        proof_proposal: {
-            ...payload.proof_proposal,
-            vdf_parameters_hash: b4a.alloc(32, 9)
-        }
+        proof_proposal: fakeProofProposal
     };
 
     await t.exception(

--- a/tests/unit/consensus/V1EpochProofProposalRequest.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalRequest.test.js
@@ -5,7 +5,6 @@ import tracCryptoApi from 'trac-crypto-api';
 import {solveWesolowski} from '@tracsystems/trac-vdf';
 
 import ConsensusMessageBuilder from '../../../src/messages/consensus/v1/ConsensusMessageBuilder.js';
-import V1BaseConsensusOperation from '../../../src/core/consensus/v1/validators/V1BaseConsensusOperation.js';
 import V1EpochProofProposalRequest from '../../../src/core/consensus/v1/validators/V1EpochProofProposalRequest.js';
 import {V1ConsensusProtocolError} from '../../../src/core/consensus/v1/V1ConsensusProtocolError.js';
 import {addressToBuffer} from '../../../src/core/state/utils/address.js';
@@ -36,24 +35,6 @@ const TEST_VDF_PARAMS = Object.freeze({
 });
 const vdfProofCache = new Map();
 const defaultPreviousEpochRecordHash = b4a.alloc(32, 1);
-
-test('V1BaseConsensusOperation normalizes non-Error failures', async t => {
-    const thrownValue = {reason: 'state unavailable'};
-    const validator = new V1BaseConsensusOperation(config, {});
-
-    try {
-        await validator.validateAsProtocolError(() => {
-            throw thrownValue;
-        });
-        t.fail('should reject');
-    } catch (error) {
-        t.ok(error instanceof V1ConsensusProtocolError);
-        t.is(error.resultCode, ConsensusResultCode.UNEXPECTED_ERROR);
-        t.is(error.message, 'Validation threw a non-Error value.');
-        t.ok(error.cause instanceof TypeError);
-        t.is(error.cause.cause, thrownValue);
-    }
-});
 
 function createState({
     currentEpoch = 0n,

--- a/tests/unit/consensus/V1EpochProofProposalRequest.test.js
+++ b/tests/unit/consensus/V1EpochProofProposalRequest.test.js
@@ -41,11 +41,17 @@ const defaultPreviousEpochRecordHash = b4a.alloc(32, 1);
 
 function createState({
     currentEpoch = 0n,
-    currentEpochHash = defaultPreviousEpochRecordHash
+    currentEpochHash = defaultPreviousEpochRecordHash,
+    vdfDifficulty = vdfTestConfig.vdfDifficulty,
+    vdfDiscriminantSize = vdfTestConfig.vdfDiscriminantSizeBits
 } = {}) {
     return {
         getCurrentEpoch: async () => currentEpoch,
         getEpoch: async () => currentEpochHash,
+        getSignedVDFParams: async () => ({
+            vdfDifficulty,
+            vdfDiscriminantSize
+        }),
         isIndexerAddress: async () => true
     };
 }
@@ -135,10 +141,16 @@ test('V1EpochProofProposalRequest validates proof proposal signature', async t =
         currentEpochHash: genesisEpochHash
     });
     const getCurrentEpoch = state.getCurrentEpoch;
+    const getSignedVDFParams = state.getSignedVDFParams;
     let currentEpochReads = 0;
+    let vdfParamsReads = 0;
     state.getCurrentEpoch = async () => {
         currentEpochReads++;
         return await getCurrentEpoch();
+    };
+    state.getSignedVDFParams = async () => {
+        vdfParamsReads++;
+        return await getSignedVDFParams();
     };
     const validator = new V1EpochProofProposalRequest(vdfTestConfig, state);
     const payload = await buildProofProposalPayload(wallet, vdfTestConfig, {
@@ -150,6 +162,7 @@ test('V1EpochProofProposalRequest validates proof proposal signature', async t =
     await validator.validate(payload, {remotePublicKey: wallet.publicKey});
 
     t.is(currentEpochReads, 1);
+    t.is(vdfParamsReads, 1);
     t.pass();
 });
 

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -37,6 +37,10 @@ async function loadMainSettlementBus() {
             this.getNodeEntry = sinon.stub().resolves(null);
             this.getSigned = sinon.stub().resolves(null);
             this.getSignedVDFParams = sinon.stub().resolves(null);
+            this.requireSignedVDFParams = sinon.stub().resolves({
+                vdfDifficulty: 55_000_000,
+                vdfDiscriminantSize: 2048,
+            });
             this.getIndexerSequenceState = sinon.stub().resolves(b4a.from('11'.repeat(32), 'hex'));
             this.append = sinon.stub().resolves();
             this.isWritable = sinon.stub().returns(false);
@@ -162,7 +166,7 @@ if (isBareRuntime) {
             vdfDiscriminantSize: '2048',
         });
 
-        t.ok(loaded.state.getSigned.calledOnce);
+        t.ok(loaded.state.getSignedVDFParams.calledOnce);
         t.ok(loaded.state.getIndexerSequenceState.calledOnce);
         t.ok(loaded.state.append.calledOnce);
 
@@ -215,7 +219,7 @@ if (isBareRuntime) {
             errorMessageIncludes('admin has not been initialized')
         );
 
-        t.ok(loaded.state.getSigned.notCalled);
+        t.ok(loaded.state.getSignedVDFParams.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -241,7 +245,7 @@ if (isBareRuntime) {
             errorMessageIncludes('wallet is not initialized')
         );
 
-        t.ok(loaded.state.getSigned.notCalled);
+        t.ok(loaded.state.getSignedVDFParams.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -270,7 +274,7 @@ if (isBareRuntime) {
             errorMessageIncludes('you are not the admin')
         );
 
-        t.ok(loaded.state.getSigned.notCalled);
+        t.ok(loaded.state.getSignedVDFParams.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -299,7 +303,7 @@ if (isBareRuntime) {
             errorMessageIncludes('you are not the admin')
         );
 
-        t.ok(loaded.state.getSigned.notCalled);
+        t.ok(loaded.state.getSignedVDFParams.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -317,7 +321,7 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSigned.resolves(null);
+        loaded.state.getSignedVDFParams.resolves(null);
 
         await t.exception(
             () => msb.handleEpochGenesisInitialization({
@@ -345,7 +349,7 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSigned.resolves(null);
+        loaded.state.getSignedVDFParams.resolves(null);
 
         await t.exception(
             () => msb.handleEpochGenesisInitialization({
@@ -373,7 +377,10 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSigned.resolves(b4a.alloc(6, 1));
+        loaded.state.getSignedVDFParams.resolves({
+            vdfDifficulty: 16_843_009,
+            vdfDiscriminantSize: 257,
+        });
 
         await t.exception(
             () => msb.handleEpochGenesisInitialization({
@@ -402,7 +409,7 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSignedVDFParams.resolves({
+        loaded.state.requireSignedVDFParams.resolves({
             vdfDifficulty: 55000000,
             vdfDiscriminantSize: 2048,
         });
@@ -412,7 +419,7 @@ if (isBareRuntime) {
             vdfDifficulty: '60000000',
         });
 
-        t.ok(loaded.state.getSignedVDFParams.calledOnce);
+        t.ok(loaded.state.requireSignedVDFParams.calledOnce);
         t.ok(loaded.state.getIndexerSequenceState.calledOnce);
         t.ok(loaded.state.append.calledOnce);
 
@@ -462,7 +469,7 @@ if (isBareRuntime) {
             errorMessageIncludes('admin has not been initialized')
         );
 
-        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.requireSignedVDFParams.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -490,7 +497,7 @@ if (isBareRuntime) {
             errorMessageIncludes('you are not the admin')
         );
 
-        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.requireSignedVDFParams.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -508,7 +515,7 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSignedVDFParams.rejects(
+        loaded.state.requireSignedVDFParams.rejects(
             new Error('VDF parameters are not initialized.')
         );
 
@@ -537,7 +544,7 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSignedVDFParams.resolves({
+        loaded.state.requireSignedVDFParams.resolves({
             vdfDifficulty: 55000000,
             vdfDiscriminantSize: 2048,
         });

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -35,6 +35,7 @@ async function loadMainSettlementBus() {
             this.close = sinon.stub().resolves();
             this.getAdminEntry = sinon.stub().resolves(null);
             this.getNodeEntry = sinon.stub().resolves(null);
+            this.getSigned = sinon.stub().resolves(null);
             this.getSignedVDFParams = sinon.stub().resolves(null);
             this.getIndexerSequenceState = sinon.stub().resolves(b4a.from('11'.repeat(32), 'hex'));
             this.append = sinon.stub().resolves();
@@ -153,7 +154,7 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSignedVDFParams.resolves(null);
+        loaded.state.getSigned.resolves(null);
         loaded.state.getIndexerSequenceState.resolves(txValidity);
 
         await msb.handleEpochGenesisInitialization({
@@ -161,7 +162,7 @@ if (isBareRuntime) {
             vdfDiscriminantSize: '2048',
         });
 
-        t.ok(loaded.state.getSignedVDFParams.calledOnce);
+        t.ok(loaded.state.getSigned.calledOnce);
         t.ok(loaded.state.getIndexerSequenceState.calledOnce);
         t.ok(loaded.state.append.calledOnce);
 
@@ -214,7 +215,7 @@ if (isBareRuntime) {
             errorMessageIncludes('admin has not been initialized')
         );
 
-        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.getSigned.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -240,7 +241,7 @@ if (isBareRuntime) {
             errorMessageIncludes('wallet is not initialized')
         );
 
-        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.getSigned.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -269,7 +270,7 @@ if (isBareRuntime) {
             errorMessageIncludes('you are not the admin')
         );
 
-        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.getSigned.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -298,7 +299,7 @@ if (isBareRuntime) {
             errorMessageIncludes('you are not the admin')
         );
 
-        t.ok(loaded.state.getSignedVDFParams.notCalled);
+        t.ok(loaded.state.getSigned.notCalled);
         t.ok(loaded.state.append.notCalled);
 
         await msb.close();
@@ -316,7 +317,7 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSignedVDFParams.resolves(null);
+        loaded.state.getSigned.resolves(null);
 
         await t.exception(
             () => msb.handleEpochGenesisInitialization({
@@ -344,7 +345,7 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSignedVDFParams.resolves(null);
+        loaded.state.getSigned.resolves(null);
 
         await t.exception(
             () => msb.handleEpochGenesisInitialization({
@@ -372,10 +373,7 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSignedVDFParams.resolves({
-            vdfDifficulty: 55000000,
-            vdfDiscriminantSize: 2048,
-        });
+        loaded.state.getSigned.resolves(b4a.alloc(6, 1));
 
         await t.exception(
             () => msb.handleEpochGenesisInitialization({

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -510,13 +510,15 @@ if (isBareRuntime) {
         await msb.ready();
 
         loaded.state.getAdminEntry.resolves(adminEntryFor(wallet, loaded.state));
-        loaded.state.getSignedVDFParams.resolves(null);
+        loaded.state.getSignedVDFParams.rejects(
+            new Error('VDF parameters are not initialized.')
+        );
 
         await t.exception(
             () => msb.handleSetVdfParams({
                 vdfDifficulty: '60000000',
             }),
-            errorMessageIncludes('VDF parameters have not been initialized')
+            errorMessageIncludes('VDF parameters are not initialized.')
         );
 
         t.ok(loaded.state.getIndexerSequenceState.notCalled);

--- a/tests/unit/state/vdfParams.test.js
+++ b/tests/unit/state/vdfParams.test.js
@@ -25,10 +25,13 @@ async function createStateWithSignedValue(value) {
     return new State(null, null, config);
 }
 
-test('State#getSignedVDFParams returns null when params are missing', async t => {
+test('State#getSignedVDFParams rejects when params are missing', async t => {
     const state = await createStateWithSignedValue(undefined);
 
-    t.is(await state.getSignedVDFParams(), null);
+    await t.exception(
+        () => state.getSignedVDFParams(),
+        errorMessageIncludes('VDF parameters are not initialized.')
+    );
 });
 
 test('State#getSignedVDFParams decodes stored VDF params', async t => {

--- a/tests/unit/state/vdfParams.test.js
+++ b/tests/unit/state/vdfParams.test.js
@@ -25,11 +25,17 @@ async function createStateWithSignedValue(value) {
     return new State(null, null, config);
 }
 
-test('State#getSignedVDFParams rejects when params are missing', async t => {
+test('State#getSignedVDFParams returns null when params are missing', async t => {
+    const state = await createStateWithSignedValue(undefined);
+
+    t.is(await state.getSignedVDFParams(), null);
+});
+
+test('State#requireSignedVDFParams rejects when params are missing', async t => {
     const state = await createStateWithSignedValue(undefined);
 
     await t.exception(
-        () => state.getSignedVDFParams(),
+        () => state.requireSignedVDFParams(),
         errorMessageIncludes('VDF parameters are not initialized.')
     );
 });
@@ -41,6 +47,18 @@ test('State#getSignedVDFParams decodes stored VDF params', async t => {
     const state = await createStateWithSignedValue(vdfParams);
 
     t.alike(await state.getSignedVDFParams(), {
+        vdfDifficulty: 55_000_000,
+        vdfDiscriminantSize: 2048,
+    });
+});
+
+test('State#requireSignedVDFParams returns decoded stored VDF params', async t => {
+    const vdfParams = b4a.alloc(6);
+    vdfParams.writeUInt32BE(55_000_000, 0);
+    vdfParams.writeUInt16BE(2048, 4);
+    const state = await createStateWithSignedValue(vdfParams);
+
+    t.alike(await state.requireSignedVDFParams(), {
         vdfDifficulty: 55_000_000,
         vdfDiscriminantSize: 2048,
     });


### PR DESCRIPTION
## Summary

- Added missing proof proposal validations for epoch, previous epoch hash, and indexer membership.
- Sourced VDF parameters from signed state to keep consensus nodes consistent.
- Added a shared error boundary to normalize unexpected failures into protocol errors.
- Made missing epoch and VDF state fail explicitly instead of returning null.
- Removed obsolete VDF parameters from local configuration.
- Updated protocol documentation and expanded unit test coverage.