### PR TITLE
chore: Update #handleApplySetGenesisEpoch to support generic config data

### DIFF
--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -4237,12 +4237,12 @@ class State extends ReadyResource {
         const encodedConsensusConfig = safeEncodeConsensusConfig(op.cco.cc);
 
         if (encodedConsensusConfig.length === 0) {
-            this.#safeLogApply(OperationType.SET_CONSENSUS_CONFIG, "Failed to encode consensus config.", node.from.key);
+            this.#safeLogApply(OperationType.SET_GENESIS_EPOCH, "Failed to encode consensus config.", node.from.key);
             return Status.FAILURE;
         }
 
         if (!this.#validateConsensusConfigApply(op.cco.cc)) {
-            this.#safeLogApply(OperationType.SET_CONSENSUS_CONFIG, "Consensus config validation failed.", node.from.key);
+            this.#safeLogApply(OperationType.SET_GENESIS_EPOCH, "Consensus config validation failed.", node.from.key);
             return Status.FAILURE;
         }
 

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -30,7 +30,6 @@ import {
     ZERO_WK,
     NULL_BUFFER,
     isZeroBuffer,
-    safeUint8ToBuffer,
     safeWriteUInt32BE,
     safeReadUint32BE,
     deepCopyBuffer, safeReadUint8
@@ -59,7 +58,6 @@ import { createGenesisEpochProof } from './utils/epochProof.js';
 import {
     decodeVdfConfig,
     safeDecodeVdfConfig,
-    safeEncodeVdfConfig
 } from '../../codecs/consensus/v1/vdfConfigCodec.js';
 import _ from 'lodash';
 
@@ -4236,12 +4234,23 @@ class State extends ReadyResource {
             return Status.FAILURE;
         }
 
+        const encodedConsensusConfig = safeEncodeConsensusConfig(op.cco.cc);
+
+        if (encodedConsensusConfig.length === 0) {
+            this.#safeLogApply(OperationType.SET_CONSENSUS_CONFIG, "Failed to encode consensus config.", node.from.key);
+            return Status.FAILURE;
+        }
+
+        if (!this.#validateConsensusConfigApply(op.cco.cc)) {
+            this.#safeLogApply(OperationType.SET_CONSENSUS_CONFIG, "Consensus config validation failed.", node.from.key);
+            return Status.FAILURE;
+        }
+
         // verify requester signature
         const message = createMessage(
             this.#config.networkId,
             op.cco.txv,
-            op.cco.df,
-            op.cco.db,
+            encodedConsensusConfig,
             op.cco.in,
             OperationType.SET_GENESIS_EPOCH
         );
@@ -4300,11 +4309,12 @@ class State extends ReadyResource {
             return Status.IGNORE;
         }
 
-        const genesisConsensusConfigKey = EntryType.CONSENSUS_CONFIG_RECORD + 0;
-        const currentConsensusConfigId = await this.#getEntryApply(
+        const currentConsensusConfigIndex = await this.#getEntryApply(
             EntryType.CONSENSUS_CONFIG_CURRENT,
             batch
         );
+
+        const genesisConsensusConfigKey = EntryType.CONSENSUS_CONFIG_RECORD + 0;
 
         const genesisConsensusConfig = await this.#getEntryApply(
             genesisConsensusConfigKey,
@@ -4312,7 +4322,7 @@ class State extends ReadyResource {
         );
 
         // Check if currently genesis config exists
-        if (currentConsensusConfigId !== null || genesisConsensusConfig !== null) {
+        if (currentConsensusConfigIndex !== null || genesisConsensusConfig !== null) {
             this.#safeLogApply(
                 OperationType.SET_GENESIS_EPOCH,
                 "Genesis consensus config is set. Cannot set a new genesis epoch",
@@ -4321,52 +4331,14 @@ class State extends ReadyResource {
             return Status.IGNORE;
         }
 
-        const vdfDifficultyBuffer = op.sgo.df;
-        const vdfDiscriminantBitSizeBuffer = op.sgo.db;
-
-        if (
-            isZeroBuffer(vdfDifficultyBuffer) ||
-            isZeroBuffer(vdfDiscriminantBitSizeBuffer)
-        ) {
-            this.#safeLogApply(
-                OperationType.SET_GENESIS_EPOCH,
-                "VDF parameters must be greater than zero. Cannot set a new genesis epoch",
-                node.from.key
-            );
-            return Status.FAILURE;
-        }
-
-        const encodedConfigData = safeEncodeVdfConfig({
-            difficulty: vdfDifficultyBuffer,
-            discriminantBitSize: vdfDiscriminantBitSizeBuffer
-        });
-
-        if (encodedConfigData.length === 0) {
-            this.#safeLogApply(OperationType.SET_GENESIS_EPOCH, "Could not encode vdf parameters. Cannot set a new genesis epoch", node.from.key)
-            return Status.FAILURE;
-        }
-
-        const encodedConsensusConfig = safeEncodeConsensusConfig({
-            sv: safeUint8ToBuffer(1),
-            cd: encodedConfigData
-        });
-
-        if (encodedConsensusConfig.length === 0) {
-            this.#safeLogApply(
-                OperationType.SET_GENESIS_EPOCH,
-                "Could not encode genesis consensus config. Cannot set a new genesis epoch",
-                node.from.key
-            );
-            return Status.FAILURE;
-        }
 
         const genesisEpoch = await createGenesisEpochProof(
             this.#config,
             requesterAddressString,
-            encodedConfigData
+            encodedConsensusConfig
         );
 
-        if (!genesisEpoch) {
+        if (genesisEpoch === null) {
             this.#safeLogApply(OperationType.SET_GENESIS_EPOCH, "Could not initialize genesis epoch", node.from.key)
             return Status.FAILURE;
         }
@@ -4414,7 +4386,7 @@ class State extends ReadyResource {
     }
 
     async #handleApplySetConsensusConfig(op, _view, base, node, batch) {
-        if (!this.#stateValidationSchema.validateSetConsensusConfigOperation(op)) {
+        if (!this.#stateValidationSchema.validateConsensusControlOperation(op)) {
             this.#safeLogApply(OperationType.SET_CONSENSUS_CONFIG, "Contract schema validation failed.", node.from.key)
             return Status.FAILURE;
         }

--- a/src/core/state/utils/epochProof.js
+++ b/src/core/state/utils/epochProof.js
@@ -57,5 +57,10 @@ export async function createGenesisEpochProof(config, proposerAddress, encodedCo
         app: []
     }
 
-    return safeEncodeEpochProof(genesisEpochProof);
+    const encodedEpochProof = safeEncodeEpochProof(genesisEpochProof);
+    if (encodedEpochProof.length === 0) {
+        return null;
+    }
+
+    return encodedEpochProof;
 }

--- a/src/core/state/utils/epochProof.js
+++ b/src/core/state/utils/epochProof.js
@@ -19,7 +19,7 @@ export async function createGenesisEpochProof(config, proposerAddress, encodedCo
     if (proposer.length === 0) {
         return null;
     }
-
+    // TODO: To be deleted because we are going to replace vdfParametersHash with parameters directly to save 28 bytes
     const vdfParametersHash = await tracCryptoApi.hash.blake3Safe(encodedConfigData);
     if (!isBufferValid(vdfParametersHash, HASH_BYTE_LENGTH)) {
         return null;
@@ -35,6 +35,7 @@ export async function createGenesisEpochProof(config, proposerAddress, encodedCo
     }
     const epoch = b4a.alloc(8, 0); // Epoch Zero
 
+    // TODO: To be deleted because we are going to replace vdfParametersHash with parameters directly to save 28 bytes
     const proofData = {
         protocol_version: protocolVersion,
         network_id: networkId,

--- a/src/index.js
+++ b/src/index.js
@@ -713,45 +713,45 @@ export class MainSettlementBus extends ReadyResource {
         }
     }
 
-    async banValidator(addresstToBan) {
+    async banValidator(addressToBan) {
         if (!this.#config.enableWallet) {
             throw new Error(
-                `Can not ban writer with address: ${addresstToBan} - wallet is not enabled.`
+                `Can not ban writer with address: ${addressToBan} - wallet is not enabled.`
             );
         }
         const adminEntry = await this.#state.getAdminEntry();
 
         if (!adminEntry) {
             throw new Error(
-                `Can not ban writer with address: ${addresstToBan} - admin entry has not been initialized.`
+                `Can not ban writer with address: ${addressToBan} - admin entry has not been initialized.`
             );
         }
 
-        if (!isAddressValid(addresstToBan, this.#config.addressPrefix)) {
+        if (!isAddressValid(addressToBan, this.#config.addressPrefix)) {
             throw new Error(
-                `Can not ban writer with address:  ${addresstToBan} - invalid address.`
+                `Can not ban writer with address:  ${addressToBan} - invalid address.`
             );
         }
 
         if (!this.isAdmin(adminEntry)) {
             throw new Error(
-                `Can not ban writer with address: ${addresstToBan} - You are not an admin.`
+                `Can not ban writer with address: ${addressToBan} - You are not an admin.`
             );
         }
 
-        const isWhitelisted = await this.#state.isAddressWhitelisted(addresstToBan);
-        const nodeEntry = await this.#state.getNodeEntry(addresstToBan);
+        const isWhitelisted = await this.#state.isAddressWhitelisted(addressToBan);
+        const nodeEntry = await this.#state.getNodeEntry(addressToBan);
 
         if (!isWhitelisted || null === nodeEntry || nodeEntry.isIndexer === true) {
             throw new Error(
-                `Can not ban writer with address: ${addresstToBan} - node is not whitelisted or is an indexer.`
+                `Can not ban writer with address: ${addressToBan} - node is not whitelisted or is an indexer.`
             );
         }
         const txValidity = await this.#state.getIndexerSequenceState();
         const assembledBanValidatorMessage = await applyStateMessageFactory(this.#wallet, this.#config)
             .buildCompleteBanWriterMessage(
                 this.#wallet.address,
-                addresstToBan,
+                addressToBan,
                 txValidity,
             )
         const encodedPayload = safeEncodeApplyOperation(assembledBanValidatorMessage)
@@ -1164,12 +1164,10 @@ export class MainSettlementBus extends ReadyResource {
                 );
         }
 
-        const encodedConsensusConfig = encodeConsensusConfig({
+        return encodeConsensusConfig({
             sv: uint8ToBuffer(schemaVersion),
             cd: encodedConfigData
         });
-
-        return encodedConsensusConfig;
     }
 
     // TODO: REFACTOR - In the future, this function should be extracted into another module.

--- a/tests/unit/state/apply/setConsensusConfig/setConsensusConfigScenarioHelpers.js
+++ b/tests/unit/state/apply/setConsensusConfig/setConsensusConfigScenarioHelpers.js
@@ -322,12 +322,18 @@ function isCurrentConfigKey(key) {
 export async function initializeGenesisEpoch(context) {
     const adminNode = context.adminBootstrap;
     const txValidity = await deriveIndexerSequenceState(adminNode.base);
+    const encodedConsensusConfig = encodeConsensusConfig({
+        sv: b4a.from([1]),
+        cd: encodeVdfConfig({
+            difficulty: uint32ToBuffer(GENESIS_DIFFICULTY),
+            discriminantBitSize: uint16ToBuffer(GENESIS_DISCRIMINANT_BIT_SIZE)
+        })
+    });
     const payload = await applyStateMessageFactory(adminNode.wallet, config)
         .buildCompleteSetGenesisEpochMessage(
             adminNode.wallet.address,
             txValidity,
-            uint32ToBuffer(GENESIS_DIFFICULTY),
-            uint16ToBuffer(GENESIS_DISCRIMINANT_BIT_SIZE)
+            encodedConsensusConfig
         );
 
     await appendAndUpdate(adminNode.base, safeEncodeApplyOperation(payload));

--- a/tests/unit/state/apply/setGenesisEpoch/setGenesisEpochScenarioHelpers.js
+++ b/tests/unit/state/apply/setGenesisEpoch/setGenesisEpochScenarioHelpers.js
@@ -417,6 +417,28 @@ export async function applyWithGenesisProofHashFailure(context, payload) {
     return injected;
 }
 
+export async function applyWithGenesisEpochEncodingFailure(context, payload) {
+    const originalFrom = b4a.from;
+    let injected = false;
+
+    b4a.from = (value, ...args) => {
+        const encodedValue = originalFrom(value, ...args);
+        if (!injected && isEncodedGenesisEpochProof(encodedValue)) {
+            injected = true;
+            throw new Error('forced genesis epoch encoding failure');
+        }
+        return encodedValue;
+    };
+
+    try {
+        await appendAndUpdate(context.adminBootstrap.base, payload);
+    } finally {
+        b4a.from = originalFrom;
+    }
+
+    return injected;
+}
+
 function patchEntriesForNextApply(base, overrides) {
     const originalApply = base._handlers.apply;
     let shouldPatchNextApply = true;
@@ -480,4 +502,12 @@ function buffersHaveSameBytes(left, right) {
         if (left[index] !== right[index]) return false;
     }
     return true;
+}
+
+function isEncodedGenesisEpochProof(value) {
+    const epochProof = safeDecodeEpochProof(value);
+    if (!epochProof || epochProof.app.length !== 0) return false;
+
+    const proofProposal = safeDecodeProofProposal(epochProof.pd);
+    return proofProposal !== null;
 }

--- a/tests/unit/state/apply/setGenesisEpoch/setGenesisEpochScenarioHelpers.js
+++ b/tests/unit/state/apply/setGenesisEpoch/setGenesisEpochScenarioHelpers.js
@@ -1,0 +1,483 @@
+import b4a from 'b4a';
+import tracCryptoApi from 'trac-crypto-api';
+import { setupStateNetwork } from '../../../../helpers/StateNetworkFactory.js';
+import {
+    defaultOpenHyperbeeView,
+    deriveIndexerSequenceState,
+    eventFlush,
+    seedBootstrapIndexer
+} from '../../../../helpers/autobaseTestHelpers.js';
+import { applyStateMessageFactory } from '../../../../../src/messages/state/applyStateMessageFactory.js';
+import {
+    safeDecodeApplyOperation,
+    safeDecodeEpochProof,
+    safeEncodeApplyOperation,
+    safeEncodeConsensusConfig
+} from '../../../../../src/codecs/apply/applyOperationCodec.js';
+import {
+    decodeVdfConfig,
+    encodeVdfConfig
+} from '../../../../../src/codecs/consensus/v1/vdfConfigCodec.js';
+import { safeDecodeProofProposal } from '../../../../../src/codecs/consensus/v1/consensusV1OperationCodec.js';
+import {
+    AUTOBASE_VALUE_ENCODING,
+    ConsensusProtocolVersion,
+    EntryType,
+    HASH_BYTE_LENGTH,
+    SIGNATURE_BYTE_LENGTH,
+    VDF_BLOB_PROOF_SIZE
+} from '../../../../../src/utils/constants.js';
+import {
+    safeReadUint32BE,
+    safeUint8ToBuffer,
+    uint16ToBuffer,
+    uint32ToBuffer
+} from '../../../../../src/utils/buffer.js';
+import { config } from '../../../../helpers/config.js';
+import { buildAddAdminRequesterPayload } from '../addAdmin/addAdminScenarioHelpers.js';
+
+export const GENESIS_DIFFICULTY = 55_000_000;
+export const GENESIS_DISCRIMINANT_BIT_SIZE = 2048;
+
+export async function setupSetGenesisEpochScenario(t, { nodes = 2 } = {}) {
+    const context = await setupStateNetwork({
+        nodes,
+        valueEncoding: AUTOBASE_VALUE_ENCODING,
+        open: defaultOpenHyperbeeView,
+        stateOptions: { enableTxApplyLogs: false }
+    });
+
+    seedBootstrapIndexer(context);
+    t.teardown(async () => context.teardown());
+
+    await appendAndUpdate(
+        context.adminBootstrap.base,
+        await buildAddAdminRequesterPayload(context)
+    );
+
+    return context;
+}
+
+export async function buildSetGenesisEpochPayload(
+    context,
+    {
+        difficulty = GENESIS_DIFFICULTY,
+        discriminantBitSize = GENESIS_DISCRIMINANT_BIT_SIZE,
+        schemaVersion = 1,
+        configData,
+        wallet = context.adminBootstrap.wallet,
+        txValidity,
+        messageConfig = config,
+        transformEncodedConfig
+    } = {}
+) {
+    const effectiveTxValidity = txValidity ??
+        await deriveIndexerSequenceState(context.adminBootstrap.base);
+    const effectiveConfigData = configData ?? encodeVdfConfig({
+        difficulty: uint32ToBuffer(difficulty),
+        discriminantBitSize: uint16ToBuffer(discriminantBitSize)
+    });
+    const canonicalConsensusConfig = safeEncodeConsensusConfig({
+        sv: b4a.from([schemaVersion]),
+        cd: effectiveConfigData
+    });
+    const encodedConsensusConfig = transformEncodedConfig
+        ? transformEncodedConfig(canonicalConsensusConfig)
+        : canonicalConsensusConfig;
+    const payload = await applyStateMessageFactory(wallet, messageConfig)
+        .buildCompleteSetGenesisEpochMessage(
+            wallet.address,
+            effectiveTxValidity,
+            encodedConsensusConfig
+        );
+
+    return safeEncodeApplyOperation(payload);
+}
+
+export async function appendAndUpdate(base, payload) {
+    await base.append(payload);
+    await base.update();
+    await eventFlush();
+}
+
+export async function appendBatchAndUpdate(base, payloads) {
+    await base.append(payloads);
+    await base.update();
+    await eventFlush();
+}
+
+export async function assertGenesisUninitialized(t, base, payload = null) {
+    t.is(
+        await base.view.get(EntryType.EPOCH_CURRENT),
+        null,
+        'current epoch pointer is absent'
+    );
+    t.is(
+        await base.view.get(EntryType.EPOCH + '0'),
+        null,
+        'genesis epoch hash is absent'
+    );
+    t.is(
+        await base.view.get(EntryType.CONSENSUS_CONFIG_CURRENT),
+        null,
+        'current consensus config pointer is absent'
+    );
+    t.is(
+        await base.view.get(EntryType.CONSENSUS_CONFIG_RECORD + 0),
+        null,
+        'genesis consensus config record is absent'
+    );
+
+    const epochProofEntries = await collectEntriesWithPrefix(base, EntryType.EPOCH_HASH);
+    t.is(epochProofEntries.length, 0, 'genesis epoch proof ledger is empty');
+
+    if (payload) {
+        await assertOperationRecorded(t, base, payload, false);
+    }
+}
+
+export async function assertSetGenesisEpochFailureState(
+    t,
+    context,
+    payload,
+    { skipSync = false } = {}
+) {
+    await assertGenesisUninitialized(t, context.adminBootstrap.base, payload);
+
+    if (!skipSync) {
+        await context.sync();
+        for (const reader of context.peers.slice(1)) {
+            await assertGenesisUninitialized(t, reader.base, payload);
+        }
+    }
+}
+
+export async function assertGenesisInitialized(
+    t,
+    base,
+    payload,
+    {
+        difficulty = GENESIS_DIFFICULTY,
+        discriminantBitSize = GENESIS_DISCRIMINANT_BIT_SIZE
+    } = {}
+) {
+    const operation = safeDecodeApplyOperation(payload);
+    t.ok(operation?.cco?.cc, 'SET_GENESIS_EPOCH payload decodes');
+    if (!operation?.cco?.cc) return;
+
+    const encodedConsensusConfig = safeEncodeConsensusConfig(operation.cco.cc);
+    t.ok(encodedConsensusConfig.length > 0, 'genesis consensus config encodes canonically');
+
+    const currentEpochEntry = await base.view.get(EntryType.EPOCH_CURRENT);
+    t.ok(currentEpochEntry, 'current epoch pointer exists');
+    if (!currentEpochEntry) return;
+    t.is(currentEpochEntry.value.length, 8, 'current epoch pointer has uint64 width');
+    t.ok(
+        b4a.equals(currentEpochEntry.value, b4a.alloc(8)),
+        'current epoch pointer stores epoch zero'
+    );
+
+    const epochZeroEntry = await base.view.get(EntryType.EPOCH + '0');
+    t.ok(epochZeroEntry, 'genesis epoch hash exists');
+    if (!epochZeroEntry) return;
+    t.is(epochZeroEntry.value.length, HASH_BYTE_LENGTH, 'genesis epoch hash has canonical width');
+
+    const epochProofKey = EntryType.EPOCH_HASH + epochZeroEntry.value.toString('hex');
+    const epochProofEntry = await base.view.get(epochProofKey);
+    t.ok(epochProofEntry, 'genesis epoch proof exists under its content hash');
+    if (!epochProofEntry) return;
+
+    const calculatedEpochProofHash = await tracCryptoApi.hash.blake3Safe(epochProofEntry.value);
+    t.ok(
+        b4a.equals(calculatedEpochProofHash, epochZeroEntry.value),
+        'epoch zero points to the stored genesis proof'
+    );
+
+    const epochProof = safeDecodeEpochProof(epochProofEntry.value);
+    t.ok(epochProof, 'stored genesis epoch proof decodes');
+    if (!epochProof) return;
+    t.is(epochProof.app.length, 0, 'genesis epoch proof has no approvals');
+
+    const proofProposal = safeDecodeProofProposal(epochProof.pd);
+    t.ok(proofProposal, 'stored genesis proof proposal decodes');
+    if (!proofProposal) return;
+
+    t.ok(
+        b4a.equals(
+            proofProposal.protocol_version,
+            safeUint8ToBuffer(ConsensusProtocolVersion.V1)
+        ),
+        'genesis proof uses consensus protocol version 1'
+    );
+    t.ok(
+        b4a.equals(proofProposal.network_id, uint16ToBuffer(config.networkId)),
+        'genesis proof stores the configured network id'
+    );
+    t.ok(b4a.equals(proofProposal.epoch, b4a.alloc(8)), 'genesis proof stores epoch zero');
+    t.ok(
+        b4a.equals(
+            proofProposal.previous_epoch_record_hash,
+            b4a.alloc(HASH_BYTE_LENGTH)
+        ),
+        'genesis proof has a zero previous epoch hash'
+    );
+    t.ok(
+        b4a.equals(proofProposal.proposer, operation.address),
+        'genesis proof proposer is the requesting admin'
+    );
+
+    const expectedVdfParametersHash = await tracCryptoApi.hash.blake3Safe(
+        encodedConsensusConfig
+    );
+    t.ok(
+        b4a.equals(proofProposal.vdf_parameters_hash, expectedVdfParametersHash),
+        'genesis proof binds the canonical consensus config'
+    );
+    t.ok(
+        b4a.equals(proofProposal.vdf_proof, b4a.alloc(VDF_BLOB_PROOF_SIZE)),
+        'genesis proof starts with an empty VDF proof'
+    );
+    t.ok(
+        b4a.equals(proofProposal.signature, b4a.alloc(SIGNATURE_BYTE_LENGTH)),
+        'genesis proof starts with an empty signature'
+    );
+
+    const currentConfigEntry = await base.view.get(EntryType.CONSENSUS_CONFIG_CURRENT);
+    t.ok(currentConfigEntry, 'current consensus config pointer exists');
+    if (!currentConfigEntry) return;
+    t.is(currentConfigEntry.value.length, 4, 'current consensus config pointer has uint32 width');
+    t.is(safeReadUint32BE(currentConfigEntry.value), 0, 'genesis consensus config is current');
+
+    const configRecordEntry = await base.view.get(EntryType.CONSENSUS_CONFIG_RECORD + 0);
+    t.ok(configRecordEntry, 'genesis consensus config record exists');
+    if (!configRecordEntry) return;
+    t.ok(
+        b4a.equals(configRecordEntry.value, encodedConsensusConfig),
+        'genesis consensus config record stores canonical bytes'
+    );
+
+    const decodedVdfConfig = decodeVdfConfig(operation.cco.cc.cd);
+    t.is(
+        decodedVdfConfig.difficulty.readUInt32BE(0),
+        difficulty,
+        'genesis VDF difficulty matches'
+    );
+    t.is(
+        decodedVdfConfig.discriminantBitSize.readUInt16BE(0),
+        discriminantBitSize,
+        'genesis VDF discriminant bit size matches'
+    );
+
+    t.is(await base.view.get(EntryType.EPOCH + '1'), null, 'epoch one is absent');
+    t.is(
+        await base.view.get(EntryType.CONSENSUS_CONFIG_RECORD + 1),
+        null,
+        'consensus config record one is absent'
+    );
+    t.is(
+        (await collectEntriesWithPrefix(base, EntryType.EPOCH_HASH)).length,
+        1,
+        'exactly one epoch proof is stored'
+    );
+
+    await assertOperationRecorded(t, base, payload, true);
+}
+
+export async function assertOperationRecorded(t, base, payload, expected) {
+    const operation = safeDecodeApplyOperation(payload);
+    t.ok(operation?.cco?.tx, 'SET_GENESIS_EPOCH transaction hash decodes');
+
+    const entry = operation?.cco?.tx
+        ? await base.view.get(operation.cco.tx.toString('hex'))
+        : null;
+    if (expected) {
+        t.ok(entry, 'SET_GENESIS_EPOCH transaction is recorded');
+        if (!entry) return;
+        t.ok(
+            b4a.equals(entry.value, payload),
+            'transaction marker stores the complete original operation payload'
+        );
+    } else {
+        t.is(entry, null, 'SET_GENESIS_EPOCH transaction is not recorded');
+    }
+}
+
+export function mutatePayloadForInvalidSchema(t, validPayload) {
+    return mutatePayloadBuffer(t, validPayload, ['cco', 'tx'], HASH_BYTE_LENGTH - 1);
+}
+
+export function mutatePayloadBuffer(t, validPayload, path, length) {
+    const operation = safeDecodeApplyOperation(validPayload);
+    t.ok(operation, 'fixtures decode');
+
+    let parent = operation;
+    for (const key of path.slice(0, -1)) {
+        parent = parent?.[key];
+    }
+    if (!parent) return validPayload;
+
+    parent[path.at(-1)] = b4a.alloc(length, 1);
+    return safeEncodeApplyOperation(operation);
+}
+
+export function mutateConfigDataWithoutResigning(t, validPayload) {
+    const operation = safeDecodeApplyOperation(validPayload);
+    t.ok(operation?.cco?.cc?.cd, 'fixtures decode');
+    const mutated = b4a.from(operation.cco.cc.cd);
+    mutated[0] ^= 0x01;
+    operation.cco.cc.cd = mutated;
+    return safeEncodeApplyOperation(operation);
+}
+
+export async function buildPayloadWithTxValidity(context, txValidity) {
+    return buildSetGenesisEpochPayload(context, { txValidity });
+}
+
+export async function applyWithEntryOverrides(context, payload, overrides) {
+    const base = context.adminBootstrap.base;
+    const cleanup = patchEntriesForNextApply(base, overrides);
+    try {
+        await appendAndUpdate(base, payload);
+    } finally {
+        cleanup();
+    }
+}
+
+export async function applyWithConsensusConfigEncodingFailure(context, payload) {
+    const operation = safeDecodeApplyOperation(payload);
+    const encodedConsensusConfig = safeEncodeConsensusConfig(operation?.cco?.cc);
+    const originalFrom = b4a.from;
+    let injected = false;
+
+    b4a.from = (value, ...args) => {
+        if (!injected && buffersHaveSameBytes(value, encodedConsensusConfig)) {
+            injected = true;
+            throw new Error('forced consensus config encoding failure');
+        }
+        return originalFrom(value, ...args);
+    };
+
+    try {
+        await appendAndUpdate(context.adminBootstrap.base, payload);
+    } finally {
+        b4a.from = originalFrom;
+    }
+
+    return injected;
+}
+
+export async function applyWithMessageConstructionFailure(context, payload) {
+    const operation = safeDecodeApplyOperation(payload);
+    const encodedConsensusConfig = safeEncodeConsensusConfig(operation?.cco?.cc);
+    const originalConcat = b4a.concat;
+    let injected = false;
+
+    b4a.concat = (buffers, ...args) => {
+        if (
+            !injected &&
+            Array.isArray(buffers) &&
+            buffers.length === 5 &&
+            buffersHaveSameBytes(buffers[2], encodedConsensusConfig)
+        ) {
+            injected = true;
+            return b4a.alloc(0);
+        }
+        return originalConcat(buffers, ...args);
+    };
+
+    try {
+        await appendAndUpdate(context.adminBootstrap.base, payload);
+    } finally {
+        b4a.concat = originalConcat;
+    }
+
+    return injected;
+}
+
+export async function applyWithGenesisProofHashFailure(context, payload) {
+    const operation = safeDecodeApplyOperation(payload);
+    const encodedConsensusConfig = safeEncodeConsensusConfig(operation?.cco?.cc);
+    const originalHash = tracCryptoApi.hash.blake3Safe;
+    let injected = false;
+
+    tracCryptoApi.hash.blake3Safe = async value => {
+        if (!injected && buffersHaveSameBytes(value, encodedConsensusConfig)) {
+            injected = true;
+            return b4a.alloc(0);
+        }
+        return originalHash(value);
+    };
+
+    try {
+        await appendAndUpdate(context.adminBootstrap.base, payload);
+    } finally {
+        tracCryptoApi.hash.blake3Safe = originalHash;
+    }
+
+    return injected;
+}
+
+function patchEntriesForNextApply(base, overrides) {
+    const originalApply = base._handlers.apply;
+    let shouldPatchNextApply = true;
+
+    base._handlers.apply = async (nodes, view, baseContext) => {
+        if (!shouldPatchNextApply) {
+            return originalApply(nodes, view, baseContext);
+        }
+
+        shouldPatchNextApply = false;
+        const previousBatch = view.batch;
+        const boundBatch = previousBatch.bind(view);
+
+        view.batch = function patchedBatch(...args) {
+            const batch = boundBatch(...args);
+            const originalGet = batch.get?.bind(batch);
+            if (typeof originalGet === 'function') {
+                batch.get = async key => {
+                    const normalizedKey = normalizeKey(key);
+                    if (!overrides.has(normalizedKey)) {
+                        return originalGet(key);
+                    }
+
+                    const value = overrides.get(normalizedKey);
+                    return value === null ? null : { value };
+                };
+            }
+            return batch;
+        };
+
+        try {
+            return await originalApply(nodes, view, baseContext);
+        } finally {
+            view.batch = previousBatch;
+        }
+    };
+
+    return () => {
+        base._handlers.apply = originalApply;
+    };
+}
+
+async function collectEntriesWithPrefix(base, prefix) {
+    const entries = [];
+    for await (const entry of base.view.createReadStream({
+        gte: prefix,
+        lt: `${prefix}\xff`
+    })) {
+        entries.push(entry);
+    }
+    return entries;
+}
+
+function normalizeKey(key) {
+    return b4a.isBuffer(key) ? key.toString() : key;
+}
+
+function buffersHaveSameBytes(left, right) {
+    if (!left || !right || left.length !== right.length) return false;
+    for (let index = 0; index < left.length; index++) {
+        if (left[index] !== right[index]) return false;
+    }
+    return true;
+}

--- a/tests/unit/state/apply/setGenesisEpoch/state.apply.setGenesisEpoch.test.js
+++ b/tests/unit/state/apply/setGenesisEpoch/state.apply.setGenesisEpoch.test.js
@@ -1,0 +1,568 @@
+import { test } from 'brittle';
+import b4a from 'b4a';
+import InvalidPayloadValidationScenario from '../common/payload-structure/invalidPayloadValidationScenario.js';
+import RequesterAddressValidationScenario from '../common/requesterAddressValidationScenario.js';
+import createRequesterPublicKeyValidationScenario from '../common/requesterPublicKeyValidationScenario.js';
+import AdminEntryMissingScenario from '../common/access-control/adminEntryMissingScenario.js';
+import AdminEntryDecodeFailureScenario from '../common/access-control/adminEntryDecodeFailureScenario.js';
+import AdminOnlyGuardScenario from '../common/access-control/adminOnlyGuardScenario.js';
+import AdminPublicKeyDecodeFailureScenario from '../common/access-control/adminPublicKeyDecodeFailureScenario.js';
+import AdminConsistencyMismatchScenario from '../common/access-control/adminConsistencyMismatchScenario.js';
+import InvalidHashValidationScenario from '../common/payload-structure/invalidHashValidationScenario.js';
+import InvalidSignatureValidationScenario, {
+    SignatureMutationStrategy
+} from '../common/payload-structure/invalidSignatureValidationScenario.js';
+import InvalidMessageComponentValidationScenario, {
+    MessageComponentStrategy
+} from '../common/invalidMessageComponentValidationScenario.js';
+import IndexerSequenceStateInvalidScenario from '../common/indexer/indexerSequenceStateInvalidScenario.js';
+import TransactionValidityMismatchScenario from '../common/transactionValidityMismatchScenario.js';
+import {
+    appendAndUpdate,
+    appendBatchAndUpdate,
+    applyWithConsensusConfigEncodingFailure,
+    applyWithEntryOverrides,
+    applyWithGenesisProofHashFailure,
+    applyWithMessageConstructionFailure,
+    assertGenesisInitialized,
+    assertGenesisUninitialized,
+    assertOperationRecorded,
+    assertSetGenesisEpochFailureState,
+    buildPayloadWithTxValidity,
+    buildSetGenesisEpochPayload,
+    mutateConfigDataWithoutResigning,
+    mutatePayloadBuffer,
+    mutatePayloadForInvalidSchema,
+    setupSetGenesisEpochScenario
+} from './setGenesisEpochScenarioHelpers.js';
+import {
+    safeDecodeApplyOperation,
+    safeEncodeConsensusConfig
+} from '../../../../../src/codecs/apply/applyOperationCodec.js';
+import {
+    CONSENSUS_CONFIG_DATA_MAX_SIZE,
+    EntryType,
+    HASH_BYTE_LENGTH,
+    NONCE_BYTE_LENGTH,
+    SIGNATURE_BYTE_LENGTH
+} from '../../../../../src/utils/constants.js';
+import { config as stateConfig } from '../../../../helpers/config.js';
+
+const assertRejected = (t, context, validPayload, invalidPayload) =>
+    assertSetGenesisEpochFailureState(t, context, invalidPayload ?? validPayload);
+const assertRejectedLocally = (t, context, validPayload, invalidPayload) =>
+    assertSetGenesisEpochFailureState(
+        t,
+        context,
+        invalidPayload ?? validPayload,
+        { skipSync: true }
+    );
+
+// #stateValidationSchema.validateConsensusControlOperation(op)
+new InvalidPayloadValidationScenario({
+    title: 'State.apply SET_GENESIS_EPOCH rejects malformed contract payloads',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    mutatePayload: mutatePayloadForInvalidSchema,
+    assertStateUnchanged: assertRejected,
+    expectedLogs: ['Contract schema validation failed.']
+}).performScenario();
+
+for (const [label, path, length] of [
+    ['short requester address', ['address'], stateConfig.addressLength - 1],
+    ['long requester address', ['address'], stateConfig.addressLength + 1],
+    ['long transaction hash', ['cco', 'tx'], HASH_BYTE_LENGTH + 1],
+    ['short transaction validity', ['cco', 'txv'], HASH_BYTE_LENGTH - 1],
+    ['long transaction validity', ['cco', 'txv'], HASH_BYTE_LENGTH + 1],
+    ['empty consensus schema version', ['cco', 'cc', 'sv'], 0],
+    ['long consensus schema version', ['cco', 'cc', 'sv'], 2],
+    ['empty consensus config data', ['cco', 'cc', 'cd'], 0],
+    [
+        'oversized consensus config data',
+        ['cco', 'cc', 'cd'],
+        CONSENSUS_CONFIG_DATA_MAX_SIZE + 1
+    ],
+    ['short nonce', ['cco', 'in'], NONCE_BYTE_LENGTH - 1],
+    ['long nonce', ['cco', 'in'], NONCE_BYTE_LENGTH + 1],
+    ['short signature', ['cco', 'is'], SIGNATURE_BYTE_LENGTH - 1],
+    ['long signature', ['cco', 'is'], SIGNATURE_BYTE_LENGTH + 1]
+]) {
+    new InvalidPayloadValidationScenario({
+        title: `State.apply SET_GENESIS_EPOCH rejects a ${label}`,
+        setupScenario: setupSetGenesisEpochScenario,
+        buildValidPayload: buildSetGenesisEpochPayload,
+        mutatePayload: (t, payload) => mutatePayloadBuffer(t, payload, path, length),
+        assertStateUnchanged: assertRejected,
+        expectedLogs: ['Contract schema validation failed.']
+    }).performScenario();
+}
+
+registerRejectedConfigCase({
+    title: 'State.apply SET_GENESIS_EPOCH rejects schema version 0 with valid config data',
+    buildOptions: { schemaVersion: 0 },
+    expectedLog: 'Contract schema validation failed.'
+});
+
+// requesterAddressString === null
+new RequesterAddressValidationScenario({
+    title: 'State.apply SET_GENESIS_EPOCH rejects an invalid requester address',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    assertStateUnchanged: assertRejected,
+    expectedLogs: ['Requester address is invalid.']
+}).performScenario();
+
+// requesterPublicKey === NULL_BUFFER
+createRequesterPublicKeyValidationScenario({
+    title: 'State.apply SET_GENESIS_EPOCH rejects an undecodable requester public key',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    assertStateUnchanged: assertRejected,
+    expectedLogs: ['Failed to decode requester public key.']
+}).performScenario();
+
+// adminEntry === null
+new AdminEntryMissingScenario({
+    title: 'State.apply SET_GENESIS_EPOCH rejects a missing admin entry',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    assertStateUnchanged: assertRejectedLocally,
+    expectedLogs: ['Invalid admin entry.']
+}).performScenario();
+
+// decodedAdminEntry === null
+new AdminEntryDecodeFailureScenario({
+    title: 'State.apply SET_GENESIS_EPOCH rejects an undecodable admin entry',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    assertStateUnchanged: assertRejectedLocally,
+    expectedLogs: ['Failed to decode admin entry.']
+}).performScenario();
+
+// !this.#isAdminApply(decodedAdminEntry, node)
+new AdminOnlyGuardScenario({
+    title: 'State.apply SET_GENESIS_EPOCH rejects a non-admin writer',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    assertStateUnchanged: assertRejectedLocally,
+    expectedLogs: ['Node is not allowed to perform this operation. (ADMIN ONLY)']
+}).performScenario();
+
+// adminPublicKey === NULL_BUFFER
+new AdminPublicKeyDecodeFailureScenario({
+    title: 'State.apply SET_GENESIS_EPOCH rejects an undecodable admin public key',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    assertStateUnchanged: assertRejectedLocally,
+    expectedLogs: ['Failed to decode admin public key.']
+}).performScenario();
+
+// adminPublicKey !== requesterPublicKey
+new AdminConsistencyMismatchScenario({
+    title: 'State.apply SET_GENESIS_EPOCH rejects requester/admin key mismatch',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    assertStateUnchanged: assertRejectedLocally,
+    expectedLogs: ['System admin and node public keys do not match.']
+}).performScenario();
+
+// encodedConsensusConfig.length === 0
+test('State.apply SET_GENESIS_EPOCH fails closed when consensus config encoding fails', async t => {
+    const context = await setupSetGenesisEpochScenario(t);
+    const payload = await buildSetGenesisEpochPayload(context);
+    const { logs, result } = captureApplyErrors(() =>
+        applyWithConsensusConfigEncodingFailure(context, payload)
+    );
+    const injected = await result;
+
+    t.ok(injected, 'consensus config encoder failure was injected');
+    await assertSetGenesisEpochFailureState(t, context, payload, { skipSync: true });
+    assertLog(t, logs, 'Failed to encode consensus config.');
+});
+
+// !this.#validateConsensusConfigApply(op.cco.cc)
+for (const schemaVersion of [2, 255]) {
+    registerRejectedConfigCase({
+        title: `State.apply SET_GENESIS_EPOCH rejects unsupported schema version ${schemaVersion}`,
+        buildOptions: { schemaVersion, configData: b4a.from([1]) },
+        expectedLog: 'Consensus config validation failed.'
+    });
+}
+
+for (const configDataLength of [
+    1,
+    2,
+    3,
+    4,
+    5,
+    7,
+    8,
+    31,
+    32,
+    255,
+    256,
+    1024,
+    CONSENSUS_CONFIG_DATA_MAX_SIZE - 1,
+    CONSENSUS_CONFIG_DATA_MAX_SIZE
+]) {
+    registerRejectedConfigCase({
+        title: `State.apply SET_GENESIS_EPOCH rejects schema-v1 data length ${configDataLength}`,
+        buildOptions: { configData: b4a.alloc(configDataLength, 1) },
+        expectedLog: 'Consensus config validation failed.'
+    });
+}
+
+registerRejectedConfigCase({
+    title: 'State.apply SET_GENESIS_EPOCH rejects zero VDF difficulty',
+    buildOptions: { difficulty: 0 },
+    expectedLog: 'Consensus config validation failed.'
+});
+
+registerRejectedConfigCase({
+    title: 'State.apply SET_GENESIS_EPOCH rejects zero VDF discriminant bit size',
+    buildOptions: { discriminantBitSize: 0 },
+    expectedLog: 'Consensus config validation failed.'
+});
+
+registerRejectedConfigCase({
+    title: 'State.apply SET_GENESIS_EPOCH rejects an all-zero VDF config',
+    buildOptions: { difficulty: 0, discriminantBitSize: 0 },
+    expectedLog: 'Consensus config validation failed.'
+});
+
+// message.length === 0
+test('State.apply SET_GENESIS_EPOCH fails closed when requester message construction fails', async t => {
+    const context = await setupSetGenesisEpochScenario(t);
+    const payload = await buildSetGenesisEpochPayload(context);
+    const { logs, result } = captureApplyErrors(() =>
+        applyWithMessageConstructionFailure(context, payload)
+    );
+    const injected = await result;
+
+    t.ok(injected, 'requester message construction failure was injected');
+    await assertSetGenesisEpochFailureState(t, context, payload, { skipSync: true });
+    assertLog(t, logs, 'Invalid requester message.');
+});
+
+// hash !== op.cco.tx
+new InvalidHashValidationScenario({
+    title: 'State.apply SET_GENESIS_EPOCH rejects a mismatched transaction hash',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    assertStateUnchanged: assertRejected,
+    expectedLogs: ['Message hash does not match the tx_hash.']
+}).performScenario();
+
+test('State.apply SET_GENESIS_EPOCH rejects a payload signed for another network', async t => {
+    const context = await setupSetGenesisEpochScenario(t);
+    const foreignNetworkId = stateConfig.networkId === 0xffff
+        ? stateConfig.networkId - 1
+        : stateConfig.networkId + 1;
+    const payload = await buildSetGenesisEpochPayload(context, {
+        messageConfig: {
+            addressPrefix: stateConfig.addressPrefix,
+            networkId: foreignNetworkId
+        }
+    });
+    const { logs, result } = captureApplyErrors(() =>
+        appendAndUpdate(context.adminBootstrap.base, payload)
+    );
+    await result;
+
+    await assertSetGenesisEpochFailureState(t, context, payload);
+    assertLog(t, logs, 'Message hash does not match the tx_hash.');
+});
+
+for (const [label, transformEncodedConfig] of [
+    [
+        'unknown protobuf fields',
+        canonicalConfig => b4a.concat([canonicalConfig, b4a.from([0x78, 0x01])])
+    ],
+    [
+        'a duplicated protobuf config field',
+        canonicalConfig => b4a.concat([canonicalConfig, canonicalConfig])
+    ]
+]) {
+    test(`State.apply SET_GENESIS_EPOCH rejects config bytes with ${label}`, async t => {
+        const context = await setupSetGenesisEpochScenario(t);
+        const payload = await buildSetGenesisEpochPayload(context, {
+            transformEncodedConfig
+        });
+        const operation = safeDecodeApplyOperation(payload);
+        t.ok(
+            operation?.cco?.cc,
+            'non-canonical protobuf config decodes into the contract payload'
+        );
+
+        const { logs, result } = captureApplyErrors(() =>
+            appendAndUpdate(context.adminBootstrap.base, payload)
+        );
+        await result;
+
+        await assertSetGenesisEpochFailureState(t, context, payload);
+        assertLog(t, logs, 'Message hash does not match the tx_hash.');
+    });
+}
+
+new InvalidHashValidationScenario({
+    title: 'State.apply SET_GENESIS_EPOCH binds config bytes into the transaction hash',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    mutatePayload: mutateConfigDataWithoutResigning,
+    assertStateUnchanged: assertRejected,
+    expectedLogs: ['Message hash does not match the tx_hash.']
+}).performScenario();
+
+for (const [label, strategy] of [
+    ['transaction validity', MessageComponentStrategy.TX_VALIDITY],
+    ['nonce', MessageComponentStrategy.NONCE]
+]) {
+    new InvalidMessageComponentValidationScenario({
+        title: `State.apply SET_GENESIS_EPOCH binds ${label} into the transaction hash`,
+        setupScenario: setupSetGenesisEpochScenario,
+        buildValidPayload: buildSetGenesisEpochPayload,
+        assertStateUnchanged: assertRejected,
+        strategy,
+        expectedLogs: ['Message hash does not match the tx_hash.']
+    }).performScenario();
+}
+
+// !isMessageVerified
+for (const [label, strategy] of [
+    ['foreign', SignatureMutationStrategy.FOREIGN_SIGNATURE],
+    ['tampered', SignatureMutationStrategy.TYPE_MISMATCH]
+]) {
+    new InvalidSignatureValidationScenario({
+        title: `State.apply SET_GENESIS_EPOCH rejects a ${label} admin signature`,
+        setupScenario: setupSetGenesisEpochScenario,
+        buildValidPayload: buildSetGenesisEpochPayload,
+        assertStateUnchanged: assertRejected,
+        strategy,
+        expectedLogs: ['Failed to verify message signature.']
+    }).performScenario();
+}
+
+// indexersSequenceState === null
+new IndexerSequenceStateInvalidScenario({
+    title: 'State.apply SET_GENESIS_EPOCH fails closed when indexer state is unavailable',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    assertStateUnchanged: assertRejectedLocally,
+    expectedLogs: ['Indexer sequence state is invalid.']
+}).performScenario();
+
+// op.cco.txv !== indexersSequenceState
+new TransactionValidityMismatchScenario({
+    title: 'State.apply SET_GENESIS_EPOCH rejects a correctly signed stale tx validity',
+    setupScenario: setupSetGenesisEpochScenario,
+    buildValidPayload: buildSetGenesisEpochPayload,
+    assertStateUnchanged: assertRejected,
+    txValidityPath: ['cco', 'txv'],
+    rebuildPayloadWithTxValidity: ({ context, mutatedTxValidity }) =>
+        buildPayloadWithTxValidity(context, mutatedTxValidity),
+    expectedLogs: ['Transaction was not executed.']
+}).performScenario();
+
+// opEntry !== null
+test('State.apply SET_GENESIS_EPOCH detects a duplicate transaction inside one batch', async t => {
+    const context = await setupSetGenesisEpochScenario(t);
+    const payload = await buildSetGenesisEpochPayload(context);
+    const { logs, result } = captureApplyErrors(() =>
+        appendBatchAndUpdate(context.adminBootstrap.base, [payload, payload])
+    );
+    await result;
+
+    await assertGenesisInitialized(t, context.adminBootstrap.base, payload);
+    assertLog(t, logs, 'Operation has already been applied.');
+});
+
+test('State.apply SET_GENESIS_EPOCH detects the same transaction in consecutive batches', async t => {
+    const context = await setupSetGenesisEpochScenario(t);
+    const payload = await buildSetGenesisEpochPayload(context);
+
+    await appendAndUpdate(context.adminBootstrap.base, payload);
+    await assertGenesisInitialized(t, context.adminBootstrap.base, payload);
+
+    const { logs, result } = captureApplyErrors(() =>
+        appendAndUpdate(context.adminBootstrap.base, payload)
+    );
+    await result;
+
+    await assertGenesisInitialized(t, context.adminBootstrap.base, payload);
+    assertLog(t, logs, 'Operation has already been applied.');
+});
+
+// currentEpoch !== null
+test('State.apply SET_GENESIS_EPOCH ignores any non-null current epoch entry', async t => {
+    const context = await setupSetGenesisEpochScenario(t);
+    const payload = await buildSetGenesisEpochPayload(context);
+    const { logs, result } = captureApplyErrors(() =>
+        applyWithEntryOverrides(
+            context,
+            payload,
+            new Map([[EntryType.EPOCH_CURRENT, b4a.from([0xff])]])
+        )
+    );
+    await result;
+
+    await assertGenesisUninitialized(t, context.adminBootstrap.base, payload);
+    assertLog(t, logs, 'Current epoch is set. Cannot set a new genesis epoch');
+});
+
+test('State.apply SET_GENESIS_EPOCH ignores a second distinct genesis in one batch', async t => {
+    const context = await setupSetGenesisEpochScenario(t);
+    const firstPayload = await buildSetGenesisEpochPayload(context);
+    const secondPayload = await buildSetGenesisEpochPayload(context);
+    const firstOperation = safeDecodeApplyOperation(firstPayload);
+    const secondOperation = safeDecodeApplyOperation(secondPayload);
+
+    t.not(
+        firstOperation.cco.tx.toString('hex'),
+        secondOperation.cco.tx.toString('hex'),
+        'independently signed genesis operations have distinct transaction hashes'
+    );
+
+    const { logs, result } = captureApplyErrors(() =>
+        appendBatchAndUpdate(context.adminBootstrap.base, [firstPayload, secondPayload])
+    );
+    await result;
+
+    await assertGenesisInitialized(t, context.adminBootstrap.base, firstPayload);
+    await assertOperationRecorded(t, context.adminBootstrap.base, secondPayload, false);
+    assertLog(t, logs, 'Current epoch is set. Cannot set a new genesis epoch');
+});
+
+// genesisEpochHash !== null
+test('State.apply SET_GENESIS_EPOCH ignores any non-null epoch-zero hash entry', async t => {
+    const context = await setupSetGenesisEpochScenario(t);
+    const payload = await buildSetGenesisEpochPayload(context);
+    const { logs, result } = captureApplyErrors(() =>
+        applyWithEntryOverrides(
+            context,
+            payload,
+            new Map([[EntryType.EPOCH + '0', b4a.from([0xff])]])
+        )
+    );
+    await result;
+
+    await assertGenesisUninitialized(t, context.adminBootstrap.base, payload);
+    assertLog(t, logs, 'Genesis epoch is set. Cannot set a new one');
+});
+
+// currentConsensusConfigIndex !== null || genesisConsensusConfig !== null
+for (const [label, overridesFactory] of [
+    [
+        'an existing current consensus config pointer',
+        () => new Map([[EntryType.CONSENSUS_CONFIG_CURRENT, b4a.from([0xff])]])
+    ],
+    [
+        'an existing genesis consensus config record',
+        encodedConfig => new Map([[EntryType.CONSENSUS_CONFIG_RECORD + 0, encodedConfig]])
+    ],
+    [
+        'both existing genesis consensus config entries',
+        encodedConfig => new Map([
+            [EntryType.CONSENSUS_CONFIG_CURRENT, b4a.from([0xff])],
+            [EntryType.CONSENSUS_CONFIG_RECORD + 0, encodedConfig]
+        ])
+    ]
+]) {
+    test(`State.apply SET_GENESIS_EPOCH ignores ${label}`, async t => {
+        const context = await setupSetGenesisEpochScenario(t);
+        const payload = await buildSetGenesisEpochPayload(context);
+        const operation = safeDecodeApplyOperation(payload);
+        const encodedConfig = safeEncodeConsensusConfig(operation.cco.cc);
+        const { logs, result } = captureApplyErrors(() =>
+            applyWithEntryOverrides(context, payload, overridesFactory(encodedConfig))
+        );
+        await result;
+
+        await assertGenesisUninitialized(t, context.adminBootstrap.base, payload);
+        assertLog(
+            t,
+            logs,
+            'Genesis consensus config is set. Cannot set a new genesis epoch'
+        );
+    });
+}
+
+// genesisEpoch === null
+test('State.apply SET_GENESIS_EPOCH fails without partial writes when proof creation fails', async t => {
+    const context = await setupSetGenesisEpochScenario(t);
+    const payload = await buildSetGenesisEpochPayload(context);
+    const { logs, result } = captureApplyErrors(() =>
+        applyWithGenesisProofHashFailure(context, payload)
+    );
+    const injected = await result;
+
+    t.ok(injected, 'genesis proof hash failure was injected');
+    await assertSetGenesisEpochFailureState(t, context, payload, { skipSync: true });
+    assertLog(t, logs, 'Could not initialize genesis epoch');
+});
+
+// Status.SUCCESS
+test('State.apply SET_GENESIS_EPOCH initializes and replicates the complete genesis state', async t => {
+    const context = await setupSetGenesisEpochScenario(t, { nodes: 3 });
+    const payload = await buildSetGenesisEpochPayload(context);
+
+    await appendAndUpdate(context.adminBootstrap.base, payload);
+    await assertGenesisInitialized(t, context.adminBootstrap.base, payload);
+
+    await context.sync();
+    for (const reader of context.peers.slice(1)) {
+        await assertGenesisInitialized(t, reader.base, payload);
+    }
+});
+
+for (const [label, difficulty, discriminantBitSize] of [
+    ['minimum', 1, 1],
+    ['non-zero values containing zero bytes', 0x00010000, 0x0100],
+    ['maximum', 0xffffffff, 0xffff]
+]) {
+    test(`State.apply SET_GENESIS_EPOCH accepts ${label} valid VDF parameters`, async t => {
+        const context = await setupSetGenesisEpochScenario(t);
+        const payload = await buildSetGenesisEpochPayload(context, {
+            difficulty,
+            discriminantBitSize
+        });
+
+        await appendAndUpdate(context.adminBootstrap.base, payload);
+        await assertGenesisInitialized(t, context.adminBootstrap.base, payload, {
+            difficulty,
+            discriminantBitSize
+        });
+    });
+}
+
+function registerRejectedConfigCase({ title, buildOptions, expectedLog }) {
+    test(title, async t => {
+        const context = await setupSetGenesisEpochScenario(t);
+        const payload = await buildSetGenesisEpochPayload(context, buildOptions);
+        const { logs, result } = captureApplyErrors(() =>
+            appendAndUpdate(context.adminBootstrap.base, payload)
+        );
+        await result;
+
+        await assertSetGenesisEpochFailureState(t, context, payload);
+        assertLog(t, logs, expectedLog);
+    });
+}
+
+function captureApplyErrors(apply) {
+    const logs = [];
+    const originalConsoleError = console.error;
+    console.error = (...args) => logs.push(args);
+
+    const result = Promise.resolve()
+        .then(apply)
+        .finally(() => {
+            console.error = originalConsoleError;
+        });
+
+    return { logs, result };
+}
+
+function assertLog(t, logs, expected) {
+    const found = logs.some(args => args.some(arg => String(arg).includes(expected)));
+    t.ok(found, `expected apply log "${expected}" was emitted`);
+}

--- a/tests/unit/state/apply/setGenesisEpoch/state.apply.setGenesisEpoch.test.js
+++ b/tests/unit/state/apply/setGenesisEpoch/state.apply.setGenesisEpoch.test.js
@@ -22,6 +22,7 @@ import {
     appendBatchAndUpdate,
     applyWithConsensusConfigEncodingFailure,
     applyWithEntryOverrides,
+    applyWithGenesisEpochEncodingFailure,
     applyWithGenesisProofHashFailure,
     applyWithMessageConstructionFailure,
     assertGenesisInitialized,
@@ -496,6 +497,19 @@ test('State.apply SET_GENESIS_EPOCH fails without partial writes when proof crea
     const injected = await result;
 
     t.ok(injected, 'genesis proof hash failure was injected');
+    await assertSetGenesisEpochFailureState(t, context, payload, { skipSync: true });
+    assertLog(t, logs, 'Could not initialize genesis epoch');
+});
+
+test('State.apply SET_GENESIS_EPOCH fails when final epoch proof encoding fails', async t => {
+    const context = await setupSetGenesisEpochScenario(t);
+    const payload = await buildSetGenesisEpochPayload(context);
+    const { logs, result } = captureApplyErrors(() =>
+        applyWithGenesisEpochEncodingFailure(context, payload)
+    );
+    const injected = await result;
+
+    t.ok(injected, 'safeEncodeEpochProof failure was injected');
     await assertSetGenesisEpochFailureState(t, context, payload, { skipSync: true });
     assertLog(t, logs, 'Could not initialize genesis epoch');
 });

--- a/tests/unit/state/apply/state.apply.test.js
+++ b/tests/unit/state/apply/state.apply.test.js
@@ -18,6 +18,7 @@ async function runStateTests() {
     await import('./txOperation/state.apply.txOperation.test.js');
     await import('./transfer/state.apply.transfer.test.js');
     await import('./adminRecovery/state.apply.adminRecovery.test.js');
+    await import('./setGenesisEpoch/state.apply.setGenesisEpoch.test.js');
     await import('./setConsensusConfig/state.apply.setConsensusConfig.test.js');
     test.resume();
 }


### PR DESCRIPTION
This pull request refactors the handling of consensus and VDF (Verifiable Delay Function) configuration encoding and validation in the `State` class, streamlining the process for setting the genesis epoch and consensus config. It removes redundant encoding steps and unused imports, and improves validation logic for consensus operations. Additionally, it prepares for a future optimization in the genesis epoch proof creation.

**Consensus and VDF config handling:**
* Refactored the genesis epoch setup to encode and validate the consensus config directly using `safeEncodeConsensusConfig`, removing the previous separate VDF encoding and related buffer checks. This simplifies and unifies how consensus configuration is handled. [[1]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5R4237-R4253) [[2]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L4324-R4341)
* Updated the consensus config application to use the new encoding and validation logic, and improved error handling for encoding failures.

**Validation improvements:**
* Changed the validation method for consensus config operations from `validateSetConsensusConfigOperation` to the more general `validateConsensusControlOperation`, ensuring broader schema validation.

**Code cleanup:**
* Removed unused imports: `safeUint8ToBuffer` and `safeEncodeVdfConfig` from `State.js`. [[1]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L33) [[2]](diffhunk://#diff-a8d8c481652d7d7e2fdccf86fde4e221237af9a7e945db8feacba3169766b5e5L62)
* Renamed variables for clarity (e.g., `currentConsensusConfigId` to `currentConsensusConfigIndex`).

**Preparation for future optimization:**
* Added TODO comments in `createGenesisEpochProof` to indicate that the `vdfParametersHash` will be replaced with direct parameters for efficiency. [[1]](diffhunk://#diff-cff10586ee2ec6e514ff62c77dadda767fdf8e5304e1a1be56a4f7a2fcb0ad07L22-R22) [[2]](diffhunk://#diff-cff10586ee2ec6e514ff62c77dadda767fdf8e5304e1a1be56a4f7a2fcb0ad07R38)