### PR TITLE
fix: guard network replication during shutdown

### DIFF
--- a/src/core/network/Network.js
+++ b/src/core/network/Network.js
@@ -177,8 +177,12 @@ class Network extends ReadyResource {
         store,
         wallet,
     ) {
+        this.#assertCanReplicate();
+
         if (!this.#swarm) {
             const { wallet: wrappedWallet, keyPair } = await this.#getOrGenerateWallet(store, wallet);
+            this.#assertCanReplicate();
+
             this.#wallet = wrappedWallet
             this.#validatorMessageOrchestrator.setWallet(this.#wallet);
 
@@ -203,6 +207,8 @@ class Network extends ReadyResource {
             );
             this.#validatorHealthCheckService = new ValidatorHealthCheckService(this.#config);
             await this.#validatorHealthCheckService.ready();
+            this.#assertCanReplicate();
+
             this.#validatorConnectionManager.subscribeToHealthChecks(this.#validatorHealthCheckService);
 
             this.#logger.info(`Channel: ${b4a.toString(this.#config.channel)}`);
@@ -385,6 +391,12 @@ class Network extends ReadyResource {
         clearTimeout(timeoutId);
         this.#pendingConnections.delete(publicKeyHex);
         return true;
+    }
+
+    #assertCanReplicate() {
+        if (this.#closing || this.closed) {
+            throw new Error('Network is closing or already closed');
+        }
     }
 
     #destroyConnection(connection) {

--- a/src/core/network/Network.js
+++ b/src/core/network/Network.js
@@ -39,6 +39,7 @@ class Network extends ReadyResource {
     #wallet;
     #validatorHealthCheckService;
     #logger;
+    #closing = false;
 
     /**
      * @param {State} state
@@ -82,6 +83,7 @@ class Network extends ReadyResource {
 
     async _open() {
         this.#logger.info('Network initialization...');
+        this.#closing = false;
 
         this.setupNetworkListeners();
 
@@ -91,6 +93,7 @@ class Network extends ReadyResource {
 
     async _close() {
         this.#logger.info('Network: closing gracefully...');
+        this.#closing = true;
         await this.transactionPoolService.stopPool();
         await sleep(100);
         await this.#validatorObserverService.stopValidatorObserver();
@@ -104,8 +107,15 @@ class Network extends ReadyResource {
         this.#pendingRequestsService.close();
         this.#transactionCommitService.close();
 
-        if (this.#swarm !== null) {
-            this.#swarm.destroy();
+        const swarm = this.#swarm;
+        if (swarm !== null) {
+            if (typeof swarm.removeAllListeners === 'function') {
+                swarm.removeAllListeners('connection');
+            }
+            await swarm.destroy();
+            if (this.#swarm === swarm) {
+                this.#swarm = null;
+            }
         }
     }
 
@@ -198,14 +208,42 @@ class Network extends ReadyResource {
             this.#logger.info(`Channel: ${b4a.toString(this.#config.channel)}`);
 
             this.#swarm.on('connection', async (connection) => {
-                // Per-peer connection initialization:
-                // - attach Protomux (legacy + v1 channels/messages)
-                // - attach connection.protocolSession (used later by tryConnect / orchestrators to send messages)
-                await this.#networkMessages.setupProtomuxMessages(connection);
+                if (this.#closing) {
+                    this.#destroyConnection(connection);
+                    return;
+                }
 
-                // ATTENTION: Must be called AFTER the protomux init above
-                const stream = store.replicate(connection);
-                wakeup.addStream(stream);
+                try {
+                    // Per-peer connection initialization:
+                    // - attach Protomux (legacy + v1 channels/messages)
+                    // - attach connection.protocolSession (used later by tryConnect / orchestrators to send messages)
+                    await this.#networkMessages.setupProtomuxMessages(connection);
+
+                    // Pear v3 can deliver a late swarm connection while shutdown is
+                    // already closing the Corestore. Do not replicate a connection
+                    // after close has begun; store.replicate would otherwise throw.
+                    if (this.#closing || this.#swarm === null) {
+                        this.#destroyConnection(connection);
+                        return;
+                    }
+
+                    // ATTENTION: Must be called AFTER the protomux init above
+                    const stream = store.replicate(connection);
+                    wakeup.addStream(stream);
+                } catch (error) {
+                    const publicKey = connection.remotePublicKey
+                        ? b4a.toString(connection.remotePublicKey, 'hex')
+                        : 'unknown';
+                    this.#pendingRequestsService.rejectPendingRequestsForPeer(
+                        publicKey,
+                        error ?? new Error('Connection setup failed')
+                    );
+                    this.#destroyConnection(connection);
+                    if (!this.#closing) {
+                        this.#logger.error(error?.message ?? 'Unknown network connection setup error');
+                    }
+                    return;
+                }
 
                 const publicKey = b4a.toString(connection.remotePublicKey, 'hex');
                 if (this.#pendingConnections.has(publicKey)) {
@@ -218,9 +256,13 @@ class Network extends ReadyResource {
                         publicKey,
                         new Error('Connection closed before response')
                     );
-                    this.#swarm.leavePeer(connection.remotePublicKey);
+                    this.#swarm?.leavePeer(connection.remotePublicKey);
                     this.#validatorConnectionManager.remove(publicKey);
-                    connection.protocolSession.close();
+                    if (connection.protocolSession) {
+                        try {
+                            connection.protocolSession.close();
+                        } catch {}
+                    }
                 });
 
                 connection.on('error', (error) => {
@@ -343,6 +385,20 @@ class Network extends ReadyResource {
         clearTimeout(timeoutId);
         this.#pendingConnections.delete(publicKeyHex);
         return true;
+    }
+
+    #destroyConnection(connection) {
+        if (!connection) return;
+        if (connection.protocolSession) {
+            try {
+                connection.protocolSession.close();
+            } catch {}
+        }
+        if (typeof connection.destroy === 'function') {
+            connection.destroy();
+        } else if (typeof connection.end === 'function') {
+            connection.end();
+        }
     }
 }
 

--- a/tests/unit/network/Network.test.js
+++ b/tests/unit/network/Network.test.js
@@ -165,7 +165,7 @@ async function loadNetwork(options = {}) {
     };
     await network.replicate({}, store, wallet);
 
-    return { network, swarmInstance, connectionManagerInstance, store };
+    return { network, swarmInstance, connectionManagerInstance, store, wallet };
 }
 
 function deferred() {
@@ -239,7 +239,7 @@ if (isBareRuntime) {
             setupEntered.resolve();
             await resumeSetup.promise;
         });
-        const { network, swarmInstance } = await loadNetwork({ store, setupProtomuxMessages });
+        const { network, swarmInstance, wallet } = await loadNetwork({ store, setupProtomuxMessages });
         const connection = new EventEmitter();
         connection.remotePublicKey = b4a.alloc(32, 4);
         connection.destroy = sinon.stub();
@@ -254,5 +254,12 @@ if (isBareRuntime) {
 
         t.is(store.replicate.callCount, 0, 'late connection should not replicate after network close begins');
         t.is(connection.destroy.callCount, 1, 'late connection should be destroyed');
+        await t.exception(
+            () => network.replicate({}, store, wallet),
+            /Network is closing or already closed/,
+            'replication should reject after network close'
+        );
+        t.is(network.swarm, null, 'closed network should not create a new swarm');
+        t.is(swarmInstance.destroy.callCount, 1, 'only the original swarm should be destroyed');
     });
 }

--- a/tests/unit/network/Network.test.js
+++ b/tests/unit/network/Network.test.js
@@ -12,7 +12,7 @@ function normalizePublicKey(publicKey) {
     return null;
 }
 
-async function loadNetwork() {
+async function loadNetwork(options = {}) {
     const { default: esmock } = await import('esmock');
     let swarmInstance = null;
     let connectionManagerInstance = null;
@@ -30,7 +30,9 @@ async function loadNetwork() {
             this.leavePeer = sinon.stub();
             this.join = sinon.stub();
             this.flush = sinon.stub();
-            this.destroy = sinon.stub();
+            this.destroy = sinon.stub().callsFake(async () => {
+                this.removeAllListeners();
+            });
         }
     }
 
@@ -114,7 +116,11 @@ async function loadNetwork() {
     }
 
     class NetworkMessagesMock {
-        async setupProtomuxMessages() {}
+        async setupProtomuxMessages(connection) {
+            if (options.setupProtomuxMessages) {
+                return options.setupProtomuxMessages(connection);
+            }
+        }
     }
 
     class TransactionRateLimiterServiceMock {}
@@ -154,9 +160,20 @@ async function loadNetwork() {
     };
 
     const network = new Network({}, config, wallet.address);
-    await network.replicate({}, {}, wallet);
+    const store = options.store ?? {
+        replicate: sinon.stub().returns(new EventEmitter()),
+    };
+    await network.replicate({}, store, wallet);
 
-    return { network, swarmInstance, connectionManagerInstance };
+    return { network, swarmInstance, connectionManagerInstance, store };
+}
+
+function deferred() {
+    let resolve;
+    const promise = new Promise((done) => {
+        resolve = done;
+    });
+    return { promise, resolve };
 }
 
 if (isBareRuntime) {
@@ -207,5 +224,35 @@ if (isBareRuntime) {
         t.absent(disconnected, 'non-validator peer should be ignored by validator disconnect helper');
         t.ok(network.isConnectionPending(publicKey), 'non-validator pending connection should remain tracked');
         t.is(swarmInstance.leavePeer.callCount, 0, 'generic peer should not be left');
+    });
+
+    test('Network#close prevents late connection setup from replicating a closed Corestore', async t => {
+        const setupEntered = deferred();
+        const resumeSetup = deferred();
+        const store = {
+            replicate: sinon.stub().throws(new Error('Corestore is closed')),
+        };
+        const setupProtomuxMessages = sinon.stub().callsFake(async (connection) => {
+            connection.protocolSession = {
+                close: sinon.stub(),
+            };
+            setupEntered.resolve();
+            await resumeSetup.promise;
+        });
+        const { network, swarmInstance } = await loadNetwork({ store, setupProtomuxMessages });
+        const connection = new EventEmitter();
+        connection.remotePublicKey = b4a.alloc(32, 4);
+        connection.destroy = sinon.stub();
+
+        swarmInstance.emit('connection', connection);
+        await setupEntered.promise;
+
+        const closePromise = network.close();
+        resumeSetup.resolve();
+        await closePromise;
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t.is(store.replicate.callCount, 0, 'late connection should not replicate after network close begins');
+        t.is(connection.destroy.callCount, 1, 'late connection should be destroyed');
     });
 }


### PR DESCRIPTION
## Summary\n- prevent late Hyperswarm connection handlers from calling Corestore.replicate after MSB shutdown begins\n- reject pending requests and destroy late/failed connections instead of letting a closed Corestore exception abort the runner\n- add a regression test for the late-connection/shutdown race\n\n## Scope\nThis is the MSB-side shutdown guard only. It does not change Autobase, Hypercore, Corestore storage semantics, consensus data, signatures, DHT behavior, public MSB behavior, or protocol formats.\n\n## Verification\n- npm run test:unit:node: 1010/1010 pass\n- npm run test:pear-runner: 8/8 pass