### PR TITLE
chore: prepare MSB for pear runtime v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The MSB leverages the [Pear Runtime and Holepunch](https://pears.com/).
 
 Node.js is required to run the application. Before installing Node.js, refer to the official [Node.js documentation](https://nodejs.org) for the latest recommended version and installation instructions. For this project, Node.js v22.22.0 (LTS) and npm 11.6.1 or newer are compatible.
 
-The Pear Runtime CLI is required to run the application. Before installing Pear, refer to the official [Pear documentation](https://docs.pears.com/guides/getting-started) for the latest recommended version and installation instructions. For this project, the latest Pear CLI is compatible.
+MSB supports both Pear v2 and Pear v3. Its Pear runner uses `pear run` with Pear v2 and the embedded [`pear-runtime`](https://docs.pears.com/reference/pear/runtime/) module with Pear v3.
 
-Install Pear globally:
+The Pear CLI is required for Pear v2 and for Pear deployment commands. Pear v3 can run MSB through the embedded module without a globally installed CLI. Install the CLI when it is needed:
 
 ```sh
 npm install -g pear
@@ -55,7 +55,7 @@ Runtime entry points cover CLI-driven runs (`start`, `rpc`) and `.env`-aware run
 
 ### Startup input validation
 
-Startup input is validated before MSB finishes booting. This applies to direct CLI flags and to the `.env` / inline environment-variable entry points, because those scripts ultimately pass the same runtime flags into `pear run .`.
+Startup input is validated before MSB finishes booting. This applies to direct CLI flags and to the `.env` / inline environment-variable entry points, because those scripts pass the same flags through the Pear v2/v3 runner.
 
 - `--network` / `NETWORK` must be one of `mainnet`, `development`, `testnet1`, or `testnet` (`testnet` is treated as an alias for `testnet1`).
 - `--stores-directory` / `STORES_DIRECTORY` must be a non-empty string.

--- a/cli/interactive.js
+++ b/cli/interactive.js
@@ -1,6 +1,6 @@
 import ReadyResource from "ready-resource";
+import process from "process";
 import readline from "readline";
-import tty from "tty";
 import { WalletProvider, exportWallet, importFromFile } from "trac-wallet";
 import { MainSettlementBus } from "../src/index.js";
 import { sleep } from "../src/utils/helpers.js";
@@ -21,8 +21,8 @@ class Cli extends ReadyResource {
 
     async _open() {
         this.#readlineInstance = readline.createInterface({
-            input: new tty.ReadStream(0),
-            output: new tty.WriteStream(1),
+            input: process.stdin,
+            output: process.stdout,
             completer: line => this.#completeCommand(line) // This only works without Pear.
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,13 +56,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -81,21 +81,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -112,14 +113,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -129,14 +130,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -146,9 +147,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -156,29 +157,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -198,9 +199,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -208,9 +209,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -218,9 +219,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -228,27 +229,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -497,33 +498,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -531,14 +532,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -630,9 +631,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -711,9 +712,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -753,10 +754,20 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -1482,9 +1493,9 @@
       }
     },
     "node_modules/@metamask/utils": {
-      "version": "11.8.1",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.1.tgz",
-      "integrity": "sha512-DIbsNUyqWLFgqJlZxi1OOCMYvI23GqFCvNJAtzv8/WXWzJfnJnvp1M24j7VvUe3URBi3S86UgQ7+7aWU9p/cnQ==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.11.0.tgz",
+      "integrity": "sha512-0nF2CWjWQr/m0Y2t2lJnBTU1/CZPPTvKvcESLplyWe/tyeb8zFOi/FeneDmaFnML6LYRIGZU6f+xR0jKAIUZfw==",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -1615,37 +1626,30 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1661,9 +1665,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@scure/base": {
@@ -1934,6 +1938,7 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -2267,6 +2272,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3064,6 +3070,7 @@
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
       "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -3125,13 +3132,16 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.28",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.28.tgz",
-      "integrity": "sha512-gYjt7OIqdM0PcttNYP2aVrr2G0bMALkBaoehD4BuRGjAOtipg0b6wHg1yNL+s5zSnLZZrGHOw4IrND8CD+3oIQ==",
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.5.tgz",
+      "integrity": "sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bech32": {
@@ -3220,9 +3230,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3273,9 +3283,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
-      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -3292,12 +3302,13 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.25",
-        "caniuse-lite": "^1.0.30001754",
-        "electron-to-chromium": "^1.5.249",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.1.4"
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3375,9 +3386,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001754",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
-      "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -3895,9 +3906,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.250",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.250.tgz",
-      "integrity": "sha512-/5UMj9IiGDMOFBnN4i7/Ry5onJrAGSbOGo3s9FEKmwobGq6xw832ccET0CE3CkkMBZ8GJSlUIesZofpyurqDXw==",
+      "version": "1.5.397",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.397.tgz",
+      "integrity": "sha512-khGTy9U9x02KEtsKM8vx5A62BsRmcOsIgDpWr1ImE32Ax8GxHGPHZf+Eu9H8zOOyHJnB0jTbseyTHbq2XCT8yw==",
       "dev": true,
       "license": "ISC"
     },
@@ -4062,6 +4073,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4147,9 +4159,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4672,17 +4684,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4985,9 +4997,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6072,9 +6084,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6240,10 +6252,20 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -6331,15 +6353,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -6599,11 +6631,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/noise-curve-ed": {
       "version": "2.1.0",
@@ -6990,33 +7025,33 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/protobufjs-cli": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.2.0.tgz",
-      "integrity": "sha512-+YvqJEmsmZHGzE5j0tvEzFeHm0sX7pzRFpyj7+GazhkS4Y0r+jgbioVvFxxSWIlPzUel/lxeOnLChBmV8NmyHA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.3.3.tgz",
+      "integrity": "sha512-zwmt6JeStPjeofZbl+QADexAVzP1EgsIAsO7mCfKkW/8oBxHwgTqJ1aD7zDrcCC0Nb+SLWSvCR3RDaKgIO3P8w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7039,7 +7074,7 @@
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "protobufjs": "^7.0.0"
+        "protobufjs": "^7.6.2"
       }
     },
     "node_modules/protobufjs-cli/node_modules/glob": {
@@ -7125,9 +7160,9 @@
       "license": "MIT"
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7204,13 +7239,14 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -7488,15 +7524,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -7508,14 +7544,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8039,9 +8075,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8137,9 +8173,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8350,9 +8386,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -8391,9 +8427,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,12 @@
         "hypercore": "11.18.3",
         "hypercore-crypto": "3.6.1",
         "hyperdht": "6.27.0",
+        "hyperschema": "1.17.1",
         "hyperswarm": "4.14.2",
         "lodash": "^4.18.1",
         "p-queue": "^9.1.0",
+        "pear-runtime": "1.3.1",
+        "process": "npm:bare-process@4.2.2",
         "protobufjs": "^7.5.4",
         "protocol-buffers-encodings": "1.2.0",
         "protomux": "3.10.1",
@@ -2589,11 +2592,31 @@
         "bare-inspect": "^3.1.2"
       }
     },
+    "node_modules/bare-broadcast-channel": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bare-broadcast-channel/-/bare-broadcast-channel-0.2.0.tgz",
+      "integrity": "sha512-MuAwdKWr4cSjNwqvbE3tA9Wn6w69q6iXYnP2Wb0nlDa6sKNSMSfY7LXkV4FzWlq9JFP9d0HkCAKPboTLKnUfWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-stream": "^2.7.0",
+        "bare-structured-clone": "^1.4.0"
+      }
+    },
+    "node_modules/bare-buffer": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.6.2.tgz",
+      "integrity": "sha512-WT9xx12FJvWbBCkgfjuAeWfY40RW6BKVr2fK9UGrTEYKbvqhcaW0J9AMkA3Sj36Wgi+DUuGXYkZPxn5jVH61LA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "bare": ">=1.20.0"
+      }
+    },
     "node_modules/bare-bundle": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/bare-bundle/-/bare-bundle-1.10.0.tgz",
       "integrity": "sha512-4LVlnJAHr00Hh6Vu6ZUJS38rcEtJT3b3vChXSsBsJ2mk1TN0lQ+gzd+Dw5L0aV7uqDZv84smuwW+O02X7PfDlw==",
-      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-buffer": "*",
@@ -2606,6 +2629,20 @@
         "bare-url": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-channel": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/bare-channel/-/bare-channel-5.2.4.tgz",
+      "integrity": "sha512-enkaOtvXUiZsLBSbataxV/QBjehCOK+SUTd2JQWUYW2iIOufpPu9jyZ9bqJqkEquktrK/rpEMVEmKsPzoci/sA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-stream": "^2.7.0",
+        "bare-structured-clone": "^1.4.0"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
       }
     },
     "node_modules/bare-cov": {
@@ -2678,16 +2715,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-env/-/bare-env-3.0.0.tgz",
       "integrity": "sha512-0u964P5ZLAxTi+lW4Kjp7YRJQ5gZr9ycYOtjLxsSrupgMz3sn5Z9n4SH/JIifHwvadsf1brA2JAjP+9IOWwTiw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -2735,7 +2771,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bare-hrtime/-/bare-hrtime-2.1.1.tgz",
       "integrity": "sha512-VMb3tHo05gsnbu3OXTmkDiwTjMlOsbQmKoysKqKEyR09m77TuDrYFbj3Q5GGk10dAKsUHrnXmwCaeJqzVpB5ZA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/bare-http-parser": {
@@ -2818,21 +2853,27 @@
         }
       }
     },
+    "node_modules/bare-mime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bare-mime/-/bare-mime-1.0.0.tgz",
+      "integrity": "sha512-lUOswzBkfqham4zjLDueKOd4Qj3gS56BiZ3q2f0g0adoFhF+HFNupvTUfZBWoicl7fWJ7Hp2RUZjmkY47dxxOQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/bare-module": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/bare-module/-/bare-module-6.1.3.tgz",
-      "integrity": "sha512-5XWsVHsvtWMH4tK4DQWgpNTV0t/sg3ZrAaQLIxrwjrS5+u8Q9vEgc/zQ4QaDPWDse/y/5h+d+YG1Q0JfSMt0zA==",
-      "dev": true,
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/bare-module/-/bare-module-6.4.0.tgz",
+      "integrity": "sha512-Yn4V5g5EqGQL4LYUOmt7fjKzj2JPWyJOqE3lPoeZwfUH5rk4CKUfZj6JhDwbzhBYCqqmUgjgQ5aY8cihAPILLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-bundle": "^1.3.0",
         "bare-module-lexer": "^1.0.0",
         "bare-module-resolve": "^1.8.0",
         "bare-path": "^3.0.0",
+        "bare-type-stripper": "^0.1.2",
         "bare-url": "^2.0.1"
       },
       "engines": {
-        "bare": ">=1.23.0"
+        "bare": ">=1.29.4"
       },
       "peerDependencies": {
         "bare-buffer": "*"
@@ -2844,10 +2885,9 @@
       }
     },
     "node_modules/bare-module-lexer": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/bare-module-lexer/-/bare-module-lexer-1.4.7.tgz",
-      "integrity": "sha512-0klU4eMsjh/wcxi8FdHmNom2j2F4kmkXOhyJFL9qTaSFp2lE3m6BtbKgMHY8R5miqC9r8/IfA8wzXnC5Os14WA==",
-      "dev": true,
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/bare-module-lexer/-/bare-module-lexer-1.6.3.tgz",
+      "integrity": "sha512-NQY7cnPV3GZlHJphX4nXmPdNPER/Tp17pVi9/he2ODw/GNZ7FXzrZlrS7WMF8zbtWigqW/NMc9aQc2BH8UJXqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "require-addon": "^1.0.2"
@@ -2878,6 +2918,30 @@
         }
       }
     },
+    "node_modules/bare-module-traverse": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/bare-module-traverse/-/bare-module-traverse-2.4.4.tgz",
+      "integrity": "sha512-zK4bDxqeD15Tvu/C5B1Mi/epl9PavjIhU3SVh5RhDb4Hpet6applPVX8Q9rinu7nT80yzgSSlBn0exzJaNXv0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-addon-resolve": "^1.5.0",
+        "bare-mime": "^1.0.0",
+        "bare-module-lexer": "^1.6.0",
+        "bare-module-resolve": "^1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bare-net": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/bare-net/-/bare-net-2.2.0.tgz",
@@ -2901,19 +2965,15 @@
       }
     },
     "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/bare-pipe": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.1.0.tgz",
-      "integrity": "sha512-0TD3NUIhh7KgPMRLyEBqSXlTZ8X/jcw1ulAjmErDWwoLdIF9FdVXvbpbzyKIl45sr9ZQ4k5AKThAOlrrtZcrXg==",
-      "dev": true,
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.2.3.tgz",
+      "integrity": "sha512-MJYji+Vy8cNMAB2fwg1WQAm1hFIOe5ojw5V9EhEa/wEEYpKT8c36WjHBDwgkgAZfUSX6wQcEFX+Q7wN09SgRow==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.0.0",
@@ -2955,6 +3015,72 @@
       "integrity": "sha512-ESVaN2nzWhcI5tf3Zzcq9aqCZ676VWzqw07eEZ0qxAcEOAFYBa0pWq8sK34OQeHLY3JsfKXZS9mDyzyxGjeLzA==",
       "license": "Apache-2.0"
     },
+    "node_modules/bare-sidecar": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/bare-sidecar/-/bare-sidecar-0.5.3.tgz",
+      "integrity": "sha512-TO/FHNUWgNEfDGiqrvmYT7+1ZxRpa4J0fWQsdVIjh5FY5xC+PocdMQPw/LiTp7iyhTUatZEeTDWr4l8DQ3jaeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.1",
+        "bare-module": "^6.1.3",
+        "bare-path": "^3.0.0",
+        "bare-pipe": "^4.1.3",
+        "bare-stream": "^2.7.0",
+        "bare-subprocess": "^6.0.0",
+        "bare-url": "^2.3.2",
+        "require-asset": "^1.1.0"
+      }
+    },
+    "node_modules/bare-sidecar/node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-sidecar/node_modules/bare-subprocess": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
+      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.2.0",
+        "bare-structured-clone": "^1.5.2",
+        "bare-tcp": "^2.4.1",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bare-signals": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/bare-signals/-/bare-signals-4.2.0.tgz",
@@ -2969,24 +3095,68 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "streamx": "^2.21.0"
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
       },
       "peerDependencies": {
+        "bare-abort-controller": "*",
         "bare-buffer": "*",
         "bare-events": "*"
       },
       "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
         "bare-buffer": {
           "optional": true
         },
         "bare-events": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-structured-clone": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bare-structured-clone/-/bare-structured-clone-1.6.0.tgz",
+      "integrity": "sha512-AZjEERyqF7kAuudlmgrweT2KwwWM0LsGG4Gx/bWyFwJrKU7E3wNG8c09z2DIrdw93p3vDtfOX8fyHOcXfy5m+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-buffer": "^3.6.0",
+        "bare-type": "^1.1.0",
+        "bare-url": "^2.4.0",
+        "compact-encoding": "^3.0.1"
+      },
+      "engines": {
+        "bare": ">=1.2.0"
+      }
+    },
+    "node_modules/bare-structured-clone/node_modules/compact-encoding": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.3.0.tgz",
+      "integrity": "sha512-e64XyzlBvTRJ3iScuU/U2w25Dglkm7fhrRbrGaHIwuTlNnzjRKMaQBCVl7mJRvZg7wI5a9wX1IVTXCuaAANNkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.3.0"
       }
     },
     "node_modules/bare-subprocess": {
@@ -3015,9 +3185,9 @@
       }
     },
     "node_modules/bare-tcp": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-tcp/-/bare-tcp-2.2.0.tgz",
-      "integrity": "sha512-vzQjwO/g2gqBXnV2JuJGLnAhYV4l/YrWsNJr0swD3I/nh7ohBi/O1Fd9kP1NNlYq3O7E+KQY9BMnpqlHBEd0aA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/bare-tcp/-/bare-tcp-2.5.3.tgz",
+      "integrity": "sha512-TsioekALDulWi0mglooIVG4ML7doxyANKfvuXUU6NS5tFMUnWVuvDht9wQplg07ZS6PQ3jfowzKxNeWdj2e02Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-dns": "^2.0.4",
@@ -3026,6 +3196,26 @@
       },
       "engines": {
         "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-pipe": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-pipe": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-thread": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/bare-thread/-/bare-thread-1.2.4.tgz",
+      "integrity": "sha512-MnqMCGVp2JJJNXgwUBC8hw+J4FrTeLkLgfCPPl5tQK6MbtV2Efi6LKK5v819VRY0da+AXlCbgssbAVge31NfRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-bundle": "^1.9.0",
+        "bare-module-resolve": "^1.11.2",
+        "bare-module-traverse": "^2.0.0",
+        "bare-url": "^2.4.2"
       }
     },
     "node_modules/bare-tls": {
@@ -3065,12 +3255,28 @@
         "bare": ">=1.2.0"
       }
     },
-    "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+    "node_modules/bare-type-stripper": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/bare-type-stripper/-/bare-type-stripper-0.1.4.tgz",
+      "integrity": "sha512-FdZhp9XEnQpj8AWFmIft/sVUyKS9XSmB6PhcxBHhuEDxxZM5Kkt8+kFS7eEpLXR7TkaRkNpSENoGH/8lpAmtkA==",
       "license": "Apache-2.0",
-      "peer": true,
+      "dependencies": {
+        "require-addon": "^1.0.2"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -3103,6 +3309,20 @@
         "bare-utils": "^1.2.0",
         "v8-to-istanbul": "^9.3.0",
         "which-runtime": "^1.2.1"
+      }
+    },
+    "node_modules/bare-worker": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/bare-worker/-/bare-worker-4.4.0.tgz",
+      "integrity": "sha512-zSc1biis9ks03nj/24M7tYS2V0CPhefizzRIxVYdglbbUAgA0zakwSgTKLJshZ6P+9NA55M/eG4k/rBALZVbxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-broadcast-channel": "^0.2.0",
+        "bare-channel": "^5.1.5",
+        "bare-events": "^2.2.1",
+        "bare-module": "^6.4.0",
+        "bare-stream": "^2.13.3",
+        "bare-thread": "^1.2.2"
       }
     },
     "node_modules/bare-ws": {
@@ -3155,6 +3375,15 @@
       "resolved": "https://registry.npmjs.org/big-sparse-array/-/big-sparse-array-1.0.3.tgz",
       "integrity": "sha512-6RjV/3mSZORlMdpUaQ6rUSpG637cZm0//E54YYGtQg1c1O+AbZP8UTdJ/TchsDZcTVLmyWZcseBfp2HBeXUXOQ==",
       "license": "MIT"
+    },
+    "node_modules/binary-stream-equals": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/binary-stream-equals/-/binary-stream-equals-1.0.0.tgz",
+      "integrity": "sha512-xiUT5LGfD8JiLhbXiG+ByOnbgb9f2ssRLfZDQMl3nZdf89EotQZGZuMkDN8J3n46emabE7RnJ1q0r7Hv3INExw==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1"
+      }
     },
     "node_modules/bip39-mnemonic": {
       "version": "2.5.0",
@@ -5056,6 +5285,31 @@
         "unslab": "^1.2.0"
       }
     },
+    "node_modules/hyperblobs": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/hyperblobs/-/hyperblobs-2.12.1.tgz",
+      "integrity": "sha512-iX5sPkL/3eDphUkMxTG43xZGEER+cVLAFbuNIQpk/WVK8CTWnmaoCYP/+94RaFFh5U7HeGoDYidQbv6E7LeAvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.1",
+        "bare-events": "^2.5.0",
+        "compact-encoding": "^3.0.0",
+        "hypercore-crypto": "^3.6.1",
+        "hypercore-errors": "^1.1.1",
+        "mutexify": "^1.4.0",
+        "speedometer": "^1.1.0",
+        "streamx": "^2.13.2"
+      }
+    },
+    "node_modules/hyperblobs/node_modules/compact-encoding": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.3.0.tgz",
+      "integrity": "sha512-e64XyzlBvTRJ3iScuU/U2w25Dglkm7fhrRbrGaHIwuTlNnzjRKMaQBCVl7mJRvZg7wI5a9wX1IVTXCuaAANNkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.3.0"
+      }
+    },
     "node_modules/hypercore": {
       "version": "11.18.3",
       "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.18.3.tgz",
@@ -5164,6 +5418,26 @@
       },
       "bin": {
         "hyperdht": "bin.js"
+      }
+    },
+    "node_modules/hyperdrive": {
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-13.3.3.tgz",
+      "integrity": "sha512-nLqBbBUg1OPsjl8vn5T3wxhtLbzQz+JxUK1i1YOKTX4tdDFET8H4HxdA17knv5P4lC9v9eVC0mlPKdFlYxzDfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hyperbee": "^2.11.1",
+        "hyperblobs": "^2.9.0",
+        "hypercore": "^11.0.0",
+        "hypercore-errors": "^1.0.0",
+        "is-options": "^1.0.2",
+        "mirror-drive": "^1.2.0",
+        "ready-resource": "^1.0.0",
+        "safety-catch": "^1.0.2",
+        "speedometer": "^1.1.0",
+        "streamx": "^2.12.4",
+        "sub-encoder": "^2.1.1",
+        "unix-path-resolve": "^1.0.2"
       }
     },
     "node_modules/hyperschema": {
@@ -6271,6 +6545,21 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/localdrive": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/localdrive/-/localdrive-2.2.1.tgz",
+      "integrity": "sha512-r7AMrscOky3zIjzOrbH+90P12WmFdQaIlJ26TXaUJrM3hGQ6lIQkWhy8eQs5xDI5ukEyrXp4962EIgO9DFdm+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.1",
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "mirror-drive": "^1.2.0",
+        "mutexify": "^1.4.0",
+        "streamx": "^2.12.5",
+        "unix-path-resolve": "^1.0.2"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -6560,6 +6849,21 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mirror-drive": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/mirror-drive/-/mirror-drive-1.14.2.tgz",
+      "integrity": "sha512-1ZtS/TonGXWX0eDAGK90JapGyzOaz8IxX7mARZWPgUuZ9eEIvaoSY7bxv6/4FOW26wL8g/YcpqJpt8mMZ/QZCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.8.2",
+        "binary-stream-equals": "^1.0.0",
+        "rabin-stream": "^2.0.0",
+        "same-data": "^1.0.0",
+        "speedometer": "^1.1.0",
+        "streamx": "^2.22.1",
+        "unix-path-resolve": "^1.0.2"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -6578,6 +6882,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/msix-manager": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/msix-manager/-/msix-manager-0.2.5.tgz",
+      "integrity": "sha512-bfAqCBIIoxCsBCuDCr9wCfucmL0fy8jE4GBf9Yx24ZXDxQe4L7r/CJcNcGQxWx9RdHGCqCuNKrrNLfTYOue3fw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.8.2",
+        "bare-url": "^2.3.2",
+        "require-addon": "^1.2.0"
+      }
     },
     "node_modules/mutexify": {
       "version": "1.4.0",
@@ -6935,6 +7250,204 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pear-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pear-errors/-/pear-errors-1.0.1.tgz",
+      "integrity": "sha512-KQyhym09QpLT4H/z3uLW0bqixgIZic2Eip2Q8Z72QmIpFzPtp6QmnzOUwB3kuHB4dqKNa+FQWHWH0NSK5lJjlw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/pear-link": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pear-link/-/pear-link-5.0.1.tgz",
+      "integrity": "sha512-h7BZAPTJWy3oqKOw/REEgAVB+wd4JR6kZEla32U2DoePlC75yorYtDIzbqAN4VsWzmr21AZcO/XLRDaOqORFMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.1.1",
+        "hypercore-id-encoding": "^1.3.0",
+        "pear-errors": "^1.0.1"
+      }
+    },
+    "node_modules/pear-runtime": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pear-runtime/-/pear-runtime-1.3.1.tgz",
+      "integrity": "sha512-IoEr3c52L40BrXkjFnMYbeNbbnjuEF8L2toFIe3IyB0lkrUOBZ/mleBiMV6Mq4YLVmp6fWTMHIefMvT/oU3LXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0",
+        "bare-sidecar": "^0.5.2",
+        "bare-worker": "^4.4.0",
+        "corestore": "^7.9.1",
+        "hyperswarm": "^4.17.0",
+        "pear-runtime-updater": "^3.0.0",
+        "ready-resource": "^1.2.0"
+      }
+    },
+    "node_modules/pear-runtime-updater": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pear-runtime-updater/-/pear-runtime-updater-3.2.0.tgz",
+      "integrity": "sha512-KLHefj2y0ehG3lE3iAgGSxSbl51ZIM9Arpzb/BW8LTjOmC3n9ydclMgvjlbuA12efQu4MnUvE7nNQ3leISxwLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.3",
+        "bare-path": "^3.0.0",
+        "bare-semver": "^1.0.2",
+        "debounceify": "^1.1.0",
+        "fs-native-extensions": "^1.4.5",
+        "hypercore-id-encoding": "^1.3.0",
+        "hyperdrive": "^13.2.1",
+        "localdrive": "^2.2.0",
+        "msix-manager": "^0.2.4",
+        "pear-link": "^5.0.0",
+        "ready-resource": "^1.2.0",
+        "which-runtime": "^1.3.2"
+      }
+    },
+    "node_modules/pear-runtime-updater/node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pear-runtime-updater/node_modules/ready-resource": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ready-resource/-/ready-resource-1.2.0.tgz",
+      "integrity": "sha512-nfcco/8iAFV0M+2PYnmIc+/xY0iRb35d42HFHQ7AfjulbGEAFa+XWpByfwSyeVeiBoMLLFVMv1HixxNCqzSQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/pear-runtime/node_modules/compact-encoding": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.3.0.tgz",
+      "integrity": "sha512-e64XyzlBvTRJ3iScuU/U2w25Dglkm7fhrRbrGaHIwuTlNnzjRKMaQBCVl7mJRvZg7wI5a9wX1IVTXCuaAANNkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.3.0"
+      }
+    },
+    "node_modules/pear-runtime/node_modules/corestore": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/corestore/-/corestore-7.12.0.tgz",
+      "integrity": "sha512-yRWQ8VkjlAl7ITRo/xT8EK9NdiJ7xrsCCkRShD2TlSaoGa3B7bRVNPr1nWGE5NjiIi4HiLBCxtiI4gzmjAjJ0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.7",
+        "bare-events": "^2.8.3",
+        "hypercore": "^11.32.0",
+        "hypercore-crypto": "^3.4.2",
+        "hypercore-errors": "^1.4.0",
+        "hypercore-id-encoding": "^1.3.0",
+        "ready-resource": "^1.1.1",
+        "sodium-universal": "^5.0.1",
+        "streamx": "^2.26.0",
+        "which-runtime": "^1.2.1"
+      }
+    },
+    "node_modules/pear-runtime/node_modules/hypercore": {
+      "version": "11.35.0",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.35.0.tgz",
+      "integrity": "sha512-ixba6oHaK2XXmv7nERLz7T6DUb9rsPc7OAMgG3wVbFELcX7x0RZkjUaupjgDEuK1VbiiNrH784+v95J9VdCC7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperswarm/secret-stream": "^6.0.0",
+        "b4a": "^1.1.0",
+        "bare-events": "^2.2.0",
+        "big-sparse-array": "^1.0.3",
+        "compact-encoding": "^3.0.0",
+        "fast-fifo": "^1.3.0",
+        "flat-tree": "^1.9.0",
+        "hypercore-crypto": "^3.2.1",
+        "hypercore-errors": "^1.5.0",
+        "hypercore-id-encoding": "^1.2.0",
+        "hypercore-storage": "^3.2.0",
+        "is-options": "^1.0.1",
+        "nanoassert": "^2.0.0",
+        "protomux": "^3.5.0",
+        "quickbit-universal": "^2.2.0",
+        "random-array-iterator": "^1.0.0",
+        "safety-catch": "^1.0.1",
+        "sodium-universal": "^5.0.1",
+        "streamx": "^2.12.4",
+        "unslab": "^1.3.0",
+        "z32": "^1.0.0"
+      }
+    },
+    "node_modules/pear-runtime/node_modules/hypercore-storage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-3.2.0.tgz",
+      "integrity": "sha512-i5O5ZMkdZaNAWGuNRXUZjuzv7B41OIhDHUwLCZPjucgVmywY0ZE5PDafu6e5oPuhtghjl6S8q6Jn+POVKN2BvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.7",
+        "bare-path": "^3.0.0",
+        "compact-encoding": "^3.1.0",
+        "device-file": "^2.1.2",
+        "flat-tree": "^1.12.1",
+        "hypercore-crypto": "^3.4.2",
+        "hyperschema": "^1.21.0",
+        "index-encoder": "^3.3.2",
+        "resolve-reject-promise": "^1.0.0",
+        "rocksdb-native": "^3.11.0",
+        "scope-lock": "^1.2.4",
+        "streamx": "^2.21.1",
+        "xache": "^1.2.1"
+      }
+    },
+    "node_modules/pear-runtime/node_modules/hyperschema": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.21.0.tgz",
+      "integrity": "sha512-lEnIbLTUQf7w6FU6X+R3yUJhBwCzF4ewRnAaYOrPdcVWe1rbOf94PzMiXb5pBKxroCXzlrPLxVujxAsTrrHc8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.0.1",
+        "compact-encoding": "^3.0.0",
+        "generate-object-property": "^2.0.0",
+        "generate-string": "^1.0.1"
+      }
+    },
+    "node_modules/pear-runtime/node_modules/hyperswarm": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.17.0.tgz",
+      "integrity": "sha512-oe86sK961Ueg7rvDN/veFwG8xH+Iv6vObPhGDkPJcDVxk/NduW41ZhAcVDnHzRbm7S0eLU7WaDUvehOYoKSpRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1",
+        "bare-events": "^2.2.0",
+        "hyperdht": "^6.21.0",
+        "safety-catch": "^1.0.2",
+        "shuffled-priority-queue": "^2.1.0",
+        "streamx": "^2.22.1",
+        "unslab": "^1.3.0"
+      }
+    },
+    "node_modules/pear-runtime/node_modules/ready-resource": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ready-resource/-/ready-resource-1.2.0.tgz",
+      "integrity": "sha512-nfcco/8iAFV0M+2PYnmIc+/xY0iRb35d42HFHQ7AfjulbGEAFa+XWpByfwSyeVeiBoMLLFVMv1HixxNCqzSQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7022,6 +7535,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "name": "bare-process",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.2.2.tgz",
+      "integrity": "sha512-ikzEw+HGLB+2lS/WLVEsqi8BXBwzleG3n7DYI0v6/YNklvNabOIGlLd1dof+7Jw5ob4jsBRPtyflweVahY7rFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.3.1",
+        "bare-hrtime": "^2.0.0",
+        "bare-os": "^3.5.0",
+        "bare-pipe": "^4.0.0",
+        "bare-signals": "^4.0.0",
+        "bare-tty": "^5.0.0"
       }
     },
     "node_modules/protobufjs": {
@@ -7284,6 +7813,25 @@
         "quickbit-native": "^2.2.0"
       }
     },
+    "node_modules/rabin-native": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rabin-native/-/rabin-native-2.0.0.tgz",
+      "integrity": "sha512-x1BlYdIWh+nk9G0scvxyscrYiDPJ7vQZepqqPlVUSInIko1Zxooi8cm6lzBghEGI9aN3DXiunC8FXLgy6kke3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/rabin-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rabin-stream/-/rabin-stream-2.0.0.tgz",
+      "integrity": "sha512-EzS2Ig/qsMBSk1PahC0O0IPdRZe3bspHHLWChhqW1feKz+J46tlVL3g4wWr4lrQdXGzABIMsOhvdT6bjXYMuUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rabin-native": "^2.0.0",
+        "streamx": "^2.23.0"
+      }
+    },
     "node_modules/rache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rache/-/rache-1.0.0.tgz",
@@ -7347,6 +7895,19 @@
       },
       "engines": {
         "bare": ">=1.10.0"
+      }
+    },
+    "node_modules/require-asset": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/require-asset/-/require-asset-1.2.2.tgz",
+      "integrity": "sha512-uc8nWKhqAxVD9Z4rST2b4yaemrC9Xb5vA1wlCz5AiCYnBYdwGRWNqFjneA5zRILzlo1MNrB63ry9+pc8wNR26w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-module-resolve": "^1.6.2"
+      },
+      "engines": {
+        "bare": ">=1.10.0",
+        "node": ">=18"
       }
     },
     "node_modules/require-directory": {
@@ -7426,6 +7987,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.2.tgz",
       "integrity": "sha512-C1UYVZ4dtbBxEtvOcpjBaaD27nP8MlvyAQEp2fOTOEe6pfUpk1cDUxij6BR1jZup6rSyUTaBBplK7LanskrULA==",
+      "license": "MIT"
+    },
+    "node_modules/same-data": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/same-data/-/same-data-1.0.0.tgz",
+      "integrity": "sha512-Eqn7N2yV+aKMlUHTRqUwYG1Iv0cJqjlvLKj/GoP5PozJn361QaOYX14+v87r7NqQUZC22noP/LfLrSQiPwAygw==",
       "license": "MIT"
     },
     "node_modules/same-object": {
@@ -7773,6 +8340,12 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/speedometer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.1.0.tgz",
+      "integrity": "sha512-z/wAiTESw2XVPssY2XRcme4niTc4S5FkkJ4gknudtVoc33Zil8TdTxHy5torRcgqMqksJV2Yz8HQcvtbsnw0mQ==",
+      "license": "MIT"
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -7801,9 +8374,9 @@
       "license": "MIT"
     },
     "node_modules/streamx": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -8057,6 +8630,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/test-exclude": {
@@ -8333,6 +8915,12 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/unix-path-resolve": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unix-path-resolve/-/unix-path-resolve-1.0.2.tgz",
+      "integrity": "sha512-kG4g5nobBBaMnH2XbrS4sLUXEpx4nY2J3C6KAlAUcnahG2HChxSPVKWYrqEq76iTo+cyMkLUjqxGaQR2tz097Q==",
       "license": "MIT"
     },
     "node_modules/unordered-set": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,20 @@
     "type": "terminal"
   },
   "type": "module",
+  "files": [
+    "cli/",
+    "msb.mjs",
+    "NOTICE",
+    "rpc/",
+    "SECURITY.md",
+    "scripts/pear-runner.js",
+    "src/"
+  ],
   "scripts": {
-    "start": "NODE_OPTIONS='--max-old-space-size=4096' pear run .",
-    "rpc": "NODE_OPTIONS='--max-old-space-size=4096' pear run . --rpc --host ${npm_config_host} --port ${npm_config_port}",
-    "env": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; NODE_OPTIONS='--max-old-space-size=4096' pear run . --stores-directory ${STORES_DIRECTORY:-stores} --network ${NETWORK:-mainnet}",
-    "env-rpc": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; NODE_OPTIONS='--max-old-space-size=4096' pear run . --stores-directory ${STORES_DIRECTORY:-stores} --rpc --host ${MSB_HOST:-127.0.0.1} --port ${MSB_PORT:-5000} --network ${NETWORK:-mainnet}",
+    "start": "NODE_OPTIONS='--max-old-space-size=4096' node scripts/pear-runner.js",
+    "rpc": "NODE_OPTIONS='--max-old-space-size=4096' node scripts/pear-runner.js --rpc --host ${npm_config_host} --port ${npm_config_port}",
+    "env": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; NODE_OPTIONS='--max-old-space-size=4096' node scripts/pear-runner.js --stores-directory ${STORES_DIRECTORY:-stores} --network ${NETWORK:-mainnet}",
+    "env-rpc": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; NODE_OPTIONS='--max-old-space-size=4096' node scripts/pear-runner.js --stores-directory ${STORES_DIRECTORY:-stores} --rpc --host ${MSB_HOST:-127.0.0.1} --port ${MSB_PORT:-5000} --network ${NETWORK:-mainnet}",
     "env-rpc-docker": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; NODE_OPTIONS='--max-old-space-size=4096' node msb.mjs --stores-directory ${STORES_DIRECTORY:-stores} --rpc --host 0.0.0.0 --port ${MSB_PORT:-5000} --network ${NETWORK:-mainnet}",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -22,7 +31,8 @@
     "test:unit:node": "brittle-node -t 60000 tests/unit/unit.test.js",
     "test:unit:bare": "brittle-bare -t 60000 tests/unit/unit.test.js",
     "test:unit:pear": "BRITTLE='-t 60000' brittle-pear tests/unit/unit.test.js",
-    "test:unit:all": "(npm run test:unit:node && npm run test:unit:bare) || exit 1",
+    "test:pear-runner": "node --test tests/runner/pear-runner.test.js",
+    "test:unit:all": "(npm run test:unit:node && npm run test:unit:bare && npm run test:pear-runner) || exit 1",
     "test:unit:node:cov": "brittle-node -c -t 60000 tests/unit/unit.test.js"
   },
   "dependencies": {
@@ -46,8 +56,11 @@
     "hypercore-crypto": "3.6.1",
     "hyperdht": "6.27.0",
     "hyperswarm": "4.14.2",
+    "hyperschema": "1.17.1",
     "lodash": "^4.18.1",
     "p-queue": "^9.1.0",
+    "pear-runtime": "1.3.1",
+    "process": "npm:bare-process@4.2.2",
     "protobufjs": "^7.5.4",
     "protocol-buffers-encodings": "1.2.0",
     "protomux": "3.10.1",

--- a/scripts/pear-runner.js
+++ b/scripts/pear-runner.js
@@ -37,13 +37,12 @@ export const detectPearMajor = (runCommand = spawnSync) => {
     }
 
     const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
-    const major = parsePearMajor(output);
 
-    if (result.status !== 0 || major === null) {
+    if (result.status !== 0) {
         throw new Error('Could not determine the installed Pear major version from `pear -v`.');
     }
 
-    return major;
+    return parsePearMajor(output);
 };
 
 const exitCodeFor = (code, signal) => {

--- a/scripts/pear-runner.js
+++ b/scripts/pear-runner.js
@@ -1,0 +1,171 @@
+import { spawn, spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SIGNAL_EXIT_CODES = new Map([
+    ['SIGHUP', 129],
+    ['SIGINT', 130],
+    ['SIGQUIT', 131],
+    ['SIGTERM', 143]
+]);
+
+const projectDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workerEntrypoint = path.join(projectDirectory, 'msb.mjs');
+
+export const parsePearMajor = output => {
+    const semver = output.match(/\bSemVer\s*=\s*(\d+)\.\d+\.\d+\b/i);
+    if (semver) {
+        return Number(semver[1]);
+    }
+
+    const summary = output.match(/\/\s*v(\d+)\.\d+\.\d+\b/i);
+    return summary ? Number(summary[1]) : null;
+};
+
+export const detectPearMajor = (runCommand = spawnSync) => {
+    const result = runCommand('pear', ['-v'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    if (result.error?.code === 'ENOENT') {
+        return null;
+    }
+
+    if (result.error) {
+        throw new Error(`Could not check the installed Pear version: ${result.error.message}`);
+    }
+
+    const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+    const major = parsePearMajor(output);
+
+    if (result.status !== 0 || major === null) {
+        throw new Error('Could not determine the installed Pear major version from `pear -v`.');
+    }
+
+    return major;
+};
+
+const exitCodeFor = (code, signal) => {
+    if (Number.isInteger(code)) {
+        return code;
+    }
+
+    return SIGNAL_EXIT_CODES.get(signal) ?? 1;
+};
+
+export const runWithPearV2 = (
+    args,
+    spawnProcess = spawn
+) => new Promise((resolve, reject) => {
+    const child = spawnProcess('pear', ['run', '.', ...args], {
+        cwd: projectDirectory,
+        env: process.env,
+        stdio: 'inherit'
+    });
+
+    child.once('error', reject);
+    child.once('exit', (code, signal) => resolve(exitCodeFor(code, signal)));
+});
+
+const pipeWorkerStdio = (worker, hostProcess) => {
+    if (worker.stdin && hostProcess.stdin?.pipe) {
+        hostProcess.stdin.pipe(worker.stdin);
+    }
+    if (worker.stdout?.pipe && hostProcess.stdout) {
+        worker.stdout.pipe(hostProcess.stdout);
+    }
+    if (worker.stderr?.pipe && hostProcess.stderr) {
+        worker.stderr.pipe(hostProcess.stderr);
+    }
+};
+
+export const runWithPearV3 = async (
+    args,
+    {
+        loadPearRuntime = () => import('pear-runtime'),
+        hostProcess = process
+    } = {}
+) => {
+    let PearRuntime;
+
+    try {
+        const pearRuntimeModule = await loadPearRuntime();
+        PearRuntime = pearRuntimeModule.default ?? pearRuntimeModule;
+    } catch (error) {
+        throw new Error(
+            'Pear v3 requires the pear-runtime dependency. Run npm install before starting MSB.',
+            { cause: error }
+        );
+    }
+
+    const worker = PearRuntime.run(workerEntrypoint, args);
+    pipeWorkerStdio(worker, hostProcess);
+
+    return new Promise((resolve, reject) => {
+        let requestedSignal = null;
+        const signalListeners = [];
+
+        const cleanup = () => {
+            for (const [signal, listener] of signalListeners) {
+                hostProcess.removeListener(signal, listener);
+            }
+
+            if (worker.stdin && hostProcess.stdin?.unpipe) {
+                hostProcess.stdin.unpipe(worker.stdin);
+            }
+        };
+
+        for (const signal of SIGNAL_EXIT_CODES.keys()) {
+            const listener = () => {
+                if (requestedSignal !== null) {
+                    return;
+                }
+
+                requestedSignal = signal;
+                worker.destroy();
+            };
+
+            signalListeners.push([signal, listener]);
+            hostProcess.once(signal, listener);
+        }
+
+        worker.once('error', error => {
+            cleanup();
+            reject(error);
+        });
+        worker.once('exit', (code, signal) => {
+            cleanup();
+            resolve(exitCodeFor(code, requestedSignal ?? signal));
+        });
+    });
+};
+
+export const run = async (
+    args = process.argv.slice(2),
+    {
+        detectVersion = detectPearMajor,
+        runPearV2 = runWithPearV2,
+        runPearV3 = runWithPearV3
+    } = {}
+) => {
+    const major = detectVersion();
+
+    if (major !== null && major < 3) {
+        return runPearV2(args);
+    }
+
+    return runPearV3(args);
+};
+
+const isMainModule = process.argv[1] &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+    try {
+        process.exitCode = await run();
+    } catch (error) {
+        console.error(`MainSettlementBus Pear runner: ${error.message}`);
+        process.exitCode = 1;
+    }
+}

--- a/src/config/args.js
+++ b/src/config/args.js
@@ -1,10 +1,11 @@
 import { createConfig, ENV } from './env.js';
 
-const getArguments = () => {
-    const pearRuntime = typeof globalThis !== 'undefined' ? globalThis.Pear : undefined;
+export const getArguments = (runtime = globalThis) => {
+    const pearRuntime = runtime.Pear;
     const pearApp = pearRuntime?.app ?? pearRuntime?.config;
-    const runtimeArgs = typeof process !== 'undefined' ? process.argv.slice(2) : [];
-    return pearApp?.args ?? runtimeArgs;
+    const bareArgs = runtime.Bare?.argv?.slice(2);
+    const processArgs = runtime.process?.argv?.slice(2) ?? [];
+    return pearApp?.args ?? bareArgs ?? processArgs;
 };
 
 const getOptionValue = (args, flag) => {

--- a/tests/runner/pear-runner.test.js
+++ b/tests/runner/pear-runner.test.js
@@ -43,6 +43,16 @@ test('detects the installed Pear major from pear -v output', () => {
     assert.equal(detectPearMajor(runCommand), 3);
 });
 
+test('treats successful unrecognized Pear CLI output as the module-based v3 path', () => {
+    const runCommand = () => ({
+        status: 0,
+        stdout: '',
+        stderr: ''
+    });
+
+    assert.equal(detectPearMajor(runCommand), null);
+});
+
 test('selects pear run for v2 and the module-based runner for v3', async () => {
     const calls = [];
     const runners = {
@@ -64,9 +74,14 @@ test('selects pear run for v2 and the module-based runner for v3', async () => {
         detectVersion: () => 3,
         ...runners
     }), 3);
+    assert.equal(await run(['--network', 'development'], {
+        detectVersion: () => null,
+        ...runners
+    }), 3);
     assert.deepEqual(calls, [
         ['v2', ['--network', 'mainnet']],
-        ['v3', ['--network', 'testnet']]
+        ['v3', ['--network', 'testnet']],
+        ['v3', ['--network', 'development']]
     ]);
 });
 

--- a/tests/runner/pear-runner.test.js
+++ b/tests/runner/pear-runner.test.js
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import test from 'node:test';
+
+import {
+    detectPearMajor,
+    parsePearMajor,
+    run,
+    runWithPearV2,
+    runWithPearV3
+} from '../../scripts/pear-runner.js';
+
+test('parses the Pear runtime SemVer reported by pear -v', () => {
+    const pearV2 = [
+        'v0.3243.key / v2.6.5',
+        'Key=key',
+        'Fork=0',
+        'Length=3243',
+        'SemVer=2.6.5'
+    ].join('\n');
+
+    assert.equal(parsePearMajor(pearV2), 2);
+    assert.equal(parsePearMajor('v0.4000.key / v3.0.0'), 3);
+    assert.equal(parsePearMajor('unrecognized output'), null);
+});
+
+test('treats a missing Pear CLI as the module-based v3 path', () => {
+    const runCommand = () => ({
+        error: Object.assign(new Error('not found'), { code: 'ENOENT' })
+    });
+
+    assert.equal(detectPearMajor(runCommand), null);
+});
+
+test('detects the installed Pear major from pear -v output', () => {
+    const runCommand = () => ({
+        status: 0,
+        stdout: 'v0.4000.key / v3.0.0\nSemVer=3.0.0',
+        stderr: ''
+    });
+
+    assert.equal(detectPearMajor(runCommand), 3);
+});
+
+test('selects pear run for v2 and the module-based runner for v3', async () => {
+    const calls = [];
+    const runners = {
+        runPearV2: async args => {
+            calls.push(['v2', args]);
+            return 2;
+        },
+        runPearV3: async args => {
+            calls.push(['v3', args]);
+            return 3;
+        }
+    };
+
+    assert.equal(await run(['--network', 'mainnet'], {
+        detectVersion: () => 2,
+        ...runners
+    }), 2);
+    assert.equal(await run(['--network', 'testnet'], {
+        detectVersion: () => 3,
+        ...runners
+    }), 3);
+    assert.deepEqual(calls, [
+        ['v2', ['--network', 'mainnet']],
+        ['v3', ['--network', 'testnet']]
+    ]);
+});
+
+test('Pear v2 runner invokes pear run and forwards application arguments', async () => {
+    const child = new EventEmitter();
+    let invocation;
+    const spawnProcess = (command, args, options) => {
+        invocation = { command, args, options };
+        setImmediate(() => child.emit('exit', 0, null));
+        return child;
+    };
+
+    assert.equal(await runWithPearV2(['--rpc', '--port', '5000'], spawnProcess), 0);
+    assert.equal(invocation.command, 'pear');
+    assert.deepEqual(invocation.args, ['run', '.', '--rpc', '--port', '5000']);
+    assert.equal(invocation.options.stdio, 'inherit');
+});
+
+test('Pear v3 runner starts the MSB Bare worker and forwards stdio', async () => {
+    const hostProcess = new EventEmitter();
+    hostProcess.stdin = new PassThrough();
+    hostProcess.stdout = new PassThrough();
+    hostProcess.stderr = new PassThrough();
+
+    const worker = new EventEmitter();
+    worker.stdin = new PassThrough();
+    worker.stdout = new PassThrough();
+    worker.stderr = new PassThrough();
+    worker.destroy = () => {};
+
+    let invocation;
+    const PearRuntime = {
+        run: (entrypoint, args) => {
+            invocation = { entrypoint, args };
+            setImmediate(() => worker.emit('exit', 7, null));
+            return worker;
+        }
+    };
+
+    const exitCode = await runWithPearV3(['--network', 'testnet'], {
+        loadPearRuntime: async () => ({ default: PearRuntime }),
+        hostProcess
+    });
+
+    assert.equal(exitCode, 7);
+    assert.match(invocation.entrypoint, /msb\.mjs$/);
+    assert.deepEqual(invocation.args, ['--network', 'testnet']);
+    assert.equal(hostProcess.listenerCount('SIGINT'), 0);
+    assert.equal(hostProcess.listenerCount('SIGTERM'), 0);
+});
+
+test('Pear v3 runner terminates the worker with the host signal exit code', async () => {
+    const hostProcess = new EventEmitter();
+    const worker = new EventEmitter();
+    let destroyed = false;
+
+    worker.destroy = () => {
+        destroyed = true;
+        setImmediate(() => worker.emit('exit', null, 'SIGTERM'));
+    };
+
+    const exitCodePromise = runWithPearV3([], {
+        loadPearRuntime: async () => ({
+            default: { run: () => worker }
+        }),
+        hostProcess
+    });
+
+    setImmediate(() => hostProcess.emit('SIGINT'));
+
+    assert.equal(await exitCodePromise, 130);
+    assert.equal(destroyed, true);
+});

--- a/tests/unit/config/args.test.js
+++ b/tests/unit/config/args.test.js
@@ -1,6 +1,11 @@
 import test from 'brittle';
 
-import { isRpcEnabled, resolveConfig, resolveEnvironment } from '../../../src/config/args.js';
+import {
+    getArguments,
+    isRpcEnabled,
+    resolveConfig,
+    resolveEnvironment
+} from '../../../src/config/args.js';
 import { ENV } from '../../../src/config/env.js';
 
 async function withArgs(args, fn) {
@@ -115,4 +120,14 @@ test('args: resolveConfig rejects malformed and out-of-range port values', async
             );
         });
     }
+});
+
+test('args: reads Pear v3 worker arguments from Bare.argv', t => {
+    const args = getArguments({
+        Bare: {
+            argv: ['bare', 'msb.mjs', '--rpc', '--network', 'testnet']
+        }
+    });
+
+    t.alike(args, ['--rpc', '--network', 'testnet']);
 });


### PR DESCRIPTION
- Added a runner that uses pear run on v2 and pear-runtime on v3.
- Routed all MSB startup scripts through the new runner.
- Added Bare.argv support for Pear v3 worker arguments.
- Replaced direct TTY streams with process stdio because v3 workers use piped streams.
- Added and pinned required runtime dependencies.
- Included required runtime files in the npm package.
- Added runner and argument compatibility tests.
- Updated the runtime documentation.