### PR TITLE
chore: Fix returned result codes in V1

### DIFF
--- a/src/core/network/protocols/v1/handlers/V1BroadcastTransactionOperationHandler.js
+++ b/src/core/network/protocols/v1/handlers/V1BroadcastTransactionOperationHandler.js
@@ -111,7 +111,7 @@ class V1BroadcastTransactionOperationHandler extends V1BaseOperationHandler {
         try {
             return unsafeDecodeApplyOperation(message);
         } catch (error) {
-            throw new V1ProtocolError(ResultCode.UNEXPECTED_ERROR, `Failed to decode apply operation from message: ${error.message}`);
+            throw new V1ProtocolError(ResultCode.TX_INVALID_PAYLOAD, `Failed to decode apply operation from message: ${error.message}`);
         }
     }
 

--- a/src/core/network/protocols/v1/validators/V1BaseOperation.js
+++ b/src/core/network/protocols/v1/validators/V1BaseOperation.js
@@ -33,7 +33,7 @@ class V1BaseOperation {
         const selectedValidator = this.#selectCheckSchemaValidator(payload.type);
         const isPayloadValid = selectedValidator(payload);
         if (!isPayloadValid) {
-            throw new V1ProtocolError(ResultCode.INVALID_PAYLOAD, 'Payload is invalid.');
+            throw new V1ProtocolError(ResultCode.SCHEMA_VALIDATION_FAILED, 'Payload is invalid.');
         }
     }
 
@@ -48,14 +48,18 @@ class V1BaseOperation {
             if (error instanceof V1ProtocolError) {
                 throw error;
             }
-            throw new V1ProtocolError(ResultCode.INVALID_PAYLOAD, `Failed to build signature message: ${error.message}`);
+            throw new V1ProtocolError(ResultCode.UNEXPECTED_ERROR, `Failed to build signature message: ${error.message}`);
+        }
+
+        if (!remotePublicKey) {
+            throw new V1ProtocolError(ResultCode.UNEXPECTED_ERROR, 'Remote public key is missing.');
         }
 
         let hash;
         try {
             hash = await tracCryptoApi.hash.blake3(message);
         } catch {
-            throw new V1ProtocolError(ResultCode.INVALID_PAYLOAD, 'Failed to hash signature message.');
+            throw new V1ProtocolError(ResultCode.UNEXPECTED_ERROR, 'Failed to hash signature message.');
         }
 
         let verified = false;
@@ -71,10 +75,10 @@ class V1BaseOperation {
 
     #buildSignatureMessage(payload) {
         if (!Number.isInteger(payload.type)) {
-            throw new V1ProtocolError(ResultCode.INVALID_PAYLOAD, 'Operation type must be an integer.');
+            throw new V1ProtocolError(ResultCode.OPERATION_TYPE_UNKNOWN, 'Operation type must be an integer.');
         }
         if (payload.type === 0) {
-            throw new V1ProtocolError(ResultCode.INVALID_PAYLOAD, 'Operation type is unspecified.');
+            throw new V1ProtocolError(ResultCode.OPERATION_TYPE_UNKNOWN, 'Operation type is unspecified.');
         }
 
         const idBuf = idToBuffer(payload.id);
@@ -147,16 +151,16 @@ class V1BaseOperation {
                 return {signature, message};
             }
             default:
-                throw new V1ProtocolError(ResultCode.UNEXPECTED_ERROR, `Unknown operation type: ${payload.type}`);
+                throw new V1ProtocolError(ResultCode.OPERATION_TYPE_UNKNOWN, `Unknown operation type: ${payload.type}`);
         }
     }
 
     #selectCheckSchemaValidator(type) {
         if (!Number.isInteger(type)) {
-            throw new V1ProtocolError(ResultCode.INVALID_PAYLOAD, 'Operation type must be an integer.');
+            throw new V1ProtocolError(ResultCode.OPERATION_TYPE_UNKNOWN, 'Operation type must be an integer.');
         }
         if (type === 0) {
-            throw new V1ProtocolError(ResultCode.INVALID_PAYLOAD, 'Operation type is unspecified.');
+            throw new V1ProtocolError(ResultCode.OPERATION_TYPE_UNKNOWN, 'Operation type is unspecified.');
         }
 
         switch (type) {
@@ -169,7 +173,7 @@ class V1BaseOperation {
             case NetworkOperationType.BROADCAST_TRANSACTION_RESPONSE:
                 return this.#v1ValidationSchema.validateV1BroadcastTransactionResponse.bind(this.#v1ValidationSchema);
             default:
-                throw new V1ProtocolError(ResultCode.UNEXPECTED_ERROR, `Unknown operation type: ${type}`);
+                throw new V1ProtocolError(ResultCode.OPERATION_TYPE_UNKNOWN, `Unknown operation type: ${type}`);
         }
     }
 

--- a/src/core/network/protocols/v1/validators/V1BroadcastTransactionRequest.js
+++ b/src/core/network/protocols/v1/validators/V1BroadcastTransactionRequest.js
@@ -18,7 +18,7 @@ class V1BroadcastTransactionRequest extends V1BaseOperation {
     isDataPropertySizeValid(payload) {
         if (b4a.byteLength(payload.broadcast_transaction_request.data) > MAX_PARTIAL_TX_PAYLOAD_BYTE_SIZE) {
             throw new V1ProtocolError(
-                ResultCode.INVALID_PAYLOAD,
+                ResultCode.SCHEMA_VALIDATION_FAILED,
                 `The 'data' field exceeds the maximum allowed byte size of ${MAX_PARTIAL_TX_PAYLOAD_BYTE_SIZE}. Actual size: ${b4a.byteLength(payload.broadcast_transaction_request.data)}`);
         }
     }

--- a/tests/unit/network/v1/V1BaseOperation.test.js
+++ b/tests/unit/network/v1/V1BaseOperation.test.js
@@ -49,6 +49,19 @@ const buildSignedPayload = async (wallet, type, options = {}) => {
     return builder.getResult();
 };
 
+async function assertProtocolError(t, action, resultCode, messageIncludes) {
+    let error;
+    try {
+        await action();
+    } catch (caughtError) {
+        error = caughtError;
+    }
+
+    t.ok(error instanceof V1ProtocolError);
+    t.is(error?.resultCode, resultCode);
+    t.ok(error?.message.includes(messageIncludes));
+}
+
 test('V1BaseOperation.validate throws "must be implemented" by default', async t => {
     const operation = new V1BaseOperation(config);
 
@@ -61,29 +74,53 @@ test('V1BaseOperation.validate throws "must be implemented" by default', async t
 test('V1BaseOperation.isPayloadSchemaValid handles missing/invalid type cases', async t => {
     const operation = new V1BaseOperation(config);
 
-    t.exception(
+    await assertProtocolError(
+        t,
         () => operation.isPayloadSchemaValid(null),
-        errorMessageIncludes('Payload or payload type is missing')
+        ResultCode.INVALID_PAYLOAD,
+        'Payload or payload type is missing'
     );
 
-    t.exception(
+    await assertProtocolError(
+        t,
         () => operation.isPayloadSchemaValid({ type: null }),
-        errorMessageIncludes('Payload or payload type is missing')
+        ResultCode.INVALID_PAYLOAD,
+        'Payload or payload type is missing'
     );
 
-    t.exception(
+    await assertProtocolError(
+        t,
         () => operation.isPayloadSchemaValid({ type: 1.5 }),
-        errorMessageIncludes('Operation type must be an integer')
+        ResultCode.OPERATION_TYPE_UNKNOWN,
+        'Operation type must be an integer'
     );
 
-    t.exception(
+    await assertProtocolError(
+        t,
         () => operation.isPayloadSchemaValid({ type: 0 }),
-        errorMessageIncludes('Operation type is unspecified')
+        ResultCode.OPERATION_TYPE_UNKNOWN,
+        'Operation type is unspecified'
     );
 
-    t.exception(
+    await assertProtocolError(
+        t,
         () => operation.isPayloadSchemaValid({ type: 9999 }),
-        errorMessageIncludes('Unknown operation type')
+        ResultCode.OPERATION_TYPE_UNKNOWN,
+        'Unknown operation type'
+    );
+});
+
+test('V1BaseOperation.isPayloadSchemaValid returns SCHEMA_VALIDATION_FAILED for an identifiable invalid payload', async t => {
+    const operation = new V1BaseOperation(config);
+    const wallet = await createWallet();
+    const payload = await buildSignedPayload(wallet, NetworkOperationType.LIVENESS_REQUEST);
+    delete payload.liveness_request.nonce;
+
+    await assertProtocolError(
+        t,
+        () => operation.isPayloadSchemaValid(payload),
+        ResultCode.SCHEMA_VALIDATION_FAILED,
+        'Payload is invalid'
     );
 });
 
@@ -130,9 +167,11 @@ test('V1BaseOperation.validateSignature throws V1ProtocolError on wrong public k
 
     const payload = await buildSignedPayload(wallet, NetworkOperationType.LIVENESS_REQUEST);
 
-    await t.exception(
-        async () => operation.validateSignature(payload, otherWallet.publicKey),
-        errorMessageIncludes('signature verification failed')
+    await assertProtocolError(
+        t,
+        () => operation.validateSignature(payload, otherWallet.publicKey),
+        ResultCode.SIGNATURE_INVALID,
+        'signature verification failed'
     );
 });
 
@@ -151,7 +190,7 @@ test('V1BaseOperation.validateSignature rethrows protocol-shaped build errors', 
         t.fail('expected validateSignature to throw');
     } catch (error) {
         t.ok(error instanceof V1ProtocolError);
-        t.is(error.resultCode, ResultCode.INVALID_PAYLOAD);
+        t.is(error.resultCode, ResultCode.OPERATION_TYPE_UNKNOWN);
         t.ok(error.message.includes('Operation type is unspecified'));
     }
 });
@@ -171,7 +210,7 @@ test('V1BaseOperation.validateSignature wraps non-protocol build errors as V1Pro
         t.fail('expected validateSignature to throw');
     } catch (error) {
         t.ok(error instanceof V1ProtocolError);
-        t.is(error.resultCode, ResultCode.INVALID_PAYLOAD);
+        t.is(error.resultCode, ResultCode.UNEXPECTED_ERROR);
         t.ok(error.message.includes('Failed to build signature message'));
     }
 });
@@ -195,8 +234,22 @@ test('V1BaseOperation.validateSignature throws V1ProtocolError when hashing fail
         t.fail('expected validateSignature to throw');
     } catch (error) {
         t.ok(error instanceof V1ProtocolError);
+        t.is(error.resultCode, ResultCode.UNEXPECTED_ERROR);
         t.ok(error.message.includes('Failed to hash signature message'));
     }
+});
+
+test('V1BaseOperation.validateSignature returns UNEXPECTED_ERROR when the remote public key is missing', async t => {
+    const operation = new V1BaseOperation(config);
+    const wallet = await createWallet();
+    const payload = await buildSignedPayload(wallet, NetworkOperationType.LIVENESS_REQUEST);
+
+    await assertProtocolError(
+        t,
+        () => operation.validateSignature(payload),
+        ResultCode.UNEXPECTED_ERROR,
+        'Remote public key is missing'
+    );
 });
 
 test('V1BaseOperation.validateSignature handles verify() throw as invalid signature', async t => {
@@ -273,9 +326,11 @@ test('V1BaseOperation.validateSignature enforces BROADCAST_TRANSACTION_RESPONSE 
         const payload = structuredClone(validBase);
         scenario.mutate(payload);
 
-        await t.exception(
-            async () => operation.validateSignature(payload, wallet.publicKey),
-            errorMessageIncludes(scenario.match)
+        await assertProtocolError(
+            t,
+            () => operation.validateSignature(payload, wallet.publicKey),
+            ResultCode.INVALID_PAYLOAD,
+            scenario.match
         );
     }
 });
@@ -290,9 +345,11 @@ test('V1BaseOperation.validateSignature throws V1ProtocolError for unknown opera
         capabilities: [],
     };
 
-    await t.exception(
-        async () => operation.validateSignature(payload, b4a.alloc(32, 1)),
-        errorMessageIncludes('Unknown operation type')
+    await assertProtocolError(
+        t,
+        () => operation.validateSignature(payload, b4a.alloc(32, 1)),
+        ResultCode.OPERATION_TYPE_UNKNOWN,
+        'Unknown operation type'
     );
 });
 

--- a/tests/unit/network/v1/V1BroadcastTransactionRequest.test.js
+++ b/tests/unit/network/v1/V1BroadcastTransactionRequest.test.js
@@ -3,7 +3,7 @@ import b4a from 'b4a';
 
 import V1BroadcastTransactionRequest from '../../../../src/core/network/protocols/v1/validators/V1BroadcastTransactionRequest.js';
 import { V1ProtocolError } from '../../../../src/core/network/protocols/v1/V1ProtocolError.js';
-import { MAX_PARTIAL_TX_PAYLOAD_BYTE_SIZE } from '../../../../src/utils/constants.js';
+import { MAX_PARTIAL_TX_PAYLOAD_BYTE_SIZE, ResultCode } from '../../../../src/utils/constants.js';
 import { config } from '../../../helpers/config.js';
 
 test('V1BroadcastTransactionRequest.validate runs schema, size and signature validation', async t => {
@@ -48,6 +48,7 @@ test('V1BroadcastTransactionRequest.isDataPropertySizeValid throws for oversized
         t.fail('expected size validation to throw');
     } catch (error) {
         t.ok(error instanceof V1ProtocolError);
+        t.is(error.resultCode, ResultCode.SCHEMA_VALIDATION_FAILED);
         t.ok(error.message.includes('exceeds the maximum allowed byte size'));
     }
 });

--- a/tests/unit/network/v1/handlers/V1BroadcastTransactionOperationHandler.test.js
+++ b/tests/unit/network/v1/handlers/V1BroadcastTransactionOperationHandler.test.js
@@ -520,20 +520,18 @@ test('handleRequest: flushes response before closing when protocol error request
     t.alike(events, ['send', 'flush', 'end']);
 });
 
-test('decodeApplyOperation failure branch', async t => {
-
+test('Malformed encoded transaction returns TX_INVALID_PAYLOAD', async t => {
     const handler = setupHandler(t);
 
-    handler.decodeApplyOperation = () => {
-        throw new Error('decode fail');
-    };
-
     await handler.handleRequest(
-        { id: b4a.alloc(32), broadcast_transaction_request: { data: b4a.alloc(1) } },
-        mockConn()
+        {
+            id: b4a.alloc(32),
+            broadcast_transaction_request: { data: b4a.from([0x0a, 0x02, 0x01]) }
+        },
+        mockConn(response => {
+            t.is(response.broadcast_transaction_response.result, ResultCode.TX_INVALID_PAYLOAD);
+        })
     );
-
-    t.pass();
 });
 
 test('Response build internal failure branch', async t => {


### PR DESCRIPTION
Fixes incorrect result codes returned by the V1 Network Protocol.
- Returns SCHEMA_VALIDATION_FAILED for identifiable schema failures
- Returns OPERATION_TYPE_UNKNOWN for invalid, unspecified, or unknown operation types
- Returns UNEXPECTED_ERROR for internal signature construction, hashing, or connection-context failures
- Returns TX_INVALID_PAYLOAD for malformed encoded transactions
- Adds exact result-code assertions to the relevant unit tests

Epoch Consensus is explicitly excluded from this PR. 