### PR TITLE
feat: implement apply handler for set vdf params

### DIFF
--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -642,6 +642,7 @@ class State extends ReadyResource {
             [OperationType.TRANSFER]: this.#handleApplyTransferOperation.bind(this),
             [OperationType.SET_EPOCH]: this.#handleApplySetEpochOperation.bind(this),
             [OperationType.SET_GENESIS_EPOCH]: this.#handleApplySetGenesisEpoch.bind(this),
+            [OperationType.SET_VDF_PARAMS]: this.#handleApplySetVdfParams.bind(this),
         };
         return handlers[type] || null;
     }
@@ -4238,6 +4239,130 @@ class State extends ReadyResource {
 
         if (this.#config.enableTxApplyLogs) {
             console.info(`Genesis Epoch initialized addr:wk:tx - ${requesterAddressString}:${decodedAdminEntry.wk.toString('hex')}:${txHashHexString}`);
+        }
+
+        return Status.SUCCESS;
+    }
+
+    async #handleApplySetVdfParams(op, _view, base, node, batch) {
+        if (!this.#stateValidationSchema.validateSetVdfParamsOperation(op)) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Contract schema validation failed.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const requesterAddressString = addressUtils.bufferToAddress(op.address, this.#config.addressPrefix);
+        if (requesterAddressString === null) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Requester address is invalid.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const requesterPublicKey = tracCryptoApi.address.decodeSafe(requesterAddressString);
+        if (b4a.equals(requesterPublicKey, NULL_BUFFER)) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Failed to decode requester public key.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const adminEntry = await this.#getEntryApply(EntryType.ADMIN, batch);
+        if (adminEntry === null) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Invalid admin entry.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const decodedAdminEntry = adminEntryUtils.decode(adminEntry, this.#config.addressPrefix);
+        if (decodedAdminEntry === null) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Failed to decode admin entry.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        if (!this.#isAdminApply(decodedAdminEntry, node)) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Node is not allowed to perform this operation. (ADMIN ONLY)", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const adminPublicKey = tracCryptoApi.address.decodeSafe(decodedAdminEntry.address);
+        if (b4a.equals(adminPublicKey, NULL_BUFFER)) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Failed to decode admin public key.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        if (!b4a.equals(adminPublicKey, requesterPublicKey)) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "System admin and node public keys do not match.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const message = createMessage(
+            this.#config.networkId,
+            op.vpo.txv,
+            op.vpo.df,
+            op.vpo.in,
+            OperationType.SET_VDF_PARAMS
+        );
+        if (message.length === 0) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Invalid requester message.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const hash = await tracCryptoApi.hash.blake3Safe(message);
+        if (!b4a.equals(hash, op.vpo.tx)) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Message hash does not match the tx_hash.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const isMessageVerified = tracCryptoApi.signature.verify(op.vpo.is, op.vpo.tx, adminPublicKey);
+        if (!isMessageVerified) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Failed to verify message signature.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const indexersSequenceState = await this.#getIndexerSequenceStateApply(base);
+        if (indexersSequenceState === null) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Indexer sequence state is invalid.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        if (!b4a.equals(op.vpo.txv, indexersSequenceState)) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Transaction was not executed.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const txHashHexString = op.vpo.tx.toString('hex');
+        const opEntry = await this.#getEntryApply(txHashHexString, batch);
+        if (opEntry !== null) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Operation has already been applied.", node.from.key)
+            return Status.IGNORE;
+        }
+
+        const existingVdfParams = await this.#getEntryApply(EntryType.VDF_PARAMS, batch);
+        if (existingVdfParams === null) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "VDF params have not been initialized.", node.from.key)
+            return Status.IGNORE;
+        }
+
+        const decodedVdfParams = decodeVdfParameters(existingVdfParams);
+        if (decodedVdfParams === null) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Stored VDF params are invalid.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        if (op.vpo.df.readUInt32BE(0) === 0) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "VDF difficulty must be greater than zero.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        const encodedVdfParams = encodeVdfParameters(
+            op.vpo.df,
+            decodedVdfParams.discriminantBitSize
+        );
+        if (encodedVdfParams.length === 0) {
+            this.#safeLogApply(OperationType.SET_VDF_PARAMS, "Could not encode VDF parameters.", node.from.key)
+            return Status.FAILURE;
+        }
+
+        await batch.put(EntryType.VDF_PARAMS, encodedVdfParams);
+        await batch.put(txHashHexString, node.value);
+
+        if (this.#config.enableTxApplyLogs) {
+            console.info(`VDF params updated addr:wk:tx - ${requesterAddressString}:${decodedAdminEntry.wk.toString('hex')}:${txHashHexString}`);
         }
 
         return Status.SUCCESS;

--- a/tests/unit/state/apply/setVdfParams/setVdfParamsScenarioHelpers.js
+++ b/tests/unit/state/apply/setVdfParams/setVdfParamsScenarioHelpers.js
@@ -1,0 +1,121 @@
+import b4a from 'b4a';
+import { setupStateNetwork } from '../../../../helpers/StateNetworkFactory.js';
+import {
+    defaultOpenHyperbeeView,
+    deriveIndexerSequenceState,
+    eventFlush,
+    seedBootstrapIndexer
+} from '../../../../helpers/autobaseTestHelpers.js';
+import { applyStateMessageFactory } from '../../../../../src/messages/state/applyStateMessageFactory.js';
+import {
+    safeDecodeApplyOperation,
+    safeEncodeApplyOperation
+} from '../../../../../src/codecs/apply/applyOperationCodec.js';
+import { decodeVdfParameters } from '../../../../../src/core/state/utils/epochProof.js';
+import {
+    AUTOBASE_VALUE_ENCODING,
+    EntryType
+} from '../../../../../src/utils/constants.js';
+import { uint16ToBuffer, uint32ToBuffer } from '../../../../../src/utils/buffer.js';
+import { config } from '../../../../helpers/config.js';
+import { buildAddAdminRequesterPayload } from '../addAdmin/addAdminScenarioHelpers.js';
+
+export const INITIAL_VDF_DIFFICULTY = 55_000_000;
+export const INITIAL_VDF_DISCRIMINANT_SIZE = 2048;
+export const UPDATED_VDF_DIFFICULTY = 60_000_000;
+
+export async function setupSetVdfParamsScenario(t, { initializeGenesis = true } = {}) {
+    const context = await setupStateNetwork({
+        nodes: 2,
+        valueEncoding: AUTOBASE_VALUE_ENCODING,
+        open: defaultOpenHyperbeeView
+    });
+
+    seedBootstrapIndexer(context);
+    t.teardown(async () => context.teardown());
+
+    await appendAndUpdate(context.adminBootstrap.base, await buildAddAdminRequesterPayload(context));
+    if (initializeGenesis) {
+        await initializeGenesisEpoch(context);
+    }
+
+    return context;
+}
+
+export async function buildSetVdfParamsPayload(
+    context,
+    difficulty = UPDATED_VDF_DIFFICULTY,
+    wallet = context.adminBootstrap.wallet
+) {
+    const txValidity = await deriveIndexerSequenceState(context.adminBootstrap.base);
+    const payload = await applyStateMessageFactory(wallet, config)
+        .buildCompleteSetVdfParamsMessage(
+            wallet.address,
+            txValidity,
+            uint32ToBuffer(difficulty)
+        );
+
+    return safeEncodeApplyOperation(payload);
+}
+
+export async function appendAndUpdate(base, payload) {
+    await base.append(payload);
+    await base.update();
+    await eventFlush();
+}
+
+export async function assertVdfParams(t, base, expectedDifficulty, expectedDiscriminantSize) {
+    const entry = await base.view.get(EntryType.VDF_PARAMS);
+    t.ok(entry, 'VDF params entry exists');
+
+    const decoded = decodeVdfParameters(entry.value);
+    t.ok(decoded, 'VDF params entry decodes');
+    t.is(decoded.difficulty.readUInt32BE(0), expectedDifficulty, 'VDF difficulty matches');
+    t.is(
+        decoded.discriminantBitSize.readUInt16BE(0),
+        expectedDiscriminantSize,
+        'VDF discriminant size is preserved'
+    );
+}
+
+export async function assertOperationRecorded(t, base, payload, expected) {
+    const operation = safeDecodeApplyOperation(payload);
+    t.ok(operation?.vpo?.tx, 'SET_VDF_PARAMS payload decodes');
+
+    const entry = await base.view.get(operation.vpo.tx.toString('hex'));
+    if (expected) {
+        t.ok(entry, 'SET_VDF_PARAMS transaction is recorded');
+    } else {
+        t.is(entry, null, 'SET_VDF_PARAMS transaction is not recorded');
+    }
+}
+
+export async function assertVdfParamsMissing(t, base) {
+    const entry = await base.view.get(EntryType.VDF_PARAMS);
+    t.is(entry, null, 'VDF params remain uninitialized');
+}
+
+export function mutateVdfDifficulty(payload, difficulty) {
+    const operation = safeDecodeApplyOperation(payload);
+    operation.vpo.df = uint32ToBuffer(difficulty);
+    return safeEncodeApplyOperation(operation);
+}
+
+async function initializeGenesisEpoch(context) {
+    const adminNode = context.adminBootstrap;
+    const txValidity = await deriveIndexerSequenceState(adminNode.base);
+    const payload = await applyStateMessageFactory(adminNode.wallet, config)
+        .buildCompleteSetGenesisEpochMessage(
+            adminNode.wallet.address,
+            txValidity,
+            uint32ToBuffer(INITIAL_VDF_DIFFICULTY),
+            uint16ToBuffer(INITIAL_VDF_DISCRIMINANT_SIZE)
+        );
+
+    await appendAndUpdate(adminNode.base, safeEncodeApplyOperation(payload));
+
+    const entry = await adminNode.base.view.get(EntryType.VDF_PARAMS);
+    if (!entry || !b4a.isBuffer(entry.value)) {
+        throw new Error('Failed to initialize VDF params for SET_VDF_PARAMS scenario.');
+    }
+}

--- a/tests/unit/state/apply/setVdfParams/state.apply.setVdfParams.test.js
+++ b/tests/unit/state/apply/setVdfParams/state.apply.setVdfParams.test.js
@@ -1,0 +1,104 @@
+import { test } from 'brittle';
+import {
+    INITIAL_VDF_DIFFICULTY,
+    INITIAL_VDF_DISCRIMINANT_SIZE,
+    UPDATED_VDF_DIFFICULTY,
+    appendAndUpdate,
+    assertOperationRecorded,
+    assertVdfParams,
+    assertVdfParamsMissing,
+    buildSetVdfParamsPayload,
+    mutateVdfDifficulty,
+    setupSetVdfParamsScenario
+} from './setVdfParamsScenarioHelpers.js';
+
+test('State.apply SET_VDF_PARAMS updates difficulty and preserves discriminant size', async t => {
+    const context = await setupSetVdfParamsScenario(t);
+    const adminNode = context.adminBootstrap;
+    const readerNode = context.peers[1];
+    const payload = await buildSetVdfParamsPayload(context);
+
+    await appendAndUpdate(adminNode.base, payload);
+
+    await assertVdfParams(
+        t,
+        adminNode.base,
+        UPDATED_VDF_DIFFICULTY,
+        INITIAL_VDF_DISCRIMINANT_SIZE
+    );
+    await assertOperationRecorded(t, adminNode.base, payload, true);
+
+    await context.sync();
+    await assertVdfParams(
+        t,
+        readerNode.base,
+        UPDATED_VDF_DIFFICULTY,
+        INITIAL_VDF_DISCRIMINANT_SIZE
+    );
+    await assertOperationRecorded(t, readerNode.base, payload, true);
+});
+
+test('State.apply SET_VDF_PARAMS rejects updates before genesis initialization', async t => {
+    const context = await setupSetVdfParamsScenario(t, { initializeGenesis: false });
+    const adminNode = context.adminBootstrap;
+    const payload = await buildSetVdfParamsPayload(context);
+
+    await appendAndUpdate(adminNode.base, payload);
+
+    await assertVdfParamsMissing(t, adminNode.base);
+    await assertOperationRecorded(t, adminNode.base, payload, false);
+});
+
+test('State.apply SET_VDF_PARAMS rejects a non-admin requester', async t => {
+    const context = await setupSetVdfParamsScenario(t);
+    const adminNode = context.adminBootstrap;
+    const nonAdminWallet = context.peers[1].wallet;
+    const payload = await buildSetVdfParamsPayload(
+        context,
+        UPDATED_VDF_DIFFICULTY,
+        nonAdminWallet
+    );
+
+    await appendAndUpdate(adminNode.base, payload);
+
+    await assertVdfParams(
+        t,
+        adminNode.base,
+        INITIAL_VDF_DIFFICULTY,
+        INITIAL_VDF_DISCRIMINANT_SIZE
+    );
+    await assertOperationRecorded(t, adminNode.base, payload, false);
+});
+
+test('State.apply SET_VDF_PARAMS rejects zero difficulty', async t => {
+    const context = await setupSetVdfParamsScenario(t);
+    const adminNode = context.adminBootstrap;
+    const payload = await buildSetVdfParamsPayload(context, 0);
+
+    await appendAndUpdate(adminNode.base, payload);
+
+    await assertVdfParams(
+        t,
+        adminNode.base,
+        INITIAL_VDF_DIFFICULTY,
+        INITIAL_VDF_DISCRIMINANT_SIZE
+    );
+    await assertOperationRecorded(t, adminNode.base, payload, false);
+});
+
+test('State.apply SET_VDF_PARAMS rejects difficulty not covered by the signed hash', async t => {
+    const context = await setupSetVdfParamsScenario(t);
+    const adminNode = context.adminBootstrap;
+    const validPayload = await buildSetVdfParamsPayload(context);
+    const mutatedPayload = mutateVdfDifficulty(validPayload, UPDATED_VDF_DIFFICULTY + 1);
+
+    await appendAndUpdate(adminNode.base, mutatedPayload);
+
+    await assertVdfParams(
+        t,
+        adminNode.base,
+        INITIAL_VDF_DIFFICULTY,
+        INITIAL_VDF_DISCRIMINANT_SIZE
+    );
+    await assertOperationRecorded(t, adminNode.base, validPayload, false);
+});

--- a/tests/unit/state/apply/state.apply.test.js
+++ b/tests/unit/state/apply/state.apply.test.js
@@ -18,6 +18,7 @@ async function runStateTests() {
     await import('./txOperation/state.apply.txOperation.test.js');
     await import('./transfer/state.apply.transfer.test.js');
     await import('./adminRecovery/state.apply.adminRecovery.test.js');
+    await import('./setVdfParams/state.apply.setVdfParams.test.js');
     test.resume();
 }
 


### PR DESCRIPTION
Implements the SET_VDF_PARAMS apply operation, allowing the network admin to update VDF difficulty.

Includes authorization, signature, transaction validity and replay checks, plus apply-level unit tests.