### PR TITLE
feat: hook up network events

### DIFF
--- a/cli/commandHandler.js
+++ b/cli/commandHandler.js
@@ -8,6 +8,17 @@ import {
     MAX_VDF_DISCRIMINANT_BIT_SIZE
 } from "../src/utils/constants.js";
 
+const OPERATIONS = {
+    CONFIRMATION: "confirmation",
+    GENESIS_DIFFICULTY: "genesis-difficulty",
+    GENESIS_DISCRIMINANT_BIT_SIZE: "genesis-discriminant-bit-size",
+    CONSENSUS_CONFIG: "consensus-config",
+    VDF_DIFFICULTY: "vdf-difficulty",
+    VDF_DISCRIMINANT_BIT_SIZE: "vdf-discriminant-bit-size",
+    GENESIS_PREFIX: "genesis-",
+    VDF_PREFIX: "vdf-"
+};
+
 export const COMMANDS = {
     HELP: "/help",
     EXIT: "/exit",
@@ -75,19 +86,19 @@ export class CommandHandler {
     #getHandlers() {
         return [
             {
-                evaluate: ({ context }) => context.pending?.op === "confirmation",
+                evaluate: ({ context }) => context.pending?.op === OPERATIONS.CONFIRMATION,
                 process: async ({ input, context }) => this.#handlePendingConfirmation(input, context)
             },
             {
-                evaluate: ({ context }) => context.pending?.op.startsWith("genesis-"),
+                evaluate: ({ context }) => context.pending?.op.startsWith(OPERATIONS.GENESIS_PREFIX),
                 process: async ({ input, context }) => this.#handlePendingGenesisInitialization(input, context)
             },
             {
-                evaluate: ({ context }) => context.pending?.op === "consensus-config",
+                evaluate: ({ context }) => context.pending?.op === OPERATIONS.CONSENSUS_CONFIG,
                 process: async ({ input, context }) => this.#handlePendingSetConsensusConfig(input, context)
             },
             {
-                evaluate: ({ context }) => context.pending?.op.startsWith("vdf-"),
+                evaluate: ({ context }) => context.pending?.op.startsWith(OPERATIONS.VDF_PREFIX),
                 process: async ({ input, context }) => this.#handlePendingSetVdfParams(input, context)
             },
             {
@@ -299,7 +310,7 @@ export class CommandHandler {
         console.info(`Balance after transaction: ${bigIntToDecimalString(preparedTransfer.expectedNewBalance)}`);
 
         context.pending = {
-            op: "confirmation",
+            op: OPERATIONS.CONFIRMATION,
             prompt: "Do you want to proceed? (y/n)",
             onConfirm: async () => this.#msb.submitPreparedTransferOperation(preparedTransfer),
             onDecline: async () => this.#msb.printHelp()
@@ -310,7 +321,7 @@ export class CommandHandler {
 
     #queueEpochGenesisInitialization(context) {
         context.pending = {
-            op: "genesis-difficulty"
+            op: OPERATIONS.GENESIS_DIFFICULTY
         };
 
         console.log(this.#getGenesisDifficultyPrompt());
@@ -319,7 +330,7 @@ export class CommandHandler {
     #handlePendingGenesisInitialization(input, context) {
         const pendingGenesisInitialization = context.pending;
 
-        if (pendingGenesisInitialization.op === "genesis-difficulty") {
+        if (pendingGenesisInitialization.op === OPERATIONS.GENESIS_DIFFICULTY) {
             const difficulty = this.#parsePositiveInteger(input, BigInt(MAX_VDF_DIFFICULTY));
             if (!difficulty) {
                 console.log("Invalid difficulty. Please enter a positive integer (example 55_000_000).");
@@ -328,7 +339,7 @@ export class CommandHandler {
             }
 
             pendingGenesisInitialization.difficulty = difficulty;
-            pendingGenesisInitialization.op = "genesis-discriminant-bit-size";
+            pendingGenesisInitialization.op = OPERATIONS.GENESIS_DISCRIMINANT_BIT_SIZE;
             console.log(this.#getGenesisDiscriminantBitSizePrompt());
             return;
         }
@@ -363,7 +374,7 @@ export class CommandHandler {
         console.info(`VDF discriminant bit size: ${discriminantBitSize.display}`);
 
         context.pending = {
-            op: "confirmation",
+            op: OPERATIONS.CONFIRMATION,
             prompt: "Do you want to proceed? (yes/no)",
             invalidMessage: 'Invalid input. Please answer "yes" or "no".',
             failureMessage: "Genesis epoch initialization failed",
@@ -375,7 +386,7 @@ export class CommandHandler {
     }
 
     #queueSetConsensusConfig(context) {
-        context.pending = { op: "consensus-config" };
+        context.pending = { op: OPERATIONS.CONSENSUS_CONFIG };
 
         console.log(this.#getSetConsensusConfigPrompt());
     }
@@ -405,7 +416,7 @@ export class CommandHandler {
         console.info(JSON.stringify(consensusConfig, null, 2));
 
         context.pending = {
-            op: "confirmation",
+            op: OPERATIONS.CONFIRMATION,
             prompt: "Do you want to proceed? (yes/no)",
             invalidMessage: 'Invalid input. Please answer "yes" or "no".',
             failureMessage: "Consensus config update failed",
@@ -418,7 +429,7 @@ export class CommandHandler {
 
     #queueSetVdfParams(context) {
         context.pending = {
-            op: "vdf-difficulty"
+            op: OPERATIONS.VDF_DIFFICULTY
         };
 
         console.log(this.#getSetVdfParamsDifficultyPrompt());
@@ -433,7 +444,7 @@ export class CommandHandler {
 
         const pendingSetVdfParams = context.pending;
 
-        if (pendingSetVdfParams.op === "vdf-difficulty") {
+        if (pendingSetVdfParams.op === OPERATIONS.VDF_DIFFICULTY) {
             const difficulty = this.#parsePositiveInteger(input, BigInt(MAX_VDF_DIFFICULTY));
             if (!difficulty) {
                 console.log(
@@ -444,7 +455,7 @@ export class CommandHandler {
             }
 
             pendingSetVdfParams.difficulty = difficulty;
-            pendingSetVdfParams.op = "vdf-discriminant-bit-size";
+            pendingSetVdfParams.op = OPERATIONS.VDF_DISCRIMINANT_BIT_SIZE;
             console.log(this.#getSetVdfParamsDiscriminantBitSizePrompt());
             return;
         }
@@ -480,7 +491,7 @@ export class CommandHandler {
         console.info(`VDF discriminant bit size: ${discriminantBitSize.display}`);
 
         context.pending = {
-            op: "confirmation",
+            op: OPERATIONS.CONFIRMATION,
             prompt: "Do you want to proceed? (yes/no)",
             invalidMessage: 'Invalid input. Please answer "yes" or "no".',
             failureMessage: "VDF params update failed",

--- a/cli/commandHandler.js
+++ b/cli/commandHandler.js
@@ -53,10 +53,6 @@ export class CommandHandler {
     #closeCli;
     #wallet;
     #handlers;
-    #pendingConfirmation = null;
-    #pendingGenesisInitialization = null;
-    #pendingSetConsensusConfig = null;
-    #pendingSetVdfParams = null;
 
     constructor({ config, msb, handleClose, wallet }) {
         this.#msb = msb;
@@ -65,35 +61,35 @@ export class CommandHandler {
         this.#handlers = new Handlers(msb, config);
     }
 
-    async handle(input) {
-        if (this.#pendingConfirmation !== null) {
-            return this.#handlePendingConfirmation(input);
-        }
-
-        if (this.#pendingGenesisInitialization !== null) {
-            return this.#handlePendingGenesisInitialization(input);
-        }
-
-        if (this.#pendingSetConsensusConfig !== null) {
-            return this.#handlePendingSetConsensusConfig(input);
-        }
-
-        if (this.#pendingSetVdfParams !== null) {
-            return this.#handlePendingSetVdfParams(input);
-        }
-
+    async handle(input, context) {
         const [command, ...parts] = input.split(" ");
-        const context = { command, input, parts };
+        const handlerContext = { command, input, parts, context };
         const handlers = this.#getHandlers();
-        const handler = handlers.find(({ evaluate }) => evaluate(context));
+        const handler = handlers.find(({ evaluate }) => evaluate(handlerContext));
 
         if (handler) {
-            return handler.process(context);
+            return handler.process(handlerContext);
         }
     }
 
     #getHandlers() {
         return [
+            {
+                evaluate: ({ context }) => context.pending?.op === "confirmation",
+                process: async ({ input, context }) => this.#handlePendingConfirmation(input, context)
+            },
+            {
+                evaluate: ({ context }) => context.pending?.op.startsWith("genesis-"),
+                process: async ({ input, context }) => this.#handlePendingGenesisInitialization(input, context)
+            },
+            {
+                evaluate: ({ context }) => context.pending?.op === "consensus-config",
+                process: async ({ input, context }) => this.#handlePendingSetConsensusConfig(input, context)
+            },
+            {
+                evaluate: ({ context }) => context.pending?.op.startsWith("vdf-"),
+                process: async ({ input, context }) => this.#handlePendingSetVdfParams(input, context)
+            },
             {
                 evaluate: ({ command }) => command === COMMANDS.HELP,
                 process: async () => {
@@ -195,7 +191,7 @@ export class CommandHandler {
             },
             {
                 evaluate: ({ input }) => input.startsWith(COMMANDS.TRANSFER),
-                process: async ({ parts }) => this.#queueTransferConfirmation(parts[0], parts[1])
+                process: async ({ parts, context }) => this.#queueTransferConfirmation(parts[0], parts[1], context)
             },
             {
                 evaluate: ({ input }) => input.startsWith(COMMANDS.GET_BALANCE),
@@ -246,25 +242,25 @@ export class CommandHandler {
             },
             {
                 evaluate: ({ input }) => input.startsWith(COMMANDS.EPOCH_GENESIS_INITIALIZATION),
-                process: async () => this.#queueEpochGenesisInitialization()
+                process: async ({ context }) => this.#queueEpochGenesisInitialization(context)
             },
             {
                 evaluate: ({ command }) => command === COMMANDS.SET_CONSENSUS_CONFIG,
-                process: async () => this.#queueSetConsensusConfig()
+                process: async ({ context }) => this.#queueSetConsensusConfig(context)
             },
             {
                 evaluate: ({ command }) => command === COMMANDS.SET_VDF_PARAMS,
-                process: async () => this.#queueSetVdfParams()
+                process: async ({ context }) => this.#queueSetVdfParams(context)
             }
         ];
     }
 
-    async #handlePendingConfirmation(input) {
+    async #handlePendingConfirmation(input, context) {
         const normalizedInput = input.trim().toLowerCase();
-        const pendingConfirmation = this.#pendingConfirmation;
+        const pendingConfirmation = context.pending;
 
         if (normalizedInput === "y" || normalizedInput === "yes") {
-            this.#pendingConfirmation = null;
+            context.pending = null;
 
             try {
                 return await pendingConfirmation.onConfirm();
@@ -281,7 +277,7 @@ export class CommandHandler {
         }
 
         if (normalizedInput === "n" || normalizedInput === "no") {
-            this.#pendingConfirmation = null;
+            context.pending = null;
             return pendingConfirmation.onDecline();
         }
 
@@ -289,7 +285,7 @@ export class CommandHandler {
         console.log(pendingConfirmation.prompt);
     }
 
-    async #queueTransferConfirmation(recipientAddress, amount) {
+    async #queueTransferConfirmation(recipientAddress, amount, context) {
         const preparedTransfer = await this.#msb.prepareTransferOperation(recipientAddress, amount);
 
         console.info("Transfer Details:");
@@ -302,27 +298,28 @@ export class CommandHandler {
         console.info(`Current balance: ${bigIntToDecimalString(preparedTransfer.senderBalance)}`);
         console.info(`Balance after transaction: ${bigIntToDecimalString(preparedTransfer.expectedNewBalance)}`);
 
-        this.#pendingConfirmation = {
+        context.pending = {
+            op: "confirmation",
             prompt: "Do you want to proceed? (y/n)",
             onConfirm: async () => this.#msb.submitPreparedTransferOperation(preparedTransfer),
             onDecline: async () => this.#msb.printHelp()
         };
 
-        console.log(this.#pendingConfirmation.prompt);
+        console.log(context.pending.prompt);
     }
 
-    #queueEpochGenesisInitialization() {
-        this.#pendingGenesisInitialization = {
-            step: "difficulty"
+    #queueEpochGenesisInitialization(context) {
+        context.pending = {
+            op: "genesis-difficulty"
         };
 
         console.log(this.#getGenesisDifficultyPrompt());
     }
 
-    #handlePendingGenesisInitialization(input) {
-        const pendingGenesisInitialization = this.#pendingGenesisInitialization;
+    #handlePendingGenesisInitialization(input, context) {
+        const pendingGenesisInitialization = context.pending;
 
-        if (pendingGenesisInitialization.step === "difficulty") {
+        if (pendingGenesisInitialization.op === "genesis-difficulty") {
             const difficulty = this.#parsePositiveInteger(input, BigInt(MAX_VDF_DIFFICULTY));
             if (!difficulty) {
                 console.log("Invalid difficulty. Please enter a positive integer (example 55_000_000).");
@@ -331,7 +328,7 @@ export class CommandHandler {
             }
 
             pendingGenesisInitialization.difficulty = difficulty;
-            pendingGenesisInitialization.step = "discriminantBitSize";
+            pendingGenesisInitialization.op = "genesis-discriminant-bit-size";
             console.log(this.#getGenesisDiscriminantBitSizePrompt());
             return;
         }
@@ -344,15 +341,15 @@ export class CommandHandler {
         }
 
         const difficulty = pendingGenesisInitialization.difficulty;
-        this.#pendingGenesisInitialization = null;
+        context.pending = null;
 
         return this.#queueEpochGenesisConfirmation({
             difficulty,
             discriminantBitSize
-        });
+        }, context);
     }
 
-    #queueEpochGenesisConfirmation({ difficulty, discriminantBitSize }) {
+    #queueEpochGenesisConfirmation({ difficulty, discriminantBitSize }, context) {
         const consensusConfig = {
             schemaVersion: 1,
             configData: {
@@ -365,7 +362,8 @@ export class CommandHandler {
         console.info(`VDF difficulty: ${difficulty.display}`);
         console.info(`VDF discriminant bit size: ${discriminantBitSize.display}`);
 
-        this.#pendingConfirmation = {
+        context.pending = {
+            op: "confirmation",
             prompt: "Do you want to proceed? (yes/no)",
             invalidMessage: 'Invalid input. Please answer "yes" or "no".',
             failureMessage: "Genesis epoch initialization failed",
@@ -373,18 +371,18 @@ export class CommandHandler {
             onDecline: async () => console.log("Genesis epoch initialization cancelled.")
         };
 
-        console.log(this.#pendingConfirmation.prompt);
+        console.log(context.pending.prompt);
     }
 
-    #queueSetConsensusConfig() {
-        this.#pendingSetConsensusConfig = {};
+    #queueSetConsensusConfig(context) {
+        context.pending = { op: "consensus-config" };
 
         console.log(this.#getSetConsensusConfigPrompt());
     }
 
-    #handlePendingSetConsensusConfig(input) {
+    #handlePendingSetConsensusConfig(input, context) {
         if (input.trim().toLowerCase() === "/cancel") {
-            this.#pendingSetConsensusConfig = null;
+            context.pending = null;
             console.log("Consensus config update cancelled.");
             return;
         }
@@ -398,15 +396,16 @@ export class CommandHandler {
             return;
         }
 
-        this.#pendingSetConsensusConfig = null;
-        return this.#queueSetConsensusConfigConfirmation(consensusConfig);
+        context.pending = null;
+        return this.#queueSetConsensusConfigConfirmation(consensusConfig, context);
     }
 
-    #queueSetConsensusConfigConfirmation(consensusConfig) {
+    #queueSetConsensusConfigConfirmation(consensusConfig, context) {
         console.info("Consensus Config Update:");
         console.info(JSON.stringify(consensusConfig, null, 2));
 
-        this.#pendingConfirmation = {
+        context.pending = {
+            op: "confirmation",
             prompt: "Do you want to proceed? (yes/no)",
             invalidMessage: 'Invalid input. Please answer "yes" or "no".',
             failureMessage: "Consensus config update failed",
@@ -414,27 +413,27 @@ export class CommandHandler {
             onDecline: async () => console.log("Consensus config update cancelled.")
         };
 
-        console.log(this.#pendingConfirmation.prompt);
+        console.log(context.pending.prompt);
     }
 
-    #queueSetVdfParams() {
-        this.#pendingSetVdfParams = {
-            step: "difficulty"
+    #queueSetVdfParams(context) {
+        context.pending = {
+            op: "vdf-difficulty"
         };
 
         console.log(this.#getSetVdfParamsDifficultyPrompt());
     }
 
-    #handlePendingSetVdfParams(input) {
+    #handlePendingSetVdfParams(input, context) {
         if (input.trim().toLowerCase() === "/cancel") {
-            this.#pendingSetVdfParams = null;
+            context.pending = null;
             console.log("VDF params update cancelled.");
             return;
         }
 
-        const pendingSetVdfParams = this.#pendingSetVdfParams;
+        const pendingSetVdfParams = context.pending;
 
-        if (pendingSetVdfParams.step === "difficulty") {
+        if (pendingSetVdfParams.op === "vdf-difficulty") {
             const difficulty = this.#parsePositiveInteger(input, BigInt(MAX_VDF_DIFFICULTY));
             if (!difficulty) {
                 console.log(
@@ -445,7 +444,7 @@ export class CommandHandler {
             }
 
             pendingSetVdfParams.difficulty = difficulty;
-            pendingSetVdfParams.step = "discriminantBitSize";
+            pendingSetVdfParams.op = "vdf-discriminant-bit-size";
             console.log(this.#getSetVdfParamsDiscriminantBitSizePrompt());
             return;
         }
@@ -460,14 +459,14 @@ export class CommandHandler {
         }
 
         const difficulty = pendingSetVdfParams.difficulty;
-        this.#pendingSetVdfParams = null;
+        context.pending = null;
         return this.#queueSetVdfParamsConfirmation({
             difficulty,
             discriminantBitSize
-        });
+        }, context);
     }
 
-    #queueSetVdfParamsConfirmation({ difficulty, discriminantBitSize }) {
+    #queueSetVdfParamsConfirmation({ difficulty, discriminantBitSize }, context) {
         const consensusConfig = {
             schemaVersion: 1,
             configData: {
@@ -480,7 +479,8 @@ export class CommandHandler {
         console.info(`VDF difficulty: ${difficulty.display}`);
         console.info(`VDF discriminant bit size: ${discriminantBitSize.display}`);
 
-        this.#pendingConfirmation = {
+        context.pending = {
+            op: "confirmation",
             prompt: "Do you want to proceed? (yes/no)",
             invalidMessage: 'Invalid input. Please answer "yes" or "no".',
             failureMessage: "VDF params update failed",
@@ -488,7 +488,7 @@ export class CommandHandler {
             onDecline: async () => console.log("VDF params update cancelled.")
         };
 
-        console.log(this.#pendingConfirmation.prompt);
+        console.log(context.pending.prompt);
     }
 
     #parseConsensusConfig(input) {

--- a/cli/interactive.js
+++ b/cli/interactive.js
@@ -59,6 +59,7 @@ class Cli extends ReadyResource {
 
     startInteractiveMode() {
         console.log('RPC server will not be started.');
+        const context = { pending: null };
 
         this.#commandHandlers = new CommandHandler({
             config: this.#config,
@@ -71,7 +72,7 @@ class Cli extends ReadyResource {
 
         this.#readlineInstance.on("line", async (input) => {
             try {
-                await this.#handleCommand(input.trim());
+                await this.#handleCommand(input.trim(), context);
             } catch (err) {
                 console.error(`${err}`);
             }
@@ -81,8 +82,8 @@ class Cli extends ReadyResource {
         this.#readlineInstance.prompt();
     }
 
-    async #handleCommand(input) {
-        return this.#commandHandlers.handle(input);
+    async #handleCommand(input, context) {
+        return this.#commandHandlers.handle(input, context);
     }
 
     #completeCommand(line) {

--- a/src/core/consensus/services/EpochCoordinatorService.js
+++ b/src/core/consensus/services/EpochCoordinatorService.js
@@ -1,4 +1,4 @@
-import SchedulableService from "../../../utils/scheduler/SchedulableService.js";
+import SchedulableService, { SCHEDULABLE_SERVICE_EVENTS } from "../../../utils/scheduler/SchedulableService.js";
 import { EPOCH_EVENTS, EPOCH_STATES, EpochStateMachine } from "./EpochStateMachine.js";
 import { ConsensusProtocolVersion, CustomEventType } from "../../../utils/constants.js";
 import { Logger } from "../../../utils/logger.js";
@@ -309,6 +309,11 @@ class EpochCoordinatorService extends SchedulableService {
         const toClean = []
 
         // External events
+
+        const cleanStop = listenTo(this, SCHEDULABLE_SERVICE_EVENTS.STOP, () => {
+            stateMachine.close();
+        });
+        toClean.push(cleanStop)
 
         const cleanProposal = listenTo(this.#state, CustomEventType.EPOCH_PROPOSAL_VALIDATION_SUCCESS, () => {
             stateMachine.appendContext({ remoteProposalReceived: true })

--- a/src/core/network/Network.js
+++ b/src/core/network/Network.js
@@ -203,7 +203,7 @@ class Network extends ReadyResource {
         this.#state.on(CustomEventType.IS_NON_INDEXER, async (bufferAddress) => {
             const address = tracCryptoApi.address.encode(this.#config.addressPrefix, bufferAddress);
             if (address === this.#wallet.address) {
-                this.#epochCoordinatorService.stop();
+                await this.#epochCoordinatorService.stop();
             } else {
                 this.#indexerConnectionManager.remove(bufferAddress);
                 const indexerCount = await this.#state.indexerCount();

--- a/src/core/network/Network.js
+++ b/src/core/network/Network.js
@@ -144,7 +144,7 @@ class Network extends ReadyResource {
         await this.#epochCoordinatorService.ready();
 
         this.#logger.info(`Channel: ${b4a.toString(this.#config.channel)}`);
-        this.#listerners();
+        this.#listeners();
 
         this.#swarm.join(this.#config.channel, { server: true, client: true });
         this.#swarm.flush();
@@ -179,7 +179,7 @@ class Network extends ReadyResource {
         wakeup.addStream(stream);
     }
 
-    #listerners() {
+    #listeners() {
         this.#state.on(CustomEventType.IS_INDEXER, async (publicKey) => {
             const publicKeyHex = this.#normalizePublicKey(publicKey);
             this.#validatorConnectionManager.remove(publicKeyHex);

--- a/src/core/network/Network.js
+++ b/src/core/network/Network.js
@@ -151,7 +151,9 @@ class Network extends ReadyResource {
         this.validatorObserverService.start();
 
         if (this.#state.isIndexer()) {
-            this.#epochCoordinatorService.start();
+            if (await this.#state.getCurrentEpoch() !== null) {
+                this.#epochCoordinatorService.start();
+            }
         }
     }
 
@@ -178,19 +180,40 @@ class Network extends ReadyResource {
     }
 
     #listerners() {
-        this.#state.on(CustomEventType.IS_INDEXER, (publicKey) => {
+        this.#state.on(CustomEventType.IS_INDEXER, async (publicKey) => {
             const publicKeyHex = this.#normalizePublicKey(publicKey);
             this.#validatorConnectionManager.remove(publicKeyHex);
+            const indexerCount = await this.#state.indexerCount();
+            this.#indexerConnectionManager.setMax(indexerCount - 1);
         });
 
         this.#state.on(CustomEventType.UNWRITABLE, (publicKey) => {
             this.disconnectValidatorPeer(publicKey, 'peer became unwritable');
         });
 
-        this.#state.on(CustomEventType.IS_NON_INDEXER, (bufferAddress) => {
+        this.#state.on(CustomEventType.IS_INDEXER, async bufferAddress => {
+            const address = tracCryptoApi.address.encode(this.#config.addressPrefix, bufferAddress);
+            if (address === this.#wallet.address) {
+                if (await this.#state.getCurrentEpoch() !== null) {
+                    this.#epochCoordinatorService.start();
+                }
+            }
+        });
+
+        this.#state.on(CustomEventType.IS_NON_INDEXER, async (bufferAddress) => {
             const address = tracCryptoApi.address.encode(this.#config.addressPrefix, bufferAddress);
             if (address === this.#wallet.address) {
                 this.#epochCoordinatorService.stop();
+            } else {
+                this.#indexerConnectionManager.remove(bufferAddress);
+                const indexerCount = await this.#state.indexerCount();
+                this.#indexerConnectionManager.setMax(indexerCount - 1);
+            }
+        });
+
+        this.#state.on(CustomEventType.GENESIS_EPOCH_CREATED, () => {
+            if (this.#state.isIndexer()) {
+                this.#epochCoordinatorService.start();
             }
         });
 

--- a/src/core/state/State.js
+++ b/src/core/state/State.js
@@ -4582,6 +4582,7 @@ class State extends ReadyResource {
             console.info(`Genesis Epoch initialized addr:wk:tx - ${requesterAddressString}:${decodedAdminEntry.wk.toString('hex')}:${txHashHexString}`);
         }
 
+        this.emit(CustomEventType.GENESIS_EPOCH_CREATED, { epoch: 0n, proposerAddress: requesterAddressString });
         return Status.SUCCESS;
     }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -179,6 +179,7 @@ export const CustomEventType = Object.freeze({
     EPOCH_PROPOSAL_APPROVAL_RECEIVED: 'msb:epoch_proposal_approval_received',
     EPOCH_PROPOSAL_APPROVAL_SUCCESS: 'msb:epoch_proposal_approval_success',
     EPOCH_PROPOSAL_APPROVAL_FAILURE: 'msb:epoch_proposal_approval_failure',
+    GENESIS_EPOCH_CREATED: 'msb:genesis_epoch_created',
     EPOCH_CREATED: 'msb:epoch_created'
 });
 

--- a/src/utils/scheduler/SchedulableService.js
+++ b/src/utils/scheduler/SchedulableService.js
@@ -1,6 +1,10 @@
 import ReadyResource from 'ready-resource';
 import Scheduler from './Scheduler.js';
 
+export const SCHEDULABLE_SERVICE_EVENTS = Object.freeze({
+    STOP: 'schedulable-service-stop',
+});
+
 /**
  * Base class for services that execute recurring work through the shared scheduler.
  *
@@ -79,6 +83,7 @@ class SchedulableService extends ReadyResource {
      * @returns {Promise<boolean>}
      */
     async stop(waitForCurrent = true) {
+        this.emit(SCHEDULABLE_SERVICE_EVENTS.STOP);
         if (!this.isSchedulerRunning) return false;
 
         this.#isInterrupted = true;

--- a/tests/unit/cli/commandHandler.test.js
+++ b/tests/unit/cli/commandHandler.test.js
@@ -26,12 +26,16 @@ function createSubject(overrides = {}) {
         ...overrides.msb
     };
 
-    const handler = new CommandHandler({
+    const commandHandler = new CommandHandler({
         config: {},
         msb,
         handleClose: async () => {},
         wallet: undefined
     });
+    const context = { pending: null };
+    const handler = {
+        handle: input => commandHandler.handle(input, context)
+    };
 
     return { handler, msb, preparedTransfer };
 }

--- a/tests/unit/core/consensus/services/epochCoordinatorService/epochCoordinatorService.test.js
+++ b/tests/unit/core/consensus/services/epochCoordinatorService/epochCoordinatorService.test.js
@@ -232,12 +232,11 @@ if (isBareRuntime) {
 
     // --- _close() lifecycle ---
 
-    // EPOCH_CREATED handling is not implemented in EpochCoordinatorService yet - skipped until it lands.
-    test.skip('_close() removes the EPOCH_CREATED listener from an in-flight cycle', async t => {
+    test('_close() removes the EPOCH_CREATED listener from an in-flight cycle', async t => {
         const { service, state } = await setup();
         await service.worker(sinon.stub(), sinon.stub());
         await service.close();
-        t.ok(state.removeListener.calledWith(EPOCH_CREATED, sinon.match.func));
+        t.ok(state.off.calledWith(EPOCH_CREATED, sinon.match.func));
     });
 
     test('_close() cancels a pending COLLECT_APPROVALS timeout so it never fires', async t => {

--- a/tests/unit/network/Network.test.js
+++ b/tests/unit/network/Network.test.js
@@ -321,6 +321,33 @@ if (isBareRuntime) {
         await network.close();
     });
 
+    test('Network does not start the epoch coordinator for a non-indexer with an existing genesis epoch', async t => {
+        const { network, epochCoordinatorServiceInstance } = await loadNetwork({
+            isIndexer: false,
+            currentEpoch: 0n
+        });
+
+        t.absent(epochCoordinatorServiceInstance.start.called);
+        await network.close();
+    });
+
+    test('Network starts the epoch coordinator when the local node is promoted to indexer with an existing genesis epoch', async t => {
+        const publicKey = b4a.alloc(32, 2);
+        const walletAddress = tracCryptoApi.address.encode('trac', publicKey);
+        const { network, epochCoordinatorServiceInstance, state } = await loadNetwork({
+            isIndexer: false,
+            currentEpoch: 0n,
+            indexerCount: 1,
+            walletAddress
+        });
+
+        state.emit(CustomEventType.IS_INDEXER, publicKey);
+        await Promise.resolve(); // IS_INDEXER handlers await indexerCount / getCurrentEpoch.
+
+        t.is(epochCoordinatorServiceInstance.start.callCount, 1, 'local indexer promotion starts the coordinator');
+        await network.close();
+    });
+
     test('Network stops the epoch coordinator without refreshing indexer capacity when the local node is demoted', async t => {
         const publicKey = b4a.alloc(32, 2);
         const walletAddress = tracCryptoApi.address.encode('trac', publicKey);

--- a/tests/unit/network/Network.test.js
+++ b/tests/unit/network/Network.test.js
@@ -2,6 +2,7 @@ import { test } from 'brittle';
 import sinon from 'sinon';
 import b4a from 'b4a';
 import EventEmitter from 'bare-events';
+import tracCryptoApi from 'trac-crypto-api';
 import { CONNECTION_STATUS, CustomEventType } from '../../../src/utils/constants.js';
 
 const isBareRuntime = typeof globalThis.Bare !== 'undefined';
@@ -29,10 +30,12 @@ function createMockConnection(publicKeyHex, { withProtocolSession = true, withCo
     };
 }
 
-async function loadNetwork() {
+async function loadNetwork({ isIndexer = false, currentEpoch = null, indexerCount = 0, walletAddress = 'trac_test' } = {}) {
     const { default: esmock } = await import('esmock');
     let swarmInstance = null;
     let validatorConnectionManagerInstance = null;
+    let indexerConnectionManagerInstance = null;
+    let epochCoordinatorServiceInstance = null;
 
     class HyperswarmMock extends EventEmitter {
         constructor() {
@@ -131,9 +134,36 @@ async function loadNetwork() {
     }
 
     class EpochCoordinatorServiceMock {
+        constructor() {
+            epochCoordinatorServiceInstance = this;
+            this.start = sinon.stub();
+            this.stop = sinon.stub();
+        }
+
         async ready() {}
-        start() {}
-        async stop() {}
+        async close() {}
+    }
+
+    class IndexerConnectionManagerMock {
+        constructor() {
+            indexerConnectionManagerInstance = this;
+            this.indexers = new Set();
+            this.add = sinon.stub().callsFake(publicKey => {
+                this.indexers.add(normalizePublicKey(publicKey));
+            });
+            this.remove = sinon.stub();
+            this.setMax = sinon.stub();
+        }
+
+        exists(publicKey) {
+            return this.indexers.has(normalizePublicKey(publicKey));
+        }
+
+        connected(publicKey) {
+            return this.exists(publicKey);
+        }
+
+        async ready() {}
         async close() {}
     }
 
@@ -193,6 +223,7 @@ async function loadNetwork() {
         '../../../src/core/network/services/TransactionCommitService.js': { default: TransactionCommitServiceMock },
         '../../../src/core/network/services/ValidatorHealthCheckService.js': { default: ValidatorHealthCheckServiceMock },
         '../../../src/core/consensus/services/EpochCoordinatorService.js': { default: EpochCoordinatorServiceMock },
+        '../../../src/core/consensus/services/IndexerConnectionManager.js': { default: IndexerConnectionManagerMock },
         '../../../src/core/network/protocols/NetworkMessages.js': { default: NetworkMessagesMock },
         '../../../src/core/consensus/protocols/ConsensusMessages.js': { default: ConsensusMessagesMock },
         'protomux-wakeup': { default: WakeupMock },
@@ -217,19 +248,28 @@ async function loadNetwork() {
     const wallet = {
         publicKey: b4a.alloc(32, 2),
         secretKey: b4a.alloc(64, 3),
-        address: 'trac_test',
+        address: walletAddress,
     };
 
     const store = new CorestoreMock();
     const state = new EventEmitter();
     state.isAdmin = async () => false;
-    state.isIndexer = () => false;
-    state.indexerCount = async () => 0;
+    state.isIndexer = () => isIndexer;
+    state.indexerCount = async () => indexerCount;
+    state.getCurrentEpoch = async () => currentEpoch;
     state.isAdminAddress = async () => false;
     const network = new Network(state, store, config, wallet);
     await network.ready()
 
-    return { network, store, swarmInstance, validatorConnectionManagerInstance, state };
+    return {
+        network,
+        store,
+        swarmInstance,
+        validatorConnectionManagerInstance,
+        indexerConnectionManagerInstance,
+        epochCoordinatorServiceInstance,
+        state
+    };
 }
 
 if (isBareRuntime) {
@@ -237,6 +277,68 @@ if (isBareRuntime) {
         t.pass('skipped in Bare because esmock depends on node:module');
     });
 } else {
+    test('Network does not start the epoch coordinator before genesis initialization', async t => {
+        const { network, epochCoordinatorServiceInstance } = await loadNetwork({
+            isIndexer: true,
+            currentEpoch: null
+        });
+
+        t.absent(epochCoordinatorServiceInstance.start.called);
+        await network.close();
+    });
+
+    test('Network starts the epoch coordinator for an initialized indexer', async t => {
+        const { network, epochCoordinatorServiceInstance } = await loadNetwork({
+            isIndexer: true,
+            currentEpoch: 0n
+        });
+
+        t.is(epochCoordinatorServiceInstance.start.callCount, 1);
+        await network.close();
+    });
+
+    test('Network starts the epoch coordinator when the genesis-epoch event is emitted on an indexer', async t => {
+        const { network, epochCoordinatorServiceInstance, state } = await loadNetwork({
+            isIndexer: true,
+            currentEpoch: null
+        });
+
+        state.emit(CustomEventType.GENESIS_EPOCH_CREATED, { epoch: 0n });
+
+        t.is(epochCoordinatorServiceInstance.start.callCount, 1);
+        await network.close();
+    });
+
+    test('Network ignores genesis-epoch events when this node is not an indexer', async t => {
+        const { network, epochCoordinatorServiceInstance, state } = await loadNetwork({
+            isIndexer: false,
+            currentEpoch: null
+        });
+
+        state.emit(CustomEventType.GENESIS_EPOCH_CREATED, { epoch: 0n });
+
+        t.absent(epochCoordinatorServiceInstance.start.called);
+        await network.close();
+    });
+
+    test('Network stops the epoch coordinator without refreshing indexer capacity when the local node is demoted', async t => {
+        const publicKey = b4a.alloc(32, 2);
+        const walletAddress = tracCryptoApi.address.encode('trac', publicKey);
+        const { network, epochCoordinatorServiceInstance, indexerConnectionManagerInstance, state } = await loadNetwork({
+            isIndexer: true,
+            currentEpoch: 0n,
+            indexerCount: 3,
+            walletAddress
+        });
+
+        state.emit(CustomEventType.IS_NON_INDEXER, publicKey);
+        await Promise.resolve();
+
+        t.is(epochCoordinatorServiceInstance.stop.callCount, 1, 'local indexer demotion stops the coordinator');
+        t.absent(indexerConnectionManagerInstance.setMax.called, 'local indexer demotion does not refresh connection capacity');
+        await network.close();
+    });
+
     test('Network#disconnectValidatorPeer clears pending validator attempts', async t => {
         const publicKey = 'a'.repeat(64);
         const { network, swarmInstance } = await loadNetwork();
@@ -303,7 +405,7 @@ if (isBareRuntime) {
 
     test('Network#tryConnect returns CONNECTED and promotes into the network-owned indexer manager', async t => {
         const publicKey = 'f'.repeat(64);
-        const { network, swarmInstance } = await loadNetwork();
+        const { network, swarmInstance, indexerConnectionManagerInstance } = await loadNetwork();
 
         const publicKeyBuffer = b4a.from(publicKey, 'hex');
         const connection = createMockConnection(publicKey);
@@ -312,11 +414,9 @@ if (isBareRuntime) {
 
         // Indexer connections are promoted into the single indexer manager Network
         // owns for its lifetime (network.indexerConnectionManager), not a per-call one.
-        const addSpy = sinon.spy(network.indexerConnectionManager, 'add');
-
         const status = await network.tryConnect(publicKey, 'indexer');
         t.is(status, CONNECTION_STATUS.CONNECTED, 'returns CONNECTED for ready indexer peer');
-        t.ok(addSpy.calledWith(publicKeyBuffer, connection), 'connection was promoted into the network-owned indexer manager');
+        t.ok(indexerConnectionManagerInstance.add.calledWith(publicKeyBuffer, connection), 'connection was promoted into the network-owned indexer manager');
         t.absent(network.isConnectionPending(publicKey), 'pending indexer connection was cleared');
         t.teardown(async () => await network.close());
     });
@@ -353,7 +453,13 @@ if (isBareRuntime) {
     test('Network disconnects validator peers when state role events invalidate them', async t => {
         const publicKey = 'd'.repeat(64);
         const publicKeyBuffer = b4a.from(publicKey, 'hex');
-        const { network, swarmInstance, validatorConnectionManagerInstance, state } = await loadNetwork();
+        const {
+            network,
+            swarmInstance,
+            validatorConnectionManagerInstance,
+            indexerConnectionManagerInstance,
+            state
+        } = await loadNetwork({ indexerCount: 3 });
 
         validatorConnectionManagerInstance.add(publicKey);
         swarmInstance.peers.set(publicKey, { publicKey: publicKeyBuffer });
@@ -366,11 +472,17 @@ if (isBareRuntime) {
         swarmInstance.peers.set(publicKey, { publicKey: publicKeyBuffer });
 
         state.emit(CustomEventType.IS_INDEXER, publicKeyBuffer);
-        await Promise.resolve(); // IS_INDEXER handler is async (awaits indexerCount), must yield
+        await Promise.resolve(); // IS_INDEXER handler awaits indexerCount.
         t.absent(validatorConnectionManagerInstance.exists(publicKey), 'promoted indexer should be removed from validator pool');
+        t.ok(indexerConnectionManagerInstance.setMax.calledWith(2), 'promoted indexer excludes itself from the indexer connection limit');
         // Promotion keeps the underlying connection alive (endConnection: false) so it can be
         // reused for the indexer role, so it must NOT leave the peer - unlike a hard disconnect.
         t.is(swarmInstance.leavePeer.callCount, 1, 'promoted indexer should not leave the peer, connection is reused');
+
+        state.emit(CustomEventType.IS_NON_INDEXER, publicKeyBuffer);
+        await Promise.resolve(); // IS_NON_INDEXER handler awaits indexerCount for remote peers.
+        t.ok(indexerConnectionManagerInstance.remove.calledWith(publicKeyBuffer), 'demoted remote indexer is removed before connection capacity is refreshed');
+        t.is(indexerConnectionManagerInstance.setMax.callCount, 2, 'demoted remote indexer refreshes the indexer connection limit');
         t.teardown(async () => await network.close());
     });
 

--- a/tests/unit/state/apply/setGenesisEpoch/state.apply.setGenesisEpoch.test.js
+++ b/tests/unit/state/apply/setGenesisEpoch/state.apply.setGenesisEpoch.test.js
@@ -42,6 +42,7 @@ import {
 } from '../../../../../src/codecs/apply/applyOperationCodec.js';
 import {
     CONSENSUS_CONFIG_DATA_MAX_SIZE,
+    CustomEventType,
     EntryType,
     HASH_BYTE_LENGTH,
     NONCE_BYTE_LENGTH,
@@ -518,9 +519,12 @@ test('State.apply SET_GENESIS_EPOCH fails when final epoch proof encoding fails'
 test('State.apply SET_GENESIS_EPOCH initializes and replicates the complete genesis state', async t => {
     const context = await setupSetGenesisEpochScenario(t, { nodes: 3 });
     const payload = await buildSetGenesisEpochPayload(context);
+    let epochCreated;
+    context.adminBootstrap.state.once(CustomEventType.GENESIS_EPOCH_CREATED, event => { epochCreated = event; });
 
     await appendAndUpdate(context.adminBootstrap.base, payload);
     await assertGenesisInitialized(t, context.adminBootstrap.base, payload);
+    t.alike(epochCreated, { epoch: 0n, proposerAddress: context.adminBootstrap.wallet.address }, 'genesis emits GENESIS_EPOCH_CREATED');
 
     await context.sync();
     for (const reader of context.peers.slice(1)) {

--- a/tests/unit/unit.test.js
+++ b/tests/unit/unit.test.js
@@ -9,9 +9,9 @@ async function runTests() {
     await import('./cli/commandHandler.test.js');
     await import('./utils/utils.test.js');
     await import('./messages/messages.test.js');
+    await import('./consensus/consensusModule.test.js');
     await import('./network/networkModule.test.js')
     await import('./state/stateModule.test.js');
-    await import('./consensus/consensusModule.test.js');
 
     test.resume();
 }


### PR DESCRIPTION
- This hooks the external events for the indexer manager and service associated with the epoch. It changes according the hooks on the network js.
- A refactor of the cli started here since it grew quite during the feature and it wasnt scale. The current state is (obviously) not final. It scales better but there is an implicit order to be followed, there is no structural correlation between steps of the same operation (e.g.: they are not in an array) and there are still implicit steps build as sub-operation (those weird callbacks) that shouldnt be there. 