### PR TITLE
chore: add timestamp logger

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -60,6 +60,11 @@ export class Config {
         return !!this.#config.enableErrorApplyLogs
     }
 
+    get enableLogTimestamp() {
+        if (this.#isOverriden('enableLogTimestamp')) return !!this.#options.enableLogTimestamp
+        return !!this.#config.enableLogTimestamp
+    }
+
     get enableInteractiveMode() {
         if (this.#isOverriden('enableInteractiveMode')) return this.#options.enableInteractiveMode !== false
         return !!this.#config.enableInteractiveMode

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -32,6 +32,7 @@ const configData = {
         maxWritersForAdminIndexerConnection: 10, // Connectivity constants
         disableRateLimit: false,
         enableErrorApplyLogs: true,
+        enableLogTimestamp: false,
         enableInteractiveMode: true,
         enableRoleRequester: false,
         enableTxApplyLogs: true,
@@ -87,6 +88,7 @@ const configData = {
         maxWritersForAdminIndexerConnection: 10, // Connectivity constants
         disableRateLimit: false,
         enableErrorApplyLogs: false,
+        enableLogTimestamp: false,
         enableInteractiveMode: true,
         enableRoleRequester: false,
         enableTxApplyLogs: false,
@@ -142,6 +144,7 @@ const configData = {
         maxWritersForAdminIndexerConnection: 10, // Connectivity constants
         disableRateLimit: false,
         enableErrorApplyLogs: true,
+        enableLogTimestamp: true,
         enableInteractiveMode: true,
         enableRoleRequester: false,
         enableTxApplyLogs: true,

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,25 +1,31 @@
 export class Logger {
     #config
+
     constructor(config) {
         this.#config = config;
     }
 
+    #format(message) {
+        const timestamp = this.#config.enableLogTimestamp ? `[${new Date().toISOString()}] ` : '';
+        return `${timestamp}${message}`;
+    }
+
     info(message) {
-        console.log("i: " + message);
+        console.log(this.#format("i: " + message));
     }
 
     debug(message) {
         if (this.#config.debug) {
-            console.debug("d: " + message);
+            console.debug(this.#format("d: " + message));
         }
     }
 
     error(message) {
-        console.error("e: " + message);
+        console.error(this.#format("e: " + message));
     }
 
     warn(message) {
-        console.warn("w: " + message);
+        console.warn(this.#format("w: " + message));
     }
 
 }

--- a/tests/unit/config/config.test.js
+++ b/tests/unit/config/config.test.js
@@ -16,6 +16,13 @@ test('Config: shipped presets still construct successfully', t => {
     }
 });
 
+test('Config: log timestamp can be enabled or disabled', t => {
+    t.is(createConfig(ENV.MAINNET, {}).enableLogTimestamp, false);
+    t.ok(createConfig(ENV.DEVELOPMENT, {}).enableLogTimestamp);
+    t.is(createConfig(ENV.MAINNET, { enableLogTimestamp: false }).enableLogTimestamp, false);
+    t.is(createConfig(ENV.MAINNET, { enableLogTimestamp: true }).enableLogTimestamp, true);
+});
+
 test('Config: valid overrideable startup fields remain usable after validation', t => {
     const config = createConfig(ENV.MAINNET, {
         bootstrap: 'ab'.repeat(32),


### PR DESCRIPTION
<img width="1248" height="556" alt="Screenshot from 2026-08-14 18-12-52" src="https://github.com/user-attachments/assets/f5f2c5fc-d25b-4fe1-ae5d-66a519622c3c" />

The thing is utc. It will help with the epoch integration (I hope). Its turned off in the other envs (but dev) cause its quite possible pm2 has a timestamp already.