### PR TITLE
fix: resolve isindexeraddress incorrectly comparing target with the address from the state directly

### DIFF
--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -362,10 +362,12 @@ class State extends ReadyResource {
     }
 
     async isIndexerAddress(targetAddress) {
+        const targetAddressBuffer = addressUtils.addressToBuffer(targetAddress, this.#config.addressPrefix);
+        if (targetAddressBuffer.length === 0) return false;
         const entries = await this.getIndexersEntry();
         for (const entry of entries) {
             const address = await this.getSigned(EntryType.WRITER_ADDRESS + b4a.toString(entry.key, 'hex'));
-            if (address === targetAddress) return true;
+            if (address && b4a.equals(targetAddressBuffer, address)) return true;
         }
         return false;
     }

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -361,6 +361,11 @@ class State extends ReadyResource {
         return Object.values(this.#base.system.indexers);
     }
 
+    /**
+     * Checks whether a bech32m address belongs to a registered indexer.
+     * @param {string} targetAddress Address to check.
+     * @returns {Promise<boolean>} True when the address belongs to an indexer in signed state.
+     */
     async isIndexerAddress(targetAddress) {
         const targetAddressBuffer = addressUtils.addressToBuffer(targetAddress, this.#config.addressPrefix);
         if (targetAddressBuffer.length === 0) return false;

--- a/tests/unit/state/stateAdminValidation.test.js
+++ b/tests/unit/state/stateAdminValidation.test.js
@@ -200,9 +200,10 @@ test('State#isIndexerAddress returns true when address belongs to an indexer', a
     const { state, restore } = await setupQueryState(config);
     const indexerKey = randomBuffer(WRITER_BYTE_LENGTH);
     const indexerAddress = randomAddress('trac');
+    const indexerAddressBuffer = addressUtils.addressToBuffer(indexerAddress, config.addressPrefix);
 
     const entriesStub = sinon.stub(state, 'getIndexersEntry').resolves([{ key: indexerKey }]);
-    const signedStub = sinon.stub(state, 'getSigned').resolves(indexerAddress);
+    const signedStub = sinon.stub(state, 'getSigned').resolves(indexerAddressBuffer);
     const result = await state.isIndexerAddress(indexerAddress);
     t.is(result, true, 'returns true when address matches an indexer');
 
@@ -216,12 +217,28 @@ test('State#isIndexerAddress returns false when address does not match any index
     const { state, restore } = await setupQueryState(config);
     const indexerKey = randomBuffer(WRITER_BYTE_LENGTH);
     const indexerAddress = randomAddress('trac');
+    const indexerAddressBuffer = addressUtils.addressToBuffer(indexerAddress, config.addressPrefix);
     const otherAddress = randomAddress('trac');
 
     const entriesStub = sinon.stub(state, 'getIndexersEntry').resolves([{ key: indexerKey }]);
-    const signedStub = sinon.stub(state, 'getSigned').resolves(indexerAddress);
+    const signedStub = sinon.stub(state, 'getSigned').resolves(indexerAddressBuffer);
     const result = await state.isIndexerAddress(otherAddress);
     t.is(result, false, 'returns false when address does not match any indexer');
+
+    entriesStub.restore();
+    signedStub.restore();
+    restore();
+});
+
+test('State#isIndexerAddress returns false when indexer address entry is missing', async t => {
+    const config = createStateConfig();
+    const { state, restore } = await setupQueryState(config);
+    const indexerKey = randomBuffer(WRITER_BYTE_LENGTH);
+
+    const entriesStub = sinon.stub(state, 'getIndexersEntry').resolves([{ key: indexerKey }]);
+    const signedStub = sinon.stub(state, 'getSigned').resolves(null);
+    const result = await state.isIndexerAddress(randomAddress('trac'));
+    t.is(result, false, 'returns false when indexer writer address is missing');
 
     entriesStub.restore();
     signedStub.restore();


### PR DESCRIPTION
## Description

The function isIndexerAddress was incorrectly comparing a `targetAddress` string to a buffer, which would always return false even for legit indexers. The tests were passing because the stubed `getSigned` function was returning a string, instead of a buffer, like it would in production.

## Objectives
- [x] Fix isIndexerAddress internal comparison
- [x] Write JSDoc for isIndexerAddress
- [x] Fix related tests